### PR TITLE
Add support for k8s.io

### DIFF
--- a/packages/helper-grammar-regex-collection/go.js
+++ b/packages/helper-grammar-regex-collection/go.js
@@ -9,6 +9,7 @@ const ALLOWED_DOMAINS = [
   'hub.jazz.net',
   'gopkg.in',
   'golang.org',
+  'k8s.io',
 ];
 
 function multiImportRegExpBuilder(input) {

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -354,6 +354,7 @@ const fixtures = {
       ['import "launchpad.net/foo/bar"', ['launchpad.net/foo/bar']],
       ['import "hub.jazz.net/foo/bar"', ['hub.jazz.net/foo/bar']],
       ['import "gopkg.in/foo/bar"', ['gopkg.in/foo/bar']],
+      ['import "k8s.io/foo/bar"', ['k8s.io/foo/bar']],
       ['import (\n"foo"\n)', ['foo']],
       ['import (\n_ "foo"\n)', ['foo']],
       ['import (\n. "foo"\n)', ['foo']],

--- a/packages/plugin-go/__tests__/index.js
+++ b/packages/plugin-go/__tests__/index.js
@@ -1,11 +1,11 @@
-import assert from 'assert';
+import liveResolverQuery from '@octolinker/resolver-live-query';
 import goUniversal from '../index';
 
 describe('go-universal', () => {
   const path = 'octo/dog.go';
 
   it('resolves local file', () => {
-    assert.deepEqual(goUniversal.resolve(path, ['../foo']), [
+    expect(goUniversal.resolve(path, ['../foo'])).toEqual([
       '{BASE_URL}foo/foo.go',
       '{BASE_URL}foo.go',
       '{BASE_URL}foo',
@@ -13,21 +13,22 @@ describe('go-universal', () => {
   });
 
   it('resolves package', () => {
-    assert.deepEqual(goUniversal.resolve(path, ['foo']), [
+    expect(goUniversal.resolve(path, ['foo'])).toEqual([
       'https://foo',
       'https://golang.org/pkg/foo',
+      liveResolverQuery({ type: 'go', target: 'foo' }),
     ]);
   });
 
   it('resolves github shorthand', () => {
-    assert.deepEqual(goUniversal.resolve(path, ['github.com/foo/bar']), [
+    expect(goUniversal.resolve(path, ['github.com/foo/bar'])).toEqual([
       '{BASE_URL}/foo/bar/blob/master/bar.go',
       '{BASE_URL}/foo/bar',
     ]);
   });
 
   it('resolves github deep link', () => {
-    assert.deepEqual(goUniversal.resolve(path, ['github.com/foo/bar/baze']), [
+    expect(goUniversal.resolve(path, ['github.com/foo/bar/baze'])).toEqual([
       '{BASE_URL}/foo/bar/blob/master/baze/baze.go',
       '{BASE_URL}/foo/bar/tree/master/baze',
       '{BASE_URL}/foo/bar',

--- a/packages/plugin-go/index.js
+++ b/packages/plugin-go/index.js
@@ -1,5 +1,6 @@
 import { join, dirname } from 'path';
 import { go } from '@octolinker/helper-grammar-regex-collection';
+import liveResolverQuery from '@octolinker/resolver-live-query';
 
 function goFile({ path, target }) {
   const list = [];
@@ -47,7 +48,11 @@ export default {
       return githubUrls(target);
     }
 
-    return [`https://${target}`, `https://golang.org/pkg/${target}`];
+    return [
+      `https://${target}`,
+      `https://golang.org/pkg/${target}`,
+      liveResolverQuery({ type: 'go', target }),
+    ];
   },
 
   getPattern() {

--- a/packages/plugin-go/package.json
+++ b/packages/plugin-go/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "./index.js",
   "dependencies": {
-    "@octolinker/helper-grammar-regex-collection": "1.0.0"
+    "@octolinker/helper-grammar-regex-collection": "1.0.0",
+    "@octolinker/resolver-live-query": "1.0.0"
   }
 }


### PR DESCRIPTION
Replacement for #478 to add support for kubernetes imports. 

Test url: https://github.com/kubernetes/ingress-gce/blob/6f8bdc9fad1b5576d4fe07900301a133652a8892/cmd/glbc/main.go#L31