### PR TITLE
Use custom header to avoid clash with the DNT standard

### DIFF
--- a/packages/core/utils/fetch.js
+++ b/packages/core/utils/fetch.js
@@ -10,7 +10,9 @@ export default async (urls, doTrack) => {
         };
       }
 
-      const doNotTrack = window.navigator.doNotTrack || !doTrack;
+      const headers = {
+        'Do-Not-Track': !doTrack ? '1' : undefined,
+      };
 
       // Normally, you wouldn't use `await` inside of a loop.
       // However, we explicity want to do this sequentially.
@@ -19,9 +21,7 @@ export default async (urls, doTrack) => {
       const res = await $.ajax({
         method,
         url,
-        headers: {
-          DNT: doNotTrack ? '1' : '0',
-        },
+        headers,
       });
 
       return { url, res };


### PR DESCRIPTION
Yesterday, a new version of OctoLinker was released with the option to opt-out of logging. Today, I noticed that this isn't working as expected. Setting `DNT: 1` cause the browser to throw the following error.

```
Refused to set unsafe header DNT
```

I'm not 100% sure why I can't set this header, but I worked around by introducing a custom header called `do-not-track`.  

