### PR TITLE
redirect to hoogle search page when search returns more than one result

### DIFF
--- a/packages/resolver-hoogle-search/__tests__/index.js
+++ b/packages/resolver-hoogle-search/__tests__/index.js
@@ -39,6 +39,23 @@ describe('hoogle-search', () => {
     );
   });
 
+  it('returns hoogle search page when search returns more than one result', async () => {
+    response = [
+      {
+        url:
+          'https://hackage.haskell.org/package/base-4.11.1.0/docs/Data-Typeable.html',
+      },
+      {
+        url:
+          'https://hackage.haskell.org/package/base-4.11.1.0/docs/Data-Typeable.html',
+      },
+    ];
+
+    expect(await hoogleSearch({ target })()).toBe(
+      'https://hoogle.haskell.org/?hoogle=Data.Typeable%20is:module%20is:exact',
+    );
+  });
+
   it('returns null when no results', async () => {
     response = [];
 

--- a/packages/resolver-hoogle-search/index.js
+++ b/packages/resolver-hoogle-search/index.js
@@ -18,10 +18,10 @@ function handleResponse(hoogleSearchUrl, target, response) {
 
 export function hoogleSearch({ target }) {
   const query = `${encodeURIComponent(target)}%20is:module%20is:exact`;
-  const hoogleSearchUrl = `https://hoogle.haskell.org/?hoogle=${query}&mode=json`;
+  const hoogleSearchUrl = `https://hoogle.haskell.org/?hoogle=${query}`;
 
   return async function doHoogleSearch() {
-    const response = await fetch(hoogleSearchUrl);
+    const response = await fetch(`${hoogleSearchUrl}&mode=json`);
     const json = await response.json();
 
     return handleResponse(hoogleSearchUrl, target, json);


### PR DESCRIPTION
Changes I made on @kfigiela PR's introduced a bug. 

> This simplification is not correct. Note that we use `apiUrl` for JSON API lookup. However, in case that more than one package provides module with the same name I redirect to search page that indicates matches (`hoogleSearchUrl` that lacks `&mode=json` parameter). Now it redirects to JSON response.
> Example use case: follow `Net.IPv4` import on https://github.com/rlupton20/vanguard-dataplane/blob/293e2e34c31b17051baa5cf02824c275aa82e772/app/Debug/PacketParsing/IP4.hs
> Now it redirects to https://hoogle.haskell.org/?hoogle=Net.IPv4%20is:module%20is:exact&mode=json which is not very useful, however search page looks better https://hoogle.haskell.org/?hoogle=Net.IPv4%20is:module%20is:exact

 https://github.com/OctoLinker/OctoLinker/pull/463/files/46bb18a84a3ef26ce3e37862e5e3e9e915b541e3..cc7fc70f55b40522432af6e594bcf239ca8e7fd7#r192562811