### PR TITLE
go: add k8s.io support

### DIFF
--- a/packages/helper-grammar-regex-collection/go.js
+++ b/packages/helper-grammar-regex-collection/go.js
@@ -9,6 +9,7 @@ const ALLOWED_DOMAINS = [
   'hub.jazz.net',
   'gopkg.in',
   'golang.org',
+  'k8s.io',
 ];
 
 function multiImportRegExpBuilder(input) {

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -378,6 +378,10 @@ const fixtures = {
         'import (\n"golang.org/x/net/context"\n"golang.org/pkg/net"\n)',
         ['golang.org/x/net/context', 'golang.org/pkg/net'],
       ],
+      [
+        'import (\n"k8s.io/client-go/kubernetes"\n)',
+        ['k8s.io/client-go/kubernetes'],
+      ],
     ],
     invalid: [
       'simport foo',

--- a/packages/plugin-go/__tests__/index.js
+++ b/packages/plugin-go/__tests__/index.js
@@ -33,4 +33,12 @@ describe('go-universal', () => {
       '{BASE_URL}/foo/bar',
     ]);
   });
+
+  it('resolves k8s.io links', () => {
+    assert.deepEqual(goUniversal.resolve(path, ['k8s.io/foo/bar']), [
+      '{BASE_URL}/kubernetes/foo/blob/master/bar/bar.go',
+      '{BASE_URL}/kubernetes/foo/tree/master/bar',
+      '{BASE_URL}/kubernetes/foo',
+    ]);
+  });
 });

--- a/packages/plugin-go/index.js
+++ b/packages/plugin-go/index.js
@@ -33,6 +33,11 @@ function githubUrls(url) {
   ];
 }
 
+function kubernetesUrls(url) {
+  const newUrl = url.replace('k8s.io', 'github.com/kubernetes');
+  return githubUrls(newUrl);
+}
+
 export default {
   name: 'Go',
 
@@ -45,6 +50,10 @@ export default {
 
     if (target.startsWith('github.com')) {
       return githubUrls(target);
+    }
+
+    if (target.startsWith('k8s.io')) {
+      return kubernetesUrls(target);
     }
 
     return [`https://${target}`, `https://golang.org/pkg/${target}`];


### PR DESCRIPTION
This adds support for go imports that use k8s.io.

https://github.com/kubernetes/ingress-gce/blob/master/cmd/glbc/main.go can be used to see the before/after changes

Thanks for an awesome extension!