### PR TITLE
Speed up linking 

### DIFF
--- a/packages/core/octo-linker.js
+++ b/packages/core/octo-linker.js
@@ -2,6 +2,7 @@ import injection from 'github-injection';
 import BlobReader from '@octolinker/blob-reader';
 import insertLink from '@octolinker/helper-insert-link';
 import * as storage from '@octolinker/helper-settings';
+import helperSortUrls from '@octolinker/helper-sort-urls';
 import notification from './notification';
 import clickHandler from './click-handler';
 import Plugins from './plugin-manager.js';
@@ -42,7 +43,21 @@ function run(self) {
     });
   });
 
-  matches = matches.filter(result => result !== undefined);
+  matches = matches
+    .filter(result => result !== undefined)
+    .map(({ link, urls }) => {
+      let finalUrls = urls;
+
+      // Some urls are single object e.g. live-resolver-query results
+      if (Array.isArray(urls)) {
+        finalUrls = helperSortUrls(urls, link.innerText);
+      }
+
+      return {
+        link,
+        urls: finalUrls,
+      };
+    });
 
   clickHandler(matches);
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@octolinker/blob-reader": "1.0.0",
     "@octolinker/helper-settings": "1.0.0",
+    "@octolinker/helper-sort-urls": "1.0.0",
     "@octolinker/helper-insert-link": "1.0.0",
     "@octolinker/plugin-bower-manifest": "1.0.0",
     "@octolinker/plugin-composer-manifest": "1.0.0",

--- a/packages/helper-sort-urls/__tests__/index.js
+++ b/packages/helper-sort-urls/__tests__/index.js
@@ -1,0 +1,35 @@
+import helperSortUrls from '../index';
+
+describe('helper-sort-urls', () => {
+  let urls;
+
+  beforeEach(() => {
+    urls = [
+      'foo.js',
+      'foo.json',
+      'foo/bar.json',
+      'foo/bar.js',
+      'foo/bar/baz.json',
+      'foo/bar/baz.js',
+    ];
+  });
+
+  it('reorders urls when file extension is present', () => {
+    expect(helperSortUrls(urls, 'file.json')).toEqual([
+      'foo.json',
+      'foo/bar.json',
+      'foo/bar/baz.json',
+      'foo.js',
+      'foo/bar.js',
+      'foo/bar/baz.js',
+    ]);
+  });
+
+  it('keeps order when file does not have a file extension', () => {
+    expect(helperSortUrls(urls, 'file')).toEqual(urls);
+  });
+
+  it('keeps order when file extension is not present', () => {
+    expect(helperSortUrls(urls, 'file.txt')).toEqual(urls);
+  });
+});

--- a/packages/helper-sort-urls/index.js
+++ b/packages/helper-sort-urls/index.js
@@ -1,0 +1,20 @@
+import { extname } from 'path';
+
+export default function(urls, fileName) {
+  const fileExtension = extname(fileName);
+
+  if (!fileExtension) {
+    return urls;
+  }
+
+  function prioSort(fileExt, memo, file) {
+    const index = typeof file === 'string' && file.endsWith(fileExt) ? 0 : 1;
+    memo[index].push(file);
+
+    return memo;
+  }
+
+  return [].concat(
+    ...urls.reduce(prioSort.bind(null, fileExtension), [[], []]),
+  );
+}

--- a/packages/helper-sort-urls/package.json
+++ b/packages/helper-sort-urls/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@octolinker/helper-sort-urls",
+  "version": "1.0.0",
+  "description": "",
+  "repository": "https://github.com/octolinker/octolinker/tree/master/packages/helper-sort-urls",
+  "license": "MIT",
+  "main": "./index.js"
+}


### PR DESCRIPTION
Yesterday, I noticed that in some cases, I have to wait quite long time for a redirect. For example ur [JavaScript resolvers](https://github.com/OctoLinker/OctoLinker/blob/master/packages/plugin-javascript/index.js#L21-L59) returns an Array of possible urls which is sort by the most common cases. 

```js
[
    '{BASE_URL}path/file.js',
    '{BASE_URL}path/file/index.js',
    '{BASE_URL}path/file.jsx',
    '{BASE_URL}path/file/index.jsx',
    '{BASE_URL}path/file.ts',
    '{BASE_URL}path/file/index.ts',
    '{BASE_URL}path/file.tsx',
    '{BASE_URL}path/file/index.tsx',
    '{BASE_URL}path/file.ls',
    '{BASE_URL}path/file/index.ls',
    '{BASE_URL}path/file.json',
    '{BASE_URL}path/file/index.json',
    '{BASE_URL}path/file',
]
```

This makes resolving less popular cases quite slow. In [our repository](https://github.com/OctoLinker/OctoLinker/blob/master/packages/core/notification.js#L4) we have `require('../package.json')`. A click on this will load 10 possible urls before it hits the actual loadable path.

To solve this issue, I added a new helper package which allows us to sort urls returned by a resolver by file extensions. I couldn't think of any edge cases and therefore I added this new behaviour to core which applies it to all urls by default. 






