### PR TITLE
Handle undefined results in the match array

### DIFF
--- a/packages/core/octo-linker.js
+++ b/packages/core/octo-linker.js
@@ -18,7 +18,12 @@ function initialize(self) {
 }
 
 function insertDataAttr(matches) {
-  matches.forEach(({ data, link }) => {
+  matches.forEach(item => {
+    if (!item) {
+      return;
+    }
+
+    const { data, link } = item;
     for (const key in data) {
       if (data.hasOwnProperty(key)) {
         link.dataset[key] = data[key];


### PR DESCRIPTION
Fix for #443. This was caused by combination, where the [composer plugin](https://github.com/OctoLinker/OctoLinker/blob/b175d59f1bd6f630ffb655dac6449a674852aa7f/packages/plugin-composer-manifest/index.js#L8) returns `undefined` if the json key is `php` and a not solid `forEach` loop in the octolinker core.

<img width="547" alt="screen shot 2018-02-07 at 22 54 31" src="https://user-images.githubusercontent.com/1393946/35943634-f7cf78c0-0c59-11e8-9759-154095e28ad0.png">
