### PR TITLE
Add support for non repo root Haskell projects.

### DIFF
--- a/packages/plugin-haskell/__tests__/index.js
+++ b/packages/plugin-haskell/__tests__/index.js
@@ -1,18 +1,34 @@
 import assert from 'assert';
-import githubSearch from '@octolinker/resolver-github-search';
+import { hoogleSearch } from '@octolinker/resolver-hoogle-search';
 import Haskell from '../index';
 
 describe('haskell', () => {
-  const path = '/user/repo/blob/d6/lib/plugins/javascript.js';
-  const target = 'Foo.Bar';
+  it('resolves links - top level project', () => {
+    const path = '/user/repo/blob/v0.1/src/Main.hs';
+    const target = 'Foo.Bar';
 
-  it('resolves links', () => {
     assert.deepEqual(Haskell.resolve(path, [target]), [
-      '{BASE_URL}/user/repo/blob/master/src/Foo/Bar.hs',
-      '{BASE_URL}/user/repo/blob/master/lib/Foo/Bar.hs',
-      '{BASE_URL}/user/repo/blob/master/Foo/Bar.hs',
-      githubSearch({ path, target }).toString(),
-      'https://hackage.haskell.org/package/base/docs/Foo-Bar.html',
+      '{BASE_URL}/user/repo/blob/v0.1/src/Foo/Bar.hs',
+      '{BASE_URL}/user/repo/blob/v0.1/lib/Foo/Bar.hs',
+      '{BASE_URL}/user/repo/blob/v0.1/app/Foo/Bar.hs',
+      '{BASE_URL}/user/repo/blob/v0.1/test/Foo/Bar.hs',
+      '{BASE_URL}/user/repo/blob/v0.1/Foo/Bar.hs',
+      hoogleSearch({ target }).toString(),
+    ]);
+  });
+
+  it('resolves links - monorepo project', () => {
+    const path =
+      '/user/repo/blob/v0.1/projects/project-in-monorepo/src/Main.hs';
+    const target = 'Foo.Bar';
+
+    assert.deepEqual(Haskell.resolve(path, [target]), [
+      '{BASE_URL}/user/repo/blob/v0.1/projects/project-in-monorepo/src/Foo/Bar.hs',
+      '{BASE_URL}/user/repo/blob/v0.1/projects/project-in-monorepo/lib/Foo/Bar.hs',
+      '{BASE_URL}/user/repo/blob/v0.1/projects/project-in-monorepo/app/Foo/Bar.hs',
+      '{BASE_URL}/user/repo/blob/v0.1/projects/project-in-monorepo/test/Foo/Bar.hs',
+      '{BASE_URL}/user/repo/blob/v0.1/projects/project-in-monorepo/Foo/Bar.hs',
+      hoogleSearch({ target }).toString(),
     ]);
   });
 });

--- a/packages/plugin-haskell/index.js
+++ b/packages/plugin-haskell/index.js
@@ -1,21 +1,20 @@
 import { HASKELL_IMPORT } from '@octolinker/helper-grammar-regex-collection';
-import githubSearch from '@octolinker/resolver-github-search';
+import { hoogleSearch } from '@octolinker/resolver-hoogle-search';
 
 export default {
   name: 'Haskell',
 
   resolve(path, [target]) {
-    const [, user, repo] = path.split('/');
     const filePath = target.replace(/\./g, '/');
+    const basePath = path.split(/\/(src|lib|app|test)\//)[0];
+
     return [
-      `{BASE_URL}/${user}/${repo}/blob/master/src/${filePath}.hs`,
-      `{BASE_URL}/${user}/${repo}/blob/master/lib/${filePath}.hs`,
-      `{BASE_URL}/${user}/${repo}/blob/master/${filePath}.hs`,
-      githubSearch({ path, target: `${filePath}.hs` }),
-      `https://hackage.haskell.org/package/base/docs/${target.replace(
-        /\./g,
-        '-',
-      )}.html`,
+      `{BASE_URL}${basePath}/src/${filePath}.hs`,
+      `{BASE_URL}${basePath}/lib/${filePath}.hs`,
+      `{BASE_URL}${basePath}/app/${filePath}.hs`,
+      `{BASE_URL}${basePath}/test/${filePath}.hs`,
+      `{BASE_URL}${basePath}/${filePath}.hs`,
+      hoogleSearch({ target }),
     ];
   },
 

--- a/packages/plugin-haskell/package.json
+++ b/packages/plugin-haskell/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "./index.js",
   "dependencies": {
-    "@octolinker/resolver-github-search": "1.0.0",
+    "@octolinker/resolver-hoogle-search": "1.0.0",
     "@octolinker/helper-grammar-regex-collection": "1.0.0"
   }
 }

--- a/packages/resolver-hoogle-search/__tests__/index.js
+++ b/packages/resolver-hoogle-search/__tests__/index.js
@@ -1,0 +1,26 @@
+import assert from 'assert';
+import { hoogleSearch, handleResponse } from '../index';
+
+describe('hoogle-search', () => {
+  const target = 'Data.Typeable';
+
+  beforeAll(() => {
+    global.fetch = jest.fn();
+  });
+
+  it('returns a function', () => {
+    assert.deepEqual(typeof hoogleSearch({ target }), 'function');
+  });
+
+  it('calls the hoogle search api', () => {
+    hoogleSearch({ target })();
+
+    expect(global.fetch).toBeCalledWith(
+      'https://hoogle.haskell.org/?hoogle=Data.Typeable%20is:module%20is:exact&mode=json',
+    );
+  });
+
+  it('returns null when no results', () => {
+    assert.equal(handleResponse('url', 'target', []), null);
+  });
+});

--- a/packages/resolver-hoogle-search/__tests__/index.js
+++ b/packages/resolver-hoogle-search/__tests__/index.js
@@ -1,11 +1,17 @@
 import assert from 'assert';
-import { hoogleSearch, handleResponse } from '../index';
+import { hoogleSearch } from '../index';
 
 describe('hoogle-search', () => {
   const target = 'Data.Typeable';
-
+  let response;
   beforeAll(() => {
-    global.fetch = jest.fn();
+    global.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        json() {
+          return response;
+        },
+      }),
+    );
   });
 
   it('returns a function', () => {
@@ -20,7 +26,22 @@ describe('hoogle-search', () => {
     );
   });
 
-  it('returns null when no results', () => {
-    assert.equal(handleResponse('url', 'target', []), null);
+  it('returns url', async () => {
+    response = [
+      {
+        url:
+          'https://hackage.haskell.org/package/base-4.11.1.0/docs/Data-Typeable.html',
+      },
+    ];
+
+    expect(await hoogleSearch({ target })()).toBe(
+      'https://hackage.haskell.org/package/base-4.11.1.0/docs/Data-Typeable.html',
+    );
+  });
+
+  it('returns null when no results', async () => {
+    response = [];
+
+    expect(await hoogleSearch({ target })()).toBe(null);
   });
 });

--- a/packages/resolver-hoogle-search/index.js
+++ b/packages/resolver-hoogle-search/index.js
@@ -1,0 +1,30 @@
+export function handleResponse(hoogleSearchUrl, target, response) {
+  const checkExact = function(item) {
+    return item.url.indexOf(`docs/${target.replace(/\./g, '-')}.html`) !== -1;
+  };
+
+  if (response.length > 0) {
+    // Multiple packages may provide the same module (see Crypto.MAC.HMAC)
+    // We redirect to doc if there is only exact match
+    // Otherwise, we redirect to hoogle search to avoid confucion
+    const exactMatches = response.filter(checkExact);
+    if (exactMatches.length === 1) {
+      return exactMatches[0].url;
+    }
+    return hoogleSearchUrl;
+  }
+  return null;
+}
+
+export function hoogleSearch({ target }) {
+  const query = `${encodeURIComponent(target)}%20is:module%20is:exact`;
+  const hoogleSearchUrl = `https://hoogle.haskell.org/?hoogle=${query}`;
+  const apiUrl = `${hoogleSearchUrl}&mode=json`;
+
+  return async function doHoogleSearch() {
+    const response = await fetch(apiUrl);
+    const json = await response.json();
+
+    return handleResponse(hoogleSearchUrl, target, json);
+  };
+}

--- a/packages/resolver-hoogle-search/index.js
+++ b/packages/resolver-hoogle-search/index.js
@@ -1,4 +1,4 @@
-export function handleResponse(hoogleSearchUrl, target, response) {
+function handleResponse(hoogleSearchUrl, target, response) {
   const checkExact = function(item) {
     return item.url.includes(`docs/${target.replace(/\./g, '-')}.html`);
   };

--- a/packages/resolver-hoogle-search/index.js
+++ b/packages/resolver-hoogle-search/index.js
@@ -18,11 +18,10 @@ export function handleResponse(hoogleSearchUrl, target, response) {
 
 export function hoogleSearch({ target }) {
   const query = `${encodeURIComponent(target)}%20is:module%20is:exact`;
-  const hoogleSearchUrl = `https://hoogle.haskell.org/?hoogle=${query}`;
-  const apiUrl = `${hoogleSearchUrl}&mode=json`;
+  const hoogleSearchUrl = `https://hoogle.haskell.org/?hoogle=${query}&mode=json`;
 
   return async function doHoogleSearch() {
-    const response = await fetch(apiUrl);
+    const response = await fetch(hoogleSearchUrl);
     const json = await response.json();
 
     return handleResponse(hoogleSearchUrl, target, json);

--- a/packages/resolver-hoogle-search/index.js
+++ b/packages/resolver-hoogle-search/index.js
@@ -1,6 +1,6 @@
 export function handleResponse(hoogleSearchUrl, target, response) {
   const checkExact = function(item) {
-    return item.url.indexOf(`docs/${target.replace(/\./g, '-')}.html`) !== -1;
+    return item.url.includes(`docs/${target.replace(/\./g, '-')}.html`);
   };
 
   if (response.length > 0) {

--- a/packages/resolver-hoogle-search/package.json
+++ b/packages/resolver-hoogle-search/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@octolinker/resolver-hoogle-search",
+  "version": "1.0.0",
+  "description": "",
+  "repository": "https://github.com/octolinker/octolinker/tree/master/packages/resolver-hoogle-search",
+  "license": "MIT",
+  "main": "./index.js",
+  "dependencies": {
+    "@octolinker/helper-settings": "1.0.0"
+  }
+}


### PR DESCRIPTION
In my use case we keep several Haskell projects in one repository (monorepo approach). This PR extends search to modules relative to Haskell project root (not git root). It is detected by cutting current path on `src`, `lib`, `app`, or `test`. Also adds navigation in test suites.