### PR TITLE
Do not create source maps for production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "package": "yarn build && web-ext build --source-dir dist --artifacts-dir out --overwrite-dest",
     "release": "webstore upload --source dist --auto-publish",
     "build": "webpack --mode=production",
-    "watch": "webpack --watch",
+    "watch": "webpack --watch --mode=development",
     "chrome-open": "yarn build && yarn chrome-launch --",
     "chrome-launch": "node scripts/chrome-launch.js",
     "firefox-open": "yarn build && yarn firefox-launch --",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,14 @@
 const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin'); // eslint-disable-line
 
-module.exports = {
+module.exports = (env, argv) => ({
   mode: 'development',
   entry: {
     app: './packages/core/app',
     background: './packages/core/background/index',
     options: './packages/helper-settings/page',
   },
-  devtool: 'source-map',
+  devtool: argv.mode === 'development' ? 'source-map' : '',
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: '[name].js',
@@ -27,4 +27,4 @@ module.exports = {
       },
     ],
   },
-};
+});


### PR DESCRIPTION
Yesterday, I noticed that our production build is quite big. Just our `app.js.map` has already 1.5 MB. I think we don't need to ship source maps and therefore I disabled source maps for the production build.