### PR TITLE
v4.16.0

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "OctoLinker",
-  "version": "4.15.1",
+  "version": "4.16.0",
   "manifest_version": 2,
   "author": "Stefan Buck",
   "description": "",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octolinker/core",
-  "version": "4.15.1",
+  "version": "4.16.0",
   "description": "OctoLinker browser extension core",
   "repository": "https://github.com/octolinker/octolinker/tree/master/packages/core",
   "license": "MIT",


### PR DESCRIPTION
Extended .net and typescript support 


# Highlights
- Extend existing .net proj file to support `DotNetCliToolReference` #419
- Add support for F# project files and .net props files #424
- Add support for `.tsx` files #438

## Housekeeping

- Replace Karma / Mocha with Jest (#415) 
- Fix Haskell logo path in readme #417
- Add demo git fo readme
- Improve Windows compatibility of npm scripts #423 #420
- Fix load plugins error #421
- Use XRegExp.tag instead of re-implementing it #426
- Move away from posix #428
- Continue mono repo work by using `lerna` #433
- Move insert-link and settings to separate packages #435
- Refactor helper-insert-link package #436

## All Changes

[v4.15.0...v4.16.0](https://github.com/OctoLinker/browser-extension/compare/v4.15.0...v4.16.0)

Huge thanks to our contributors: @xt0rted and @bildja 