### PR TITLE
Respect Do Not Track setting

### DIFF
--- a/packages/core/click-handler.js
+++ b/packages/core/click-handler.js
@@ -95,7 +95,7 @@ async function onClick(event) {
     });
 
   try {
-    const { url, res } = await fetch(urls);
+    const { url, res } = await fetch(urls, storage.get('doTrack'));
 
     track('success');
     showTooltip($tooltipTarget, RESOLVED);

--- a/packages/core/utils/fetch.js
+++ b/packages/core/utils/fetch.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 
-export default async urls => {
+export default async (urls, doTrack) => {
   for (const { url, func, method = 'HEAD' } of urls) {
     try {
       if (func) {
@@ -10,6 +10,8 @@ export default async urls => {
         };
       }
 
+      const doNotTrack = window.navigator.doNotTrack || !doTrack;
+
       // Normally, you wouldn't use `await` inside of a loop.
       // However, we explicity want to do this sequentially.
       // See http://eslint.org/docs/rules/no-await-in-loop
@@ -17,6 +19,9 @@ export default async urls => {
       const res = await $.ajax({
         method,
         url,
+        headers: {
+          DNT: doNotTrack ? '1' : '0',
+        },
       });
 
       return { url, res };


### PR DESCRIPTION
Adds support for the Do Not Track standard. If Do Not Track is enabled in the browser or in the extension settings, we pass this information along the request to our [redirect service](https://github.com/OctoLinker/live-resolver/).