### PR TITLE
Adjust resolver to return a single string or an array of string whenever possible

### DIFF
--- a/packages/core/click-handler.js
+++ b/packages/core/click-handler.js
@@ -37,25 +37,29 @@ function getResolverUrls(urls) {
       return null;
     }
 
+    // github-search resolver returns a function
     if (typeof url === 'function') {
       return {
         func: url,
       };
     }
 
-    if (typeof url === 'object') {
+    // Live-query resolver results
+    if (url.startsWith('https://githublinker.herokuapp.com')) {
       return {
-        url: url.url.replace('{BASE_URL}', BASE_URL),
-        method: url.method,
+        url,
+        method: 'GET',
       };
     }
 
+    // Relative file
     if (url.startsWith('{BASE_URL}') || url.startsWith(BASE_URL)) {
       return {
         url: url.replace('{BASE_URL}', BASE_URL),
       };
     }
 
+    // Extneral urls
     return {
       url: `https://githublinker.herokuapp.com/ping?url=${url}`,
       method: 'GET',

--- a/packages/core/click-handler.js
+++ b/packages/core/click-handler.js
@@ -59,7 +59,7 @@ function getResolverUrls(urls) {
       };
     }
 
-    // Extneral urls
+    // External urls
     return {
       url: `https://githublinker.herokuapp.com/ping?url=${url}`,
       method: 'GET',

--- a/packages/plugin-css/index.js
+++ b/packages/plugin-css/index.js
@@ -5,7 +5,7 @@ export default {
   name: 'CSS',
 
   resolve(path, [target]) {
-    return [relativeFile({ path, target })];
+    return relativeFile({ path, target });
   },
 
   getPattern() {

--- a/packages/plugin-docker/__tests__/index.js
+++ b/packages/plugin-docker/__tests__/index.js
@@ -1,36 +1,35 @@
-import assert from 'assert';
 import dockerImage from '../index';
 
 describe('docker-image', () => {
   const path = '/blob/path/dummy';
 
   it('resolves foo to https://hub.docker.com/_/foo', () => {
-    assert.deepEqual(dockerImage.resolve(path, ['foo']), [
+    expect(dockerImage.resolve(path, ['foo'])).toBe(
       'https://hub.docker.com/_/foo',
-    ]);
+    );
   });
 
   it('resolves foo:1.2.3 to https://hub.docker.com/_/foo', () => {
-    assert.deepEqual(dockerImage.resolve(path, ['foo:1.2.3']), [
+    expect(dockerImage.resolve(path, ['foo:1.2.3'])).toBe(
       'https://hub.docker.com/_/foo',
-    ]);
+    );
   });
 
   it('resolves foo:1.2.3-alpha to https://hub.docker.com/_/foo', () => {
-    assert.deepEqual(dockerImage.resolve(path, ['foo:1.2.3-alpha']), [
+    expect(dockerImage.resolve(path, ['foo:1.2.3-alpha'])).toBe(
       'https://hub.docker.com/_/foo',
-    ]);
+    );
   });
 
   it('resolves foo/bar to https://hub.docker.com/r/foo/bar', () => {
-    assert.deepEqual(dockerImage.resolve(path, ['foo/bar']), [
+    expect(dockerImage.resolve(path, ['foo/bar'])).toBe(
       'https://hub.docker.com/r/foo/bar',
-    ]);
+    );
   });
 
   it('resolves foo/bar:1.2.3 to https://hub.docker.com/r/foo/bar', () => {
-    assert.deepEqual(dockerImage.resolve(path, ['foo/bar:1.2.3']), [
+    expect(dockerImage.resolve(path, ['foo/bar:1.2.3'])).toBe(
       'https://hub.docker.com/r/foo/bar',
-    ]);
+    );
   });
 });

--- a/packages/plugin-docker/index.js
+++ b/packages/plugin-docker/index.js
@@ -11,7 +11,7 @@ export default {
       isOffical = false;
     }
 
-    return [`https://hub.docker.com/${isOffical ? '_' : 'r'}/${imageName}`];
+    return `https://hub.docker.com/${isOffical ? '_' : 'r'}/${imageName}`;
   },
 
   getPattern() {

--- a/packages/plugin-dot-net-core/__tests__/index.js
+++ b/packages/plugin-dot-net-core/__tests__/index.js
@@ -1,23 +1,21 @@
-import assert from 'assert';
 import dotNetCore from '../index';
 
 describe('dotNetCore', () => {
   const path = '/blob/path/dummy';
 
   it('resolves Microsoft.NETCore.App to https://www.nuget.org/packages/Microsoft.NETCore.App', () => {
-    assert.deepEqual(dotNetCore.resolve(path, ['Microsoft.NETCore.App']), [
+    expect(dotNetCore.resolve(path, ['Microsoft.NETCore.App'])).toBe(
       'https://www.nuget.org/packages/Microsoft.NETCore.App',
-    ]);
+    );
   });
 
   it('resolves Microsoft.Extensions.Configuration.FileExtensions to https://www.nuget.org/packages/Microsoft.Extensions.Configuration.FileExtensions', () => {
-    assert.deepEqual(
+    expect(
       dotNetCore.resolve(path, [
         'Microsoft.Extensions.Configuration.FileExtensions',
       ]),
-      [
-        'https://www.nuget.org/packages/Microsoft.Extensions.Configuration.FileExtensions',
-      ],
+    ).toBe(
+      'https://www.nuget.org/packages/Microsoft.Extensions.Configuration.FileExtensions',
     );
   });
 });

--- a/packages/plugin-dot-net/__tests__/index.js
+++ b/packages/plugin-dot-net/__tests__/index.js
@@ -1,18 +1,17 @@
-import assert from 'assert';
 import dotNet from '../index';
 
 describe('dotNet', () => {
   const path = '/blob/path/dummy';
 
   it('resolves EntityFramework to https://www.nuget.org/packages/EntityFramework', () => {
-    assert.deepEqual(dotNet.resolve(path, ['EntityFramework']), [
+    expect(dotNet.resolve(path, ['EntityFramework'])).toBe(
       'https://www.nuget.org/packages/EntityFramework',
-    ]);
+    );
   });
 
   it('resolves Stanford.NLP.CoreNLP to https://www.nuget.org/packages/Stanford.NLP.CoreNLP', () => {
-    assert.deepEqual(dotNet.resolve(path, ['Stanford.NLP.CoreNLP']), [
+    expect(dotNet.resolve(path, ['Stanford.NLP.CoreNLP'])).toBe(
       'https://www.nuget.org/packages/Stanford.NLP.CoreNLP',
-    ]);
+    );
   });
 });

--- a/packages/plugin-html/index.js
+++ b/packages/plugin-html/index.js
@@ -8,7 +8,7 @@ export default {
   name: 'HTML',
 
   resolve(path, [target]) {
-    return [relativeFile({ path, target })];
+    return relativeFile({ path, target });
   },
 
   getPattern() {

--- a/packages/plugin-java/__tests__/index.js
+++ b/packages/plugin-java/__tests__/index.js
@@ -16,9 +16,8 @@ describe('Java', () => {
   });
 
   it('resolves community packages', () => {
-    assert.deepEqual(Java.resolve(path, ['com.company.app']), {
-      url: 'https://githublinker.herokuapp.com/q/java/com.company.app',
-      method: 'GET',
-    });
+    expect(Java.resolve(path, ['com.company.app'])).toBe(
+      'https://githublinker.herokuapp.com/q/java/com.company.app',
+    );
   });
 });

--- a/packages/plugin-javascript/__tests__/index.js
+++ b/packages/plugin-javascript/__tests__/index.js
@@ -12,11 +12,8 @@ describe('javascript-universal', () => {
 
   it("resolves '@angular/core/bar.js' to '@angular/core'", () => {
     const type = 'npm';
-    expect(plugin.resolve(path, ['@angular/core/bar.js'], { type })[0]).toEqual(
-      {
-        url: 'https://githublinker.herokuapp.com/q/npm/@angular/core',
-        method: 'GET',
-      },
+    expect(plugin.resolve(path, ['@angular/core/bar.js'], { type })[0]).toBe(
+      'https://githublinker.herokuapp.com/q/npm/@angular/core',
     );
   });
 

--- a/packages/plugin-requirements-txt/index.js
+++ b/packages/plugin-requirements-txt/index.js
@@ -5,12 +5,10 @@ export default {
   name: 'RequirementsTxt',
 
   resolve(path, [target]) {
-    return [
-      liveResolverQuery({
-        target,
-        type: 'pypi',
-      }),
-    ];
+    return liveResolverQuery({
+      target,
+      type: 'pypi',
+    });
   },
 
   getPattern() {

--- a/packages/plugin-ruby/index.js
+++ b/packages/plugin-ruby/index.js
@@ -16,7 +16,7 @@ export default {
       return `{BASE_URL}${join(basePath, `${target}.rb`)}`;
     }
 
-    return [liveResolverQuery({ type: 'rubygems', target })];
+    return liveResolverQuery({ type: 'rubygems', target });
   },
 
   getPattern() {

--- a/packages/plugin-rust/__tests__/index.js
+++ b/packages/plugin-rust/__tests__/index.js
@@ -1,13 +1,11 @@
-import assert from 'assert';
 import rustCrate from '../index';
 
 describe('rust-crate', () => {
   const path = '/blob/path/dummy';
 
   it('resolves hamcrest using the live-resolver', () => {
-    assert.deepEqual(rustCrate.resolve(path, ['hamcrest']), {
-      url: 'https://githublinker.herokuapp.com/q/crates/hamcrest',
-      method: 'GET',
-    });
+    expect(rustCrate.resolve(path, ['hamcrest'])).toBe(
+      'https://githublinker.herokuapp.com/q/crates/hamcrest',
+    );
   });
 });

--- a/packages/resolver-live-query/index.js
+++ b/packages/resolver-live-query/index.js
@@ -1,6 +1,3 @@
 export default function({ type, target }) {
-  return {
-    url: `https://githublinker.herokuapp.com/q/${type}/${target}`,
-    method: 'GET',
-  };
+  return `https://githublinker.herokuapp.com/q/${type}/${target}`;
 }

--- a/packages/resolver-nuget/index.js
+++ b/packages/resolver-nuget/index.js
@@ -1,3 +1,3 @@
 export default function({ target }) {
-  return [`https://www.nuget.org/packages/${target}`];
+  return `https://www.nuget.org/packages/${target}`;
 }


### PR DESCRIPTION
A resolver can return either a string, an array of strings, an object or a function. This is quite confusing. This PR aims to  simplify this. Apart from the `github-search` resolver all other resolvers are returning either a string or an array of strings. 
