### PR TITLE
Prevent scroll cursor when using middle mouse click

### DIFF
--- a/packages/core/click-handler.js
+++ b/packages/core/click-handler.js
@@ -75,6 +75,8 @@ async function onClick(event) {
     return;
   }
 
+  event.preventDefault();
+
   const $tooltipTarget = $('span', event.currentTarget);
 
   showTooltip($tooltipTarget, PROCESS);


### PR DESCRIPTION
Follow up on #456 

cc @xPaw I've attached a build with the fix applied. Please let me know if this is fixing your issue. Thank you

[octolinker-scroll-fix.zip](https://github.com/OctoLinker/OctoLinker/files/1886286/octolinker-scroll-fix.zip)
