### PR TITLE
Refactor helper-insert-link package

### DIFF
--- a/packages/core/octo-linker.js
+++ b/packages/core/octo-linker.js
@@ -24,6 +24,7 @@ function run(self) {
 
   self._blobReader.read();
 
+  let matches = [];
   self._blobReader.forEach(blob => {
     const plugins = self._pluginManager.get(blob.path, blob.el.classList);
 
@@ -36,12 +37,22 @@ function run(self) {
         plugin.parseBlob(blob);
       } else if (plugin.getLinkRegexes) {
         [].concat(plugin.getLinkRegexes(blob)).forEach(regex => {
-          insertLink(blob.el, regex, {
-            pluginName: plugin.name,
-            target: '$1',
-            path: blob.path,
-          });
+          matches = matches.concat(
+            insertLink(blob.el, regex, {
+              pluginName: plugin.name,
+              target: '$1',
+              path: blob.path,
+            }),
+          );
         });
+      }
+    });
+
+    matches.forEach(({ data, link }) => {
+      for (const key in data) {
+        if (data.hasOwnProperty(key)) {
+          link.dataset[key] = data[key];
+        }
       }
     });
   });

--- a/packages/core/octo-linker.js
+++ b/packages/core/octo-linker.js
@@ -17,6 +17,16 @@ function initialize(self) {
   clickHandler(self._pluginManager);
 }
 
+function insertDataAttr(matches) {
+  matches.forEach(({ data, link }) => {
+    for (const key in data) {
+      if (data.hasOwnProperty(key)) {
+        link.dataset[key] = data[key];
+      }
+    }
+  });
+}
+
 function run(self) {
   if (!self._blobReader.hasBlobs()) {
     return false;
@@ -34,7 +44,7 @@ function run(self) {
 
     plugins.forEach(plugin => {
       if (plugin.parseBlob) {
-        plugin.parseBlob(blob);
+        matches = matches.concat(plugin.parseBlob(blob));
       } else if (plugin.getLinkRegexes) {
         [].concat(plugin.getLinkRegexes(blob)).forEach(regex => {
           matches = matches.concat(
@@ -48,13 +58,7 @@ function run(self) {
       }
     });
 
-    matches.forEach(({ data, link }) => {
-      for (const key in data) {
-        if (data.hasOwnProperty(key)) {
-          link.dataset[key] = data[key];
-        }
-      }
-    });
+    insertDataAttr(matches);
   });
 }
 

--- a/packages/core/plugins/bower-manifest.js
+++ b/packages/core/plugins/bower-manifest.js
@@ -11,7 +11,7 @@ function linkDependency(blob, key, value) {
   const isValidSemver = isSemver(value);
   const regex = jsonRegExKeyValue(key, value);
 
-  insertLink(blob.el, regex, {
+  return insertLink(blob.el, regex, {
     pluginName: 'BowerManifest',
     target: isValidSemver ? '$1' : '$2',
     type: isValidSemver ? 'liveResolverQuery' : 'git',
@@ -21,7 +21,7 @@ function linkDependency(blob, key, value) {
 function linkFile(blob, key, value) {
   const regex = jsonRegExValue(key, value);
 
-  insertLink(blob.el, regex, {
+  return insertLink(blob.el, regex, {
     pluginName: 'BowerManifest',
     type: 'file',
     path: blob.path,
@@ -52,7 +52,7 @@ export default {
   },
 
   parseBlob(blob) {
-    processJSON(blob, {
+    return processJSON(blob, {
       '$.dependencies': linkDependency,
       '$.devDependencies': linkDependency,
       '$.resolutions': linkDependency,

--- a/packages/core/plugins/composer-manifest.js
+++ b/packages/core/plugins/composer-manifest.js
@@ -10,7 +10,7 @@ function linkDependency(blob, key, value) {
 
   const regex = jsonRegExKeyValue(key, value);
 
-  insertLink(blob.el, regex, {
+  return insertLink(blob.el, regex, {
     pluginName: 'Composer',
     target: '$1',
   });
@@ -31,7 +31,7 @@ export default {
   },
 
   parseBlob(blob) {
-    processJSON(blob, {
+    return processJSON(blob, {
       '$.require': linkDependency,
       '$.require-dev': linkDependency,
       '$.conflict': linkDependency,

--- a/packages/core/plugins/dot-net-core.js
+++ b/packages/core/plugins/dot-net-core.js
@@ -6,7 +6,7 @@ import nugetResolver from '../resolver/nuget';
 function linkDependency(blob, key, value) {
   const regex = jsonRegExKeyValue(key, value);
 
-  insertLink(blob.el, regex, {
+  return insertLink(blob.el, regex, {
     pluginName: 'DotNetCore',
     target: '$1',
   });
@@ -27,7 +27,7 @@ export default {
   },
 
   parseBlob(blob) {
-    processJSON(blob, {
+    return processJSON(blob, {
       '$.dependencies': linkDependency,
       '$.tools': linkDependency,
       '$.frameworks.*.dependencies': linkDependency,

--- a/packages/core/plugins/helper/process-json.js
+++ b/packages/core/plugins/helper/process-json.js
@@ -3,15 +3,22 @@ import jsonPath from 'JSONPath';
 export default function(blob, config) {
   const json = blob.toJSON();
 
+  let results = [];
+
   Object.entries(config).forEach(([path, linker]) => {
     jsonPath({ json, path, resultType: 'all' }).forEach(result => {
       if (typeof result.value === 'string') {
-        return linker(blob, result.parentProperty, result.value);
+        results = results.concat(
+          linker(blob, result.parentProperty, result.value),
+        );
+        return;
       }
 
       for (const [key, value] of Object.entries(result.value)) {
-        linker(blob, key, value);
+        results = results.concat(linker(blob, key, value));
       }
     });
   });
+
+  return results;
 }

--- a/packages/core/plugins/npm-manifest.js
+++ b/packages/core/plugins/npm-manifest.js
@@ -11,7 +11,7 @@ function linkDependency(blob, key, value) {
   const isValidSemver = isSemver(value);
   const regex = jsonRegExKeyValue(key, value);
 
-  insertLink(blob.el, regex, {
+  return insertLink(blob.el, regex, {
     pluginName: 'NpmManifest',
     target: isValidSemver ? '$1' : '$2',
     type: isValidSemver ? 'liveResolverQuery' : 'git',
@@ -21,7 +21,7 @@ function linkDependency(blob, key, value) {
 function linkFile(blob, key, value) {
   const regex = jsonRegExValue(key, value);
 
-  insertLink(blob.el, regex, {
+  return insertLink(blob.el, regex, {
     pluginName: 'NpmManifest',
     type: 'file',
     path: blob.path,
@@ -52,7 +52,7 @@ export default {
   },
 
   parseBlob(blob) {
-    processJSON(blob, {
+    return processJSON(blob, {
       '$.dependencies': linkDependency,
       '$.devDependencies': linkDependency,
       '$.peerDependencies': linkDependency,

--- a/packages/helper-insert-link/__tests__/__snapshots__/index.js.snap
+++ b/packages/helper-insert-link/__tests__/__snapshots__/index.js.snap
@@ -18,6 +18,41 @@ exports[`insert-link does not remove closing parentheses from commented out requ
 </div>
 `;
 
+exports[`insert-link returns adds the given data-* attributes 1`] = `
+Object {
+  "bar": "baz",
+  "value": "foo",
+}
+`;
+
+exports[`insert-link returns replace placeholder with capture group value 1`] = `
+Object {
+  "value": "go/foo.txt",
+}
+`;
+
+exports[`insert-link returns returns an array 1`] = `
+Array [
+  Object {
+    "data": Object {},
+    "link": <a
+      class="octolinker-link"
+    >
+      <span>
+        bar
+      </span>
+    </a>,
+  },
+]
+`;
+
+exports[`insert-link returns wraps the second regex match 1`] = `
+Object {
+  "value": "baz",
+  "xx": "yy",
+}
+`;
+
 exports[`insert-link wraps a nested element 1`] = `
 <div>
   

--- a/packages/helper-insert-link/__tests__/__snapshots__/index.js.snap
+++ b/packages/helper-insert-link/__tests__/__snapshots__/index.js.snap
@@ -1,30 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`insert-link adds the given data-* attributes 1`] = `
-Object {
-  "bar": "baz",
-  "value": "foo",
-}
-`;
-
-exports[`insert-link can handle if value is empty string 1`] = `
-Object {
-  "value": "",
-}
-`;
-
-exports[`insert-link can handle if value is null 1`] = `
-Object {
-  "value": "null",
-}
-`;
-
-exports[`insert-link can handle if value is undefined 1`] = `
-Object {
-  "value": "undefined",
-}
-`;
-
 exports[`insert-link does not remove closing parentheses from commented out require() calls 1`] = `
 <div>
   // var faker = 
@@ -41,12 +16,6 @@ exports[`insert-link does not remove closing parentheses from commented out requ
   </span>
   )
 </div>
-`;
-
-exports[`insert-link replace placeholder with capture group value 1`] = `
-Object {
-  "value": "go/foo.txt",
-}
 `;
 
 exports[`insert-link wraps a nested element 1`] = `
@@ -279,8 +248,6 @@ exports[`insert-link wraps the second regex match 1`] = `
   </i>
   <a
     class="octolinker-link"
-    data-value="baz"
-    data-xx="yy"
   >
     <span>
       baz

--- a/packages/helper-insert-link/__tests__/index.js
+++ b/packages/helper-insert-link/__tests__/index.js
@@ -13,10 +13,11 @@ describe('insert-link', () => {
     const el = document.createElement('div');
     el.innerHTML = html;
 
-    insertLink(el, regex, options, replaceIndex);
+    const matches = insertLink(el, regex, options, replaceIndex);
 
     return {
       el,
+      matches,
     };
   }
 
@@ -79,8 +80,11 @@ describe('insert-link', () => {
 
   it('wraps the element once', () => {
     const input = 'foo <span><i>"</i>foo<i>"</i></span>';
-    const { el } = helper(input);
-    insertLink(el, DEFAULT_REGEX, {}, '$1');
+    const { el, matches: match1 } = helper(input);
+    const match2 = insertLink(el, DEFAULT_REGEX, {}, '$1');
+
+    expect(match1.length).toBe(1);
+    expect(match2.length).toBe(0);
 
     expect(el).toMatchSnapshot();
   });
@@ -90,11 +94,49 @@ describe('insert-link', () => {
     const input = 'foo <i>"</i>bar<i>"</i> <i>"</i>baz<i>"</i>';
     const regex = /foo ("\w+") ("\w+")/;
 
+    expect(helper(input, regex, options, '$2').matches.length).toBe(1);
     expect(helper(input, regex, options, '$2').el).toMatchSnapshot();
   });
 
   it('does not remove closing parentheses from commented out require() calls', () => {
     const input = "// var faker = require('faker')";
     expect(helper(input, REQUIRE).el).toMatchSnapshot();
+  });
+
+  describe('returns', () => {
+    it('returns an array', () => {
+      const input = 'foo <span>"bar"</span>';
+
+      expect(helper(input).matches.length).toBe(1);
+      expect(helper(input).matches).toMatchSnapshot();
+    });
+
+    it('adds the given data-* attributes', () => {
+      const input = 'foo <span><i>"</i>foo<i>"</i></span>';
+      const options = { value: '$1', bar: 'baz' };
+
+      expect(
+        helper(input, DEFAULT_REGEX, options).matches[0].data,
+      ).toMatchSnapshot();
+    });
+
+    it('replace placeholder with capture group value', () => {
+      const input = 'foo <span><i>"</i>foo<i>"</i></span>';
+      const options = { value: 'go/$1.txt' };
+
+      expect(
+        helper(input, DEFAULT_REGEX, options).matches[0].data,
+      ).toMatchSnapshot();
+    });
+
+    it('wraps the second regex match', () => {
+      const options = { value: '$2', xx: 'yy' };
+      const input = 'foo <i>"</i>bar<i>"</i> <i>"</i>baz<i>"</i>';
+      const regex = /foo ("\w+") ("\w+")/;
+
+      expect(
+        helper(input, regex, options, '$2').matches[0].data,
+      ).toMatchSnapshot();
+    });
   });
 });

--- a/packages/helper-insert-link/__tests__/index.js
+++ b/packages/helper-insert-link/__tests__/index.js
@@ -83,51 +83,6 @@ describe('insert-link', () => {
     expect(el).toMatchSnapshot();
   });
 
-  it('adds the given data-* attributes', () => {
-    const input = 'foo <span><i>"</i>foo<i>"</i></span>';
-    const options = { value: '$1', bar: 'baz' };
-
-    expect({
-      ...helper(input, DEFAULT_REGEX, options).querySelector('a').dataset,
-    }).toMatchSnapshot();
-  });
-
-  it('replace placeholder with capture group value', () => {
-    const input = 'foo <span><i>"</i>foo<i>"</i></span>';
-    const options = { value: 'go/$1.txt' };
-
-    expect({
-      ...helper(input, DEFAULT_REGEX, options).querySelector('a').dataset,
-    }).toMatchSnapshot();
-  });
-
-  it('can handle if value is undefined', () => {
-    const input = 'foo <span><i>"</i>foo<i>"</i></span>';
-    const options = { value: undefined };
-
-    expect({
-      ...helper(input, DEFAULT_REGEX, options).querySelector('a').dataset,
-    }).toMatchSnapshot();
-  });
-
-  it('can handle if value is null', () => {
-    const input = 'foo <span><i>"</i>foo<i>"</i></span>';
-    const options = { value: null };
-
-    expect({
-      ...helper(input, DEFAULT_REGEX, options).querySelector('a').dataset,
-    }).toMatchSnapshot();
-  });
-
-  it('can handle if value is empty string', () => {
-    const input = 'foo <span><i>"</i>foo<i>"</i></span>';
-    const options = { value: '' };
-
-    expect({
-      ...helper(input, DEFAULT_REGEX, options).querySelector('a').dataset,
-    }).toMatchSnapshot();
-  });
-
   it('wraps the second regex match', () => {
     const options = { value: '$2', xx: 'yy' };
     const input = 'foo <i>"</i>bar<i>"</i> <i>"</i>baz<i>"</i>';

--- a/packages/helper-insert-link/__tests__/index.js
+++ b/packages/helper-insert-link/__tests__/index.js
@@ -15,69 +15,71 @@ describe('insert-link', () => {
 
     insertLink(el, regex, options, replaceIndex);
 
-    return el;
+    return {
+      el,
+    };
   }
 
   it('wraps the elements based on their char position which is specified in the keywords map', () => {
-    expect(helper('foo <span><i>"</i>foo<i>"</i></span>')).toMatchSnapshot();
+    expect(helper('foo <span><i>"</i>foo<i>"</i></span>').el).toMatchSnapshot();
   });
 
   it('wraps the parent element when keyword is divided', () => {
     expect(
-      helper('foo <span><i>"</i><span>fo</span>o<i>"</i></span>'),
+      helper('foo <span><i>"</i><span>fo</span>o<i>"</i></span>').el,
     ).toMatchSnapshot();
   });
 
   it('wraps a nested element', () => {
     expect(
-      helper('foo <div><span><i>"</i>foo<i>"</i></span></div>'),
+      helper('foo <div><span><i>"</i>foo<i>"</i></span></div>').el,
     ).toMatchSnapshot();
   });
 
   it('wraps double quotes', () => {
     const input = 'foo <span>"foo"</span>';
 
-    expect(helper(input)).toMatchSnapshot();
+    expect(helper(input).el).toMatchSnapshot();
   });
 
   it('wraps single quotes', () => {
     const regex = /foo ('\w+')/;
     const input = "foo <span>'foo'</span>";
 
-    expect(helper(input, regex)).toMatchSnapshot();
+    expect(helper(input, regex).el).toMatchSnapshot();
   });
 
   it('wraps mixed quotes', () => {
     const regex = /foo ('\w+")/;
     const input = 'foo <span>\'foo"</span>';
 
-    expect(helper(input, regex)).toMatchSnapshot();
+    expect(helper(input, regex).el).toMatchSnapshot();
   });
 
   it('wraps a single word', () => {
     const regex = /foo (\w+)/;
     const input = 'foo <span>bar</span>';
 
-    expect(helper(input, regex)).toMatchSnapshot();
+    expect(helper(input, regex).el).toMatchSnapshot();
   });
 
   it('wraps a single string', () => {
     const regex = /(bar)/;
     const input = 'foo bar baz';
 
-    expect(helper(input, regex)).toMatchSnapshot();
+    expect(helper(input, regex).el).toMatchSnapshot();
   });
 
   it('wraps multiple strings', () => {
     const regex = /foo (bar)/;
     const input = 'foo bar baz';
 
-    expect(helper(input, regex)).toMatchSnapshot();
+    expect(helper(input, regex).el).toMatchSnapshot();
   });
 
   it('wraps the element once', () => {
     const input = 'foo <span><i>"</i>foo<i>"</i></span>';
-    const el = helper(input);
+    const { el } = helper(input);
     insertLink(el, DEFAULT_REGEX, {}, '$1');
 
     expect(el).toMatchSnapshot();
@@ -88,11 +90,11 @@ describe('insert-link', () => {
     const input = 'foo <i>"</i>bar<i>"</i> <i>"</i>baz<i>"</i>';
     const regex = /foo ("\w+") ("\w+")/;
 
-    expect(helper(input, regex, options, '$2')).toMatchSnapshot();
+    expect(helper(input, regex, options, '$2').el).toMatchSnapshot();
   });
 
   it('does not remove closing parentheses from commented out require() calls', () => {
     const input = "// var faker = require('faker')";
-    expect(helper(input, REQUIRE)).toMatchSnapshot();
+    expect(helper(input, REQUIRE).el).toMatchSnapshot();
   });
 });

--- a/packages/helper-insert-link/index.js
+++ b/packages/helper-insert-link/index.js
@@ -7,7 +7,7 @@ const CLASS_NAME = 'octolinker-link';
 const CLASS_INDICATOR = 'octolinker-line-indicator';
 const QUOTE_SIGNS = '"\'';
 
-function createLinkElement(text, dataAttr = {}) {
+function createLinkElement(text) {
   const linkEl = document.createElement('a');
   const spanEl = document.createElement('span');
 
@@ -21,13 +21,6 @@ function createLinkElement(text, dataAttr = {}) {
 
   if (storage.get('showLinkIndicator')) {
     linkEl.classList.add(CLASS_INDICATOR);
-  }
-
-  // Add data-* attributes
-  for (const key in dataAttr) {
-    if (dataAttr.hasOwnProperty(key)) {
-      linkEl.dataset[key] = dataAttr[key];
-    }
   }
 
   return linkEl;
@@ -103,7 +96,7 @@ function getQuoteAtPos(str, pos) {
   return '';
 }
 
-function wrapClosestElement(node, dataAttrObject, matchValue) {
+function wrapClosestElement(node, matchValue) {
   let currentNode = node;
 
   while (!currentNode.textContent.includes(matchValue)) {
@@ -111,11 +104,11 @@ function wrapClosestElement(node, dataAttrObject, matchValue) {
   }
 
   if (currentNode) {
-    $(currentNode).wrap(createLinkElement('', dataAttrObject));
+    $(currentNode).wrap(createLinkElement(''));
   }
 }
 
-function wrapsInnerString(text, matchValue, dataAttrObject) {
+function wrapsInnerString(text, matchValue) {
   const parent = document.createElement('span');
   const [leftSide, rightSide] = text.split(matchValue);
   const openingQuote = getQuoteAtPos(matchValue, 0);
@@ -127,7 +120,7 @@ function wrapsInnerString(text, matchValue, dataAttrObject) {
 
   if (leftSide) parent.appendChild(document.createTextNode(leftSide));
   if (openingQuote) parent.appendChild(document.createTextNode(openingQuote));
-  parent.appendChild(createLinkElement(linkText, dataAttrObject));
+  parent.appendChild(createLinkElement(linkText));
   if (closingQuote) parent.appendChild(document.createTextNode(closingQuote));
   if (rightSide) parent.appendChild(document.createTextNode(rightSide));
   return parent;
@@ -142,10 +135,13 @@ function replace(portion, match, dataAttr, captureGroup) {
   }
 
   const matchValue = getCaptureGroupValue(match, captureGroup);
-  const dataAttrObject = buildDataAttr(dataAttr, match);
+
+  // I know this call is usless, but I don't want to remove the function
+  // at this point. I have to refactor this in another commit anyway.
+  buildDataAttr(dataAttr, match);
 
   if (node.textContent.includes(matchValue)) {
-    return wrapsInnerString(text, matchValue, dataAttrObject);
+    return wrapsInnerString(text, matchValue);
   }
 
   const { valueStartPos, valueEndPos, portionEndPos } = getIndexes(
@@ -155,10 +151,10 @@ function replace(portion, match, dataAttr, captureGroup) {
   );
   if (valueStartPos === indexInMatch) {
     if (portionEndPos === valueEndPos) {
-      return createLinkElement(text, dataAttrObject);
+      return createLinkElement(text);
     }
 
-    wrapClosestElement(node, dataAttrObject, matchValue);
+    wrapClosestElement(node, matchValue);
     return text;
   }
 


### PR DESCRIPTION
**This PR based on #435! Related changes starting from 790dc43.**

In preparation for #277, this PR refactors the `helper-insert-link` package to return an array of matches. This allows us to separate the matching and link creation process. A match is an object with the following two properties. 
- `link` is a DOM reference to the a-tag element. 
- `data` represents the data-attributes.

Note, I moved the data attribute assignment to the `core` package to retain the functionality until we complete work for #277. 

To review related changes for this PR, you can use this [link](
https://github.com/OctoLinker/OctoLinker/compare/c36144c6b60351a21e8fd173ff1d81b796ff77b8...0da292982b5f76e940666d94e136085788e7e96c?w=1) or start reviewing from 790dc43