### PR TITLE
Add helper-array-reorder

### DIFF
--- a/packages/helper-array-reorder/README.md
+++ b/packages/helper-array-reorder/README.md
@@ -1,0 +1,15 @@
+# @octolinker/helper-array-reorder 
+
+This array helper sorts an array by passing another array which define the new order by the array index of the items you want to sort and retains all unmatched array indexes.
+
+
+```js
+// Push Fri the to beginning, because the sort array starts with the array index of 4 which is Fri
+sortResolveUrls(['Mo', 'Tue', 'Wed', 'Thu', 'Fri'], [4]); // ['Fri', 'Mo', 'Tue', 'Wed', 'Thu']
+
+// Push Fri the to beginning followed by Tue
+sortResolveUrls(['Mo', 'Tue', 'Wed', 'Thu', 'Fri'], [4, 1]); // ['Fri', 'Tue', 'Mo', 'Wed', 'Thu']
+
+// Let's revers all weekdays 
+sortResolveUrls(['Mo', 'Tue', 'Wed', 'Thu', 'Fri'], [4, 3, 2, 1, 0]); // ['Fri', 'Thu', 'Wed', 'Tue', 'Mo']
+```

--- a/packages/helper-array-reorder/__tests__/index.js
+++ b/packages/helper-array-reorder/__tests__/index.js
@@ -1,0 +1,28 @@
+import sortResolveUrls from '../index';
+
+describe('reorder-helper', () => {
+  it('keeps the order when reordering list is empty', () => {
+    expect(sortResolveUrls(['a', 'b', 'c'], [])).toEqual(['a', 'b', 'c']);
+  });
+  it('keeps the order when reordering list contains invalid array index', () => {
+    expect(sortResolveUrls(['a', 'b', 'c'], [4])).toEqual(['a', 'b', 'c']);
+  });
+  it('pushes b to the beginning', () => {
+    expect(sortResolveUrls(['a', 'b', 'c'], [1])).toEqual(['b', 'a', 'c']);
+  });
+
+  it('pushes c to the beginning', () => {
+    expect(sortResolveUrls(['a', 'b', 'c'], [2])).toEqual(['c', 'a', 'b']);
+  });
+
+  it('pushes c followed by b to the beginning', () => {
+    expect(sortResolveUrls(['a', 'b', 'c'], [2, 1])).toEqual(['c', 'b', 'a']);
+  });
+  it('reorders the list according to their reordering index', () => {
+    expect(sortResolveUrls(['a', 'b', 'c'], [2, 1, 0])).toEqual([
+      'c',
+      'b',
+      'a',
+    ]);
+  });
+});

--- a/packages/helper-array-reorder/index.js
+++ b/packages/helper-array-reorder/index.js
@@ -1,0 +1,24 @@
+import _ from 'lodash'; // eslint-disable-line id-length
+
+function sortByHighestScore(arr) {
+  return _.chain(arr)
+    .countBy()
+    .entries()
+    .sort((left, right) => left[1] > right[1])
+    .map(([index]) => index)
+    .value();
+}
+
+export default function(urls, orderBy) {
+  const score = sortByHighestScore(orderBy);
+
+  return urls.reduce((memo, item, index) => {
+    if (score.includes(index.toString())) {
+      memo.splice(0, 0, item);
+    } else {
+      memo.push(item);
+    }
+
+    return memo;
+  }, []);
+}

--- a/packages/helper-array-reorder/package.json
+++ b/packages/helper-array-reorder/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@octolinker/helper-array-reorder",
+  "version": "1.0.0",
+  "description": "",
+  "repository": "https://github.com/octolinker/octolinker/tree/master/packages/helper-array-reorder",
+  "license": "MIT",
+  "main": "./index.js",
+  "dependencies": {
+    "lodash": "^4.17.10"
+  }
+}


### PR DESCRIPTION
That's a tough one and looks weird, but trust me it makes sense. 

Since a few moths already I'm doing little refactoring here and there downwards to solve #277. This helper package is not in use yet, but in order to make PRs easier to review I'll break down all the work that I did in https://github.com/stefanbuck/OctoLinker/tree/277-real-links into small chunks. 

Back to the this PullRequest. As the readme says, it's about reordering an array based on the indexes defined in another array. I think it's best to take a look at the example or tests. 

### Why do we need this?

When we resolve all url after page load, we have to do many requests in order to figure the locations for relative files. I described the reasons for this in this comment https://github.com/OctoLinker/OctoLinker/issues/277#issuecomment-301438244 

However, this adds some kind learning algorithm while resoling urls. Whenever a possible url performs a successful HTTP HEAD request we increase that array index and store the count in another array.

Given we have an import like `require('./lib/loader');`. The possible urls array for this looks like this:

```js
[
  './lib/loader.js'        // does not match
  './lib/loader/index.js'  // does not match
  './lib/loader.ts'        // does not match
  './lib/loader/index.ts'  // Match
]
```

This will push 3 into an array and before we run the next resolver this array will be sorted again which reduces the request for some cases a lot. 

```js
[
  './lib/loader/index.ts'   
  './lib/loader.js'       
  './lib/loader/index.js' 
  './lib/loader.ts' 
]
```

This assumes that a import style within an repo is consistent and the majority wins the race.

 
