### PR TITLE
Fix bower, composer, and dotnet plugins

### DIFF
--- a/packages/core/octo-linker.js
+++ b/packages/core/octo-linker.js
@@ -42,6 +42,8 @@ function run(self) {
     });
   });
 
+  matches = matches.filter(result => result !== undefined);
+
   clickHandler(matches);
 }
 

--- a/packages/plugin-bower-manifest/index.js
+++ b/packages/plugin-bower-manifest/index.js
@@ -48,7 +48,7 @@ export default {
   },
 
   parseBlob(blob) {
-    return processJSON(blob, {
+    return processJSON(blob, this, {
       '$.dependencies': linkDependency,
       '$.devDependencies': linkDependency,
       '$.resolutions': linkDependency,

--- a/packages/plugin-composer-manifest/index.js
+++ b/packages/plugin-composer-manifest/index.js
@@ -4,23 +4,20 @@ import { jsonRegExKeyValue } from '@octolinker/helper-regex-builder';
 import liveResolverQuery from '@octolinker/resolver-live-query';
 
 function linkDependency(blob, key, value) {
-  if (key === 'php') {
+  if (key === 'php' || key.startsWith('ext-')) {
     return;
   }
 
   const regex = jsonRegExKeyValue(key, value);
 
-  return insertLink(blob.el, regex, {
-    pluginName: 'Composer',
-    target: '$1',
-  });
+  return insertLink(blob, regex, this);
 }
 
 export default {
   name: 'Composer',
 
-  resolve(path, [target]) {
-    return liveResolverQuery({ type: 'composer', target });
+  resolve(path, values) {
+    return liveResolverQuery({ type: 'composer', target: values[0] });
   },
 
   getPattern() {
@@ -31,7 +28,7 @@ export default {
   },
 
   parseBlob(blob) {
-    return processJSON(blob, {
+    return processJSON(blob, this, {
       '$.require': linkDependency,
       '$.require-dev': linkDependency,
       '$.conflict': linkDependency,

--- a/packages/plugin-composer-manifest/index.js
+++ b/packages/plugin-composer-manifest/index.js
@@ -16,8 +16,8 @@ function linkDependency(blob, key, value) {
 export default {
   name: 'Composer',
 
-  resolve(path, values) {
-    return liveResolverQuery({ type: 'composer', target: values[0] });
+  resolve(path, [target]) {
+    return liveResolverQuery({ type: 'composer', target });
   },
 
   getPattern() {

--- a/packages/plugin-dot-net-core/index.js
+++ b/packages/plugin-dot-net-core/index.js
@@ -6,10 +6,7 @@ import nugetResolver from '@octolinker/resolver-nuget';
 function linkDependency(blob, key, value) {
   const regex = jsonRegExKeyValue(key, value);
 
-  return insertLink(blob.el, regex, {
-    pluginName: 'DotNetCore',
-    target: '$1',
-  });
+  return insertLink(blob, regex, this);
 }
 
 export default {
@@ -27,7 +24,7 @@ export default {
   },
 
   parseBlob(blob) {
-    return processJSON(blob, {
+    return processJSON(blob, this, {
       '$.dependencies': linkDependency,
       '$.tools': linkDependency,
       '$.frameworks.*.dependencies': linkDependency,


### PR DESCRIPTION
Hi,

I noticed that OctoLinker is throwing an error when viewing composer.json and doesn't work in general with it. Short inspection showed that some of the changes made in March were not reflected in plugins using @octolinker/helper-process-json which lead to finding few more issues, but in the end and got it to work.

Let me know if anything needs improving.