### PR TITLE
Link npm dependecies in Pull Request

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 dist/
 packages/**/node_modules
 e2e/fixtures/
+coverage/

--- a/_jestsetup.js
+++ b/_jestsetup.js
@@ -1,7 +1,10 @@
 import fs from 'fs';
 import path from 'path';
+import fetchMock from 'jest-fetch-mock';
 
 jest.mock('path');
+
+global.fetch = fetchMock;
 
 global.chrome = {};
 global.chrome.runtime = {

--- a/e2e/automated.test.js
+++ b/e2e/automated.test.js
@@ -1,8 +1,7 @@
 const fixtures = require('./fixtures.json'); // eslint-disable-line import/no-unresolved
+const diffFixtures = require('./diff-fixtures.json'); // eslint-disable-line import/no-unresolved
 
-async function executeTest(url, lineNumber, targetUrl) {
-  const selector = `#LC${lineNumber} .octolinker-link`;
-
+async function executeTest(url, targetUrl, selector) {
   await page.goto(url);
 
   await page.waitForSelector(selector);
@@ -17,9 +16,27 @@ async function executeTest(url, lineNumber, targetUrl) {
 }
 
 describe('End to End tests', () => {
-  fixtures.forEach(({ url, content, lineNumber, targetUrl }) => {
-    it(`resolves ${content} to ${targetUrl}`, async () => {
-      await executeTest(url, lineNumber, targetUrl);
+  describe('single blob', () => {
+    fixtures.forEach(({ url, content, lineNumber, targetUrl }) => {
+      it(`resolves ${content} to ${targetUrl}`, async () => {
+        await executeTest(url, targetUrl, `#LC${lineNumber} .octolinker-link`);
+      });
+    });
+  });
+
+  describe('diff view', () => {
+    diffFixtures.forEach(({ url, targetUrl }) => {
+      it(
+        `resolves ${url} to ${targetUrl}`,
+        async () => {
+          await executeTest(
+            url,
+            targetUrl,
+            '.selected-line.blob-code .octolinker-link',
+          );
+        },
+        10000,
+      );
     });
   });
 });

--- a/e2e/diff-fixtures.json
+++ b/e2e/diff-fixtures.json
@@ -1,0 +1,10 @@
+[
+  {
+    "url": "https://github.com/OctoLinker/OctoLinker/commit/b97dfbfdbf3dee5f4836426e6dac6d6f473461db?diff=split#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R24",
+    "targetUrl": "https://github.com/eslint/eslint"
+  },
+  {
+    "url": "https://github.com/OctoLinker/OctoLinker/commit/b97dfbfdbf3dee5f4836426e6dac6d6f473461db?diff=split#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L23",
+    "targetUrl": "https://github.com/eslint/eslint"
+  }
+]

--- a/e2e/generate-fixtures-json.js
+++ b/e2e/generate-fixtures-json.js
@@ -67,8 +67,6 @@ function findTests(contents) {
   const contents = await readContent(files);
   const out = findTests(contents);
 
-  console.log(out); // eslint-disable-line
-
   fs.writeFileSync(
     path.join(__dirname, 'fixtures.json'),
     JSON.stringify(out, null, ' '),

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   moduleNameMapper: {
     '\\.css$': '<rootDir>/__mocks__/styleMock.js',
   },
+  testURL: 'http://localhost/',
   coverageDirectory: './coverage/',
   collectCoverage: true,
 };

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-prettier": "^2.3.1",
     "eslint-plugin-react": "^7.4.0",
     "jest": "^22.0.6",
+    "jest-fetch-mock": "^1.6.5",
     "jest-puppeteer": "^3.2.1",
     "json": "^9.0.4",
     "json-loader": "^0.5.7",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-prettier": "^2.3.1",
     "eslint-plugin-react": "^7.4.0",
-    "jest": "^22.0.6",
+    "jest": "^23.4.2",
     "jest-fetch-mock": "^1.6.5",
     "jest-puppeteer": "^3.2.1",
     "json": "^9.0.4",

--- a/packages/blob-reader/__snapshots__/test.js.snap
+++ b/packages/blob-reader/__snapshots__/test.js.snap
@@ -28,6 +28,27 @@ Object {
 }
 `;
 
+exports[`blob-reader blob fetchBlob fetch raw blob and update blob.lines property 1`] = `
+Array [
+  Object {
+    "lineNumber": 1,
+    "value": "// Most popular rabbit names",
+  },
+  Object {
+    "lineNumber": 2,
+    "value": "",
+  },
+  Object {
+    "lineNumber": 3,
+    "value": "Thumper",
+  },
+  Object {
+    "lineNumber": 4,
+    "value": "Daisy",
+  },
+]
+`;
+
 exports[`blob-reader diff split 1st line 1`] = `
 Object {
   "lineNumber": 1,

--- a/packages/blob-reader/__snapshots__/test.js.snap
+++ b/packages/blob-reader/__snapshots__/test.js.snap
@@ -49,6 +49,31 @@ Array [
 ]
 `;
 
+exports[`blob-reader diff fetchParentBlob fetch raw blob and update blob.lines property 1`] = `
+Array [
+  Object {
+    "lineNumber": 1,
+    "value": "// Most popular rabbit names",
+  },
+  Object {
+    "lineNumber": 2,
+    "value": "",
+  },
+  Object {
+    "lineNumber": 3,
+    "value": "Thumper",
+  },
+  Object {
+    "lineNumber": 4,
+    "value": "Daisy",
+  },
+  Object {
+    "lineNumber": 5,
+    "value": "Lily",
+  },
+]
+`;
+
 exports[`blob-reader diff split 1st line 1`] = `
 Object {
   "lineNumber": 1,

--- a/packages/blob-reader/blob.js
+++ b/packages/blob-reader/blob.js
@@ -1,4 +1,16 @@
-import { getPath, readLines } from './helper';
+import ghParse from 'github-url-parse';
+import { getPath, readLines, getParentSha } from './helper';
+
+async function fetchRaw({ user, repo, branch, path }) {
+  const response = await fetch(
+    `https://raw.githubusercontent.com/${user}/${repo}/${branch}/${path}`,
+  );
+
+  const raw = await response.text();
+  return raw
+    .split('\n')
+    .map((value, lineNumber) => ({ value, lineNumber: lineNumber + 1 }));
+}
 
 export default class Blob {
   constructor(el) {
@@ -19,5 +31,12 @@ export default class Blob {
     } catch (err) {
       return {};
     }
+  }
+
+  async fetchBlob() {
+    const { user, repo, branch, path } = ghParse(
+      `https://github.com${this.path}`,
+    );
+    this.lines = await fetchRaw({ user, repo, branch, path });
   }
 }

--- a/packages/blob-reader/blob.js
+++ b/packages/blob-reader/blob.js
@@ -5,6 +5,8 @@ export default class Blob {
     this.el = el;
     this.path = getPath(el);
     this.lines = readLines(el);
+    this.isDiff =
+      this.lines.filter(line => line.addition || line.deletion).length > 0;
   }
 
   toString() {

--- a/packages/blob-reader/blob.js
+++ b/packages/blob-reader/blob.js
@@ -39,4 +39,12 @@ export default class Blob {
     );
     this.lines = await fetchRaw({ user, repo, branch, path });
   }
+
+  async fetchParentBlob() {
+    const { user, repo, path } = ghParse(`https://github.com${this.path}`);
+    const branch = getParentSha();
+
+    this.parent = new Blob(this.el);
+    this.parent.lines = await fetchRaw({ user, repo, branch, path });
+  }
 }

--- a/packages/blob-reader/helper.js
+++ b/packages/blob-reader/helper.js
@@ -27,6 +27,11 @@ function isGist() {
   return !!document.querySelector('#gist-pjax-container');
 }
 
+function getParentSha() {
+  const el = document.querySelector('.sha-block .sha[data-hotkey]');
+  return el ? el.textContent : null;
+}
+
 function getPath(el) {
   // When current page is a diff view get path from "View" button
   let ret = $('.file-actions a', el.parentElement.parentElement)
@@ -153,4 +158,4 @@ function readLines(el) {
     .filter(line => !!line);
 }
 
-export { getPath, getBlobWrapper, readLines };
+export { getPath, getBlobWrapper, readLines, getParentSha };

--- a/packages/blob-reader/index.js
+++ b/packages/blob-reader/index.js
@@ -12,7 +12,7 @@ export default class BlobReader {
     return this;
   }
 
-  forEach(fn) {
-    this._blobs.forEach(fn);
+  getBlobs() {
+    return this._blobs;
   }
 }

--- a/packages/blob-reader/package.json
+++ b/packages/blob-reader/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "./index.js",
   "dependencies": {
+    "github-url-parse": "^0.1.0",
     "jquery": "^3.2.1"
   }
 }

--- a/packages/blob-reader/test.js
+++ b/packages/blob-reader/test.js
@@ -13,7 +13,7 @@ describe('blob-reader', () => {
         '/packages/blob-reader/fixtures/github.com/blob/89f13651df126efdb4f1e3ae40183c9fdccdb4d3.html',
       );
       const reader = new BlobReader();
-      [blob] = reader.read()._blobs;
+      [blob] = reader.read().getBlobs();
     });
 
     describe('contains blob path', () => {
@@ -29,7 +29,7 @@ describe('blob-reader', () => {
         );
         const reader = new BlobReader();
 
-        expect(reader.read()._blobs[0].path).toBe(
+        expect(reader.read().getBlobs()[0].path).toBe(
           '/OctoLinker/testrepo/blob/9981d1a99ef8fff1f569c2ae24b136d5a0275132/sourcereader/popular-cat-names.js',
         );
       });
@@ -40,7 +40,7 @@ describe('blob-reader', () => {
         );
         const reader = new BlobReader();
 
-        expect(reader.read()._blobs[0].path).toBe(
+        expect(reader.read().getBlobs()[0].path).toBe(
           '/OctoLinker/testrepo/blob/64dc9c25b3e09d1d9af437e09d968d08ad5ec903/sourcereader/popular-cat-names.js',
         );
       });
@@ -51,7 +51,7 @@ describe('blob-reader', () => {
         );
         const reader = new BlobReader();
 
-        expect(reader.read()._blobs[1].path).toBe(
+        expect(reader.read().getBlobs()[1].path).toBe(
           '/OctoLinker/testrepo/blob/cc14b0ce8b94b7044f8c5d2d7af656270330bca2/sourcereader/popular-rabbit-names.js',
         );
       });
@@ -98,7 +98,7 @@ describe('blob-reader', () => {
         '/packages/blob-reader/fixtures/github.com/blob/89f13651df126efdb4f1e3ae40183c9fdccdb4d3.html',
       );
       const reader = new BlobReader();
-      [blob] = reader.read()._blobs;
+      [blob] = reader.read().getBlobs();
     });
 
     it('contains four lines', () => {
@@ -146,7 +146,7 @@ describe('blob-reader', () => {
       });
 
       it('sets isDiff indicator to true', () => {
-        expect(result.isDiff).to(true);
+        expect(blob.isDiff).toBe(true);
       });
 
       it('1st line', () => {
@@ -170,11 +170,11 @@ describe('blob-reader', () => {
           '/packages/blob-reader/fixtures/github.com/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb_unified.html',
         );
         const reader = new BlobReader();
-        [blob] = reader.read()._blobs;
+        [blob] = reader.read().getBlobs();
       });
 
       it('sets isDiff indicator to true', () => {
-        expect(result.isDiff).toBe(true);
+        expect(blob.isDiff).toBe(true);
       });
 
       it('contains four lines', () => {
@@ -203,7 +203,7 @@ describe('blob-reader', () => {
         '/packages/blob-reader/fixtures/github.com/gist/113827963013e98c6196db51cd889c39.html',
       );
       const reader = new BlobReader();
-      [blob] = reader.read()._blobs;
+      [blob] = reader.read().getBlobs();
     });
 
     it('contains blob path', () => {
@@ -217,7 +217,7 @@ describe('blob-reader', () => {
     beforeEach(() => {
       fixture.load('/packages/blob-reader/fixtures/github.com/issue/code.html');
       const reader = new BlobReader();
-      [blob] = reader.read()._blobs;
+      [blob] = reader.read().getBlobs();
     });
 
     it('contains blob root element', () => {

--- a/packages/blob-reader/test.js
+++ b/packages/blob-reader/test.js
@@ -3,6 +3,7 @@ import BlobReader from './index.js';
 describe('blob-reader', () => {
   afterEach(() => {
     fixture.cleanup();
+    fetch.resetMocks();
   });
 
   describe('returned values object', () => {
@@ -130,6 +131,19 @@ describe('blob-reader', () => {
 
     it('4th line', () => {
       expect(blob.lines[3]).toMatchSnapshot();
+    });
+
+    describe('fetchBlob', () => {
+      it('fetch raw blob and update blob.lines property', async () => {
+        fetch.mockResponse(`// Most popular rabbit names\n\nThumper\nDaisy`);
+
+        await blob.fetchBlob();
+        expect(fetch.mock.calls[0][0]).toBe(
+          'https://raw.githubusercontent.com/OctoLinker/testrepo/89f13651df126efdb4f1e3ae40183c9fdccdb4d3/sourcereader/popular-rabbit-names.js',
+        );
+
+        expect(blob.lines).toMatchSnapshot();
+      });
     });
   });
 

--- a/packages/blob-reader/test.js
+++ b/packages/blob-reader/test.js
@@ -1,4 +1,5 @@
 import BlobReader from './index.js';
+import Blob from './blob.js';
 
 describe('blob-reader', () => {
   afterEach(() => {
@@ -205,6 +206,32 @@ describe('blob-reader', () => {
 
       it('deletions', () => {
         expect(blob.lines[5]).toMatchSnapshot();
+      });
+    });
+
+    describe('fetchParentBlob', () => {
+      let blob;
+
+      beforeEach(() => {
+        fixture.load(
+          '/packages/blob-reader/fixtures/github.com/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb_unified.html',
+        );
+        const reader = new BlobReader();
+        [blob] = reader.read().getBlobs();
+      });
+
+      it('fetch raw blob and update blob.lines property', async () => {
+        fetch.mockResponse(
+          `// Most popular rabbit names\n\nThumper\nDaisy\nLily`,
+        );
+
+        await blob.fetchParentBlob();
+
+        expect(fetch.mock.calls[0][0]).toBe(
+          'https://raw.githubusercontent.com/OctoLinker/testrepo/37d5cdd/sourcereader/popular-rabbit-names.js',
+        );
+        expect(blob.parent).toBeInstanceOf(Blob);
+        expect(blob.parent.lines).toMatchSnapshot();
       });
     });
   });

--- a/packages/blob-reader/test.js
+++ b/packages/blob-reader/test.js
@@ -113,7 +113,7 @@ describe('blob-reader', () => {
     });
 
     it('sets isDiff indicator to false', () => {
-      expect(blob.isDiff).toBeFalsy();
+      expect(blob.isDiff).toBe(false);
     });
 
     it('1st line', () => {
@@ -145,6 +145,10 @@ describe('blob-reader', () => {
         [blob] = reader.read()._blobs;
       });
 
+      it('sets isDiff indicator to true', () => {
+        expect(result.isDiff).to(true);
+      });
+
       it('1st line', () => {
         expect(blob.lines[0]).toMatchSnapshot();
       });
@@ -167,6 +171,10 @@ describe('blob-reader', () => {
         );
         const reader = new BlobReader();
         [blob] = reader.read()._blobs;
+      });
+
+      it('sets isDiff indicator to true', () => {
+        expect(result.isDiff).toBe(true);
       });
 
       it('contains four lines', () => {

--- a/packages/core/octo-linker.js
+++ b/packages/core/octo-linker.js
@@ -25,23 +25,21 @@ function run(self) {
   self._blobReader.read();
 
   let matches = [];
-  self._blobReader.forEach(blob => {
+  for (const blob of self._blobReader.getBlobs()) {
     const plugins = self._pluginManager.get(blob.path, blob.el.classList);
 
-    if (!plugins.length) {
-      return;
-    }
-
-    plugins.forEach(plugin => {
-      if (plugin.parseBlob) {
-        matches = matches.concat(plugin.parseBlob(blob));
-      } else if (plugin.getLinkRegexes) {
-        [].concat(plugin.getLinkRegexes(blob)).forEach(regex => {
-          matches = matches.concat(insertLink(blob, regex, plugin));
-        });
+    if (plugins.length) {
+      for (const plugin of plugins) {
+        if (plugin.parseBlob) {
+          matches = matches.concat(plugin.parseBlob(blob));
+        } else if (plugin.getLinkRegexes) {
+          for (const regex of [].concat(plugin.getLinkRegexes(blob))) {
+            matches = matches.concat(insertLink(blob, regex, plugin));
+          }
+        }
       }
-    });
-  });
+    }
+  }
 
   matches = matches
     .filter(result => result !== undefined)

--- a/packages/core/octo-linker.js
+++ b/packages/core/octo-linker.js
@@ -17,7 +17,7 @@ function initialize(self) {
   self._pluginManager = new Plugins(loadPlugins);
 }
 
-function run(self) {
+async function run(self) {
   if (!self._blobReader.hasBlobs()) {
     return false;
   }
@@ -30,6 +30,11 @@ function run(self) {
 
     if (plugins.length) {
       for (const plugin of plugins) {
+        if (plugin.needsContext && blob.isDiff) {
+          await blob.fetchBlob(); // eslint-disable-line no-await-in-loop
+          await blob.fetchParentBlob(); // eslint-disable-line no-await-in-loop
+        }
+
         if (plugin.parseBlob) {
           matches = matches.concat(plugin.parseBlob(blob));
         } else if (plugin.getLinkRegexes) {

--- a/packages/helper-process-json/__tests__/index.js
+++ b/packages/helper-process-json/__tests__/index.js
@@ -1,0 +1,87 @@
+import helperProcessJson from '../index';
+
+describe('helper-process-json', () => {
+  let plugin;
+  let blob;
+  let config;
+  let json;
+
+  beforeEach(() => {
+    plugin = jest.fn();
+    json = {
+      dependencies: 'foo',
+    };
+    blob = {
+      toJSON: jest.fn().mockReturnValue(json),
+    };
+    config = {
+      '$.dependencies': jest.fn().mockReturnValue('callbackValue'),
+      '$.noMatch': jest.fn(),
+    };
+  });
+
+  it('does not call callback when xPath does not match', () => {
+    helperProcessJson(blob, plugin, config);
+    expect(config['$.noMatch']).not.toBeCalled();
+  });
+
+  it('calls callback when xPath match', () => {
+    const result = helperProcessJson(blob, plugin, config);
+    expect(config['$.dependencies']).toBeCalledWith(
+      blob,
+      'dependencies',
+      'foo',
+    );
+
+    expect(result).toEqual(['callbackValue']);
+  });
+
+  it('calls callback on nested json object', () => {
+    json = {
+      devDependencies: {
+        foo: 'bar',
+        baz: 'qux',
+      },
+    };
+    config = {
+      '$.devDependencies': jest.fn(),
+    };
+    blob = {
+      toJSON: jest.fn().mockReturnValue(json),
+    };
+
+    helperProcessJson(blob, plugin, config);
+    expect(config['$.devDependencies']).toHaveBeenNthCalledWith(
+      1,
+      blob,
+      'foo',
+      'bar',
+    );
+    expect(config['$.devDependencies']).toHaveBeenNthCalledWith(
+      2,
+      blob,
+      'baz',
+      'qux',
+    );
+  });
+
+  it('runs xPath on parent blob and the actual blob and returns both results', () => {
+    const parentJson = {
+      dependencies: 'bar',
+    };
+    const parentBlob = {
+      toJSON: jest.fn().mockReturnValue(parentJson),
+    };
+    blob.parent = parentBlob;
+
+    const result = helperProcessJson(blob, plugin, config);
+    expect(config['$.dependencies']).toHaveBeenNthCalledWith(
+      2,
+      parentBlob,
+      'dependencies',
+      'bar',
+    );
+
+    expect(result).toEqual(['callbackValue', 'callbackValue']);
+  });
+});

--- a/packages/helper-process-json/index.js
+++ b/packages/helper-process-json/index.js
@@ -1,10 +1,8 @@
 import jsonPath from 'JSONPath';
 
-export default function(blob, plugin, config) {
-  const json = blob.toJSON();
-
+function callInsertLink(blob, plugin, config) {
   let results = [];
-
+  const json = blob.toJSON();
   Object.entries(config).forEach(([path, linker]) => {
     jsonPath({ json, path, resultType: 'all' }).forEach(result => {
       if (typeof result.value === 'string') {
@@ -19,6 +17,16 @@ export default function(blob, plugin, config) {
       }
     });
   });
+
+  return results;
+}
+
+export default function(blob, plugin, config) {
+  let results = callInsertLink(blob, plugin, config);
+
+  if (blob.parent) {
+    results = results.concat(callInsertLink(blob.parent, plugin, config));
+  }
 
   return results;
 }

--- a/packages/helper-regex-builder/__tests__/index.js
+++ b/packages/helper-regex-builder/__tests__/index.js
@@ -1,0 +1,19 @@
+import { jsonRegExValue, jsonRegExKeyValue } from '../index';
+
+describe('helper-regex-builder', () => {
+  it('jsonRegExValue', () => {
+    expect(jsonRegExValue('foo', 'bar')).toEqual(/"foo"\s*:\s*("bar")/);
+    expect(jsonRegExValue('foo', 'bar', false)).toEqual(/"foo"\s*:\s*("bar")/);
+    expect(jsonRegExValue('foo', 'bar', true)).toEqual(/"foo"\s*:\s*("bar")/g);
+  });
+
+  it('jsonRegExKeyValue', () => {
+    expect(jsonRegExKeyValue('foo', 'bar')).toEqual(/("foo")\s*:\s*("bar")/);
+    expect(jsonRegExKeyValue('foo', 'bar', false)).toEqual(
+      /("foo")\s*:\s*("bar")/,
+    );
+    expect(jsonRegExKeyValue('foo', 'bar', true)).toEqual(
+      /("foo")\s*:\s*("bar")/g,
+    );
+  });
+});

--- a/packages/helper-regex-builder/index.js
+++ b/packages/helper-regex-builder/index.js
@@ -1,21 +1,24 @@
 import escapeRegexString from 'escape-regex-string';
 
-function regexBuilder(key, value, groupKey) {
+function regexBuilder(key, value, groupKey, global) {
   const regexKey = escapeRegexString(key);
   const keyField = groupKey ? `("${regexKey}")` : `"${regexKey}"`;
   if (Object.prototype.toString.call(value) !== '[object String]') {
-    return new RegExp(`${keyField}`);
+    return new RegExp(`${keyField}`, global ? 'g' : undefined);
   }
 
   const regexValue = escapeRegexString(value);
   const valueField = `("${regexValue}")`;
-  return new RegExp(`${keyField}\\s*:\\s*${valueField}`);
+  return new RegExp(
+    `${keyField}\\s*:\\s*${valueField}`,
+    global ? 'g' : undefined,
+  );
 }
 
-export function jsonRegExKeyValue(key, value) {
-  return regexBuilder(key, value, true);
+export function jsonRegExKeyValue(key, value, global = false) {
+  return regexBuilder(key, value, true, global);
 }
 
-export function jsonRegExValue(key, value) {
-  return regexBuilder(key, value, false);
+export function jsonRegExValue(key, value, global = false) {
+  return regexBuilder(key, value, false, global);
 }

--- a/packages/plugin-bower-manifest/index.js
+++ b/packages/plugin-bower-manifest/index.js
@@ -12,7 +12,7 @@ import githubShorthand from '@octolinker/resolver-github-shorthand';
 
 function linkDependency(blob, key, value) {
   const isValidSemver = isSemver(value);
-  const regex = jsonRegExKeyValue(key, value);
+  const regex = jsonRegExKeyValue(key, value, blob.isDiff);
 
   return insertLink(blob, regex, this, {
     type: isValidSemver ? 'liveResolverQuery' : 'git',
@@ -20,13 +20,14 @@ function linkDependency(blob, key, value) {
 }
 
 function linkFile(blob, key, value) {
-  const regex = jsonRegExValue(key, value);
+  const regex = jsonRegExValue(key, value, blob.isDiff);
 
   return insertLink(blob, regex, this, { type: 'file' });
 }
 
 export default {
   name: 'BowerManifest',
+  needsContext: true,
 
   resolve(path, [target], { type }) {
     if (type === 'file') {

--- a/packages/plugin-composer-manifest/index.js
+++ b/packages/plugin-composer-manifest/index.js
@@ -8,13 +8,14 @@ function linkDependency(blob, key, value) {
     return;
   }
 
-  const regex = jsonRegExKeyValue(key, value);
+  const regex = jsonRegExKeyValue(key, value, blob.isDiff);
 
   return insertLink(blob, regex, this);
 }
 
 export default {
   name: 'Composer',
+  needsContext: true,
 
   resolve(path, [target]) {
     return liveResolverQuery({ type: 'composer', target });

--- a/packages/plugin-dot-net-core/index.js
+++ b/packages/plugin-dot-net-core/index.js
@@ -4,13 +4,14 @@ import { jsonRegExKeyValue } from '@octolinker/helper-regex-builder';
 import nugetResolver from '@octolinker/resolver-nuget';
 
 function linkDependency(blob, key, value) {
-  const regex = jsonRegExKeyValue(key, value);
+  const regex = jsonRegExKeyValue(key, value, blob.isDiff);
 
   return insertLink(blob, regex, this);
 }
 
 export default {
   name: 'DotNetCore',
+  needsContext: true,
 
   resolve(path, [target]) {
     return nugetResolver({ target });

--- a/packages/plugin-npm-manifest/index.js
+++ b/packages/plugin-npm-manifest/index.js
@@ -12,7 +12,7 @@ import githubShorthand from '@octolinker/resolver-github-shorthand';
 
 function linkDependency(blob, key, value) {
   const isValidSemver = isSemver(value);
-  const regex = jsonRegExKeyValue(key, value);
+  const regex = jsonRegExKeyValue(key, value, blob.isDiff);
 
   return insertLink(blob, regex, this, {
     type: isValidSemver ? 'liveResolverQuery' : 'git',
@@ -20,12 +20,13 @@ function linkDependency(blob, key, value) {
 }
 
 function linkFile(blob, key, value) {
-  const regex = jsonRegExValue(key, value);
+  const regex = jsonRegExValue(key, value, blob.isDiff);
   return insertLink(blob, regex, this, { type: 'file' });
 }
 
 export default {
   name: 'NpmManifest',
+  needsContext: true,
 
   resolve(path, values, { type }) {
     if (type === 'file') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,14 +3,14 @@
 
 
 "@babel/code-frame@^7.0.0-beta.35":
-  version "7.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz#e0d002100805daab1461c0fcb32a07e304f3a4f4"
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz#09f76300673ac085d3b90e02aafa0ffc2c96846a"
   dependencies:
-    "@babel/highlight" "7.0.0-beta.46"
+    "@babel/highlight" "7.0.0-beta.56"
 
-"@babel/highlight@7.0.0-beta.46":
-  version "7.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.46.tgz#c553c51e65f572bdedd6eff66fc0bb563016645e"
+"@babel/highlight@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.56.tgz#f8b0fc8c5c2de53bb2c12f9001ad3d99e573696d"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
@@ -181,6 +181,10 @@ abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
 
+abab@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
+
 abbrev@1, abbrev@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -207,11 +211,11 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^5.0.0, acorn@^5.3.0:
+acorn@^5.0.0:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
 
-acorn@^5.5.0:
+acorn@^5.5.0, acorn@^5.5.3:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
@@ -414,11 +418,11 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-append-transform@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
+append-transform@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
   dependencies:
-    default-require-extensions "^1.0.0"
+    default-require-extensions "^2.0.0"
 
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
@@ -621,13 +625,13 @@ async@^1.4.0, async@^1.5.0, async@^1.5.2, async@~1.5:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.0.0, async@^2.6.1, async@~2.6.0:
+async@^2.0.0, async@^2.1.4, async@^2.6.1, async@~2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:
     lodash "^4.17.10"
 
-async@^2.1.4, async@^2.6.0:
+async@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
@@ -851,12 +855,12 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-jest@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-22.4.3.tgz#4b7a0b6041691bbd422ab49b3b73654a49a6627a"
+babel-jest@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.4.2.tgz#f276de67798a5d68f2d6e87ff518c2f6e1609877"
   dependencies:
-    babel-plugin-istanbul "^4.1.5"
-    babel-preset-jest "^22.4.3"
+    babel-plugin-istanbul "^4.1.6"
+    babel-preset-jest "^23.2.0"
 
 babel-loader@^7.1.2:
   version "7.1.4"
@@ -878,7 +882,7 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-istanbul@^4.1.5:
+babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
   dependencies:
@@ -890,6 +894,10 @@ babel-plugin-istanbul@^4.1.5:
 babel-plugin-jest-hoist@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz#7d8bcccadc2667f96a0dcc6afe1891875ee6c14a"
+
+babel-plugin-jest-hoist@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -1289,11 +1297,18 @@ babel-preset-es2015@^6.9.0:
     babel-plugin-transform-es2015-unicode-regex "^6.24.1"
     babel-plugin-transform-regenerator "^6.24.1"
 
-babel-preset-jest@^22.0.3, babel-preset-jest@^22.4.3:
+babel-preset-jest@^22.0.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz#e92eef9813b7026ab4ca675799f37419b5a44156"
   dependencies:
     babel-plugin-jest-hoist "^22.4.3"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+
+babel-preset-jest@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
+  dependencies:
+    babel-plugin-jest-hoist "^23.2.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-preset-stage-1@^6.5.0:
@@ -1352,7 +1367,7 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -1366,7 +1381,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -1541,9 +1556,9 @@ browser-process-hrtime@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
 
-browser-resolve@^1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
+browser-resolve@^1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
   dependencies:
     resolve "1.1.7"
 
@@ -2230,8 +2245,8 @@ compare-func@^1.3.1:
     dot-prop "^3.0.0"
 
 compare-versions@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.1.0.tgz#43310256a5c555aaed4193c04d8f154cf9c6efd5"
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.3.0.tgz#af93ea705a96943f622ab309578b9b90586f39c3"
 
 component-emitter@^1.2.1:
   version "1.2.1"
@@ -2678,12 +2693,12 @@ csso@~2.3.1:
     source-map "^0.5.3"
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.4.tgz#8cd52e8a3acfd68d3aed38ee0a640177d2f9d797"
 
-"cssstyle@>= 0.2.37 < 0.3.0":
-  version "0.2.37"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
+cssstyle@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.0.0.tgz#79b16d51ec5591faec60e688891f15d2a5705129"
   dependencies:
     cssom "0.3.x"
 
@@ -2829,11 +2844,11 @@ deepmerge@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.1.tgz#e862b4e45ea0555072bf51e7fd0d9845170ae768"
 
-default-require-extensions@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
+default-require-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
   dependencies:
-    strip-bom "^2.0.0"
+    strip-bom "^3.0.0"
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -3008,7 +3023,7 @@ domelementtype@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
 
-domexception@^1.0.0:
+domexception@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
   dependencies:
@@ -3182,9 +3197,19 @@ error@^7.0.2:
     string-template "~0.2.1"
     xtend "~4.0.0"
 
-es-abstract@^1.4.3, es-abstract@^1.5.1, es-abstract@^1.7.0:
+es-abstract@^1.4.3, es-abstract@^1.7.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.11.0.tgz#cce87d518f0496893b1a30cd8461835535480681"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-abstract@^1.5.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.1"
@@ -3290,9 +3315,9 @@ escodegen@1.x.x:
   optionalDependencies:
     source-map "~0.6.1"
 
-escodegen@^1.9.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.1.tgz#dbae17ef96c8e4bedb1356f4504fa4cc2f7cb7e2"
+escodegen@^1.9.1:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.0.tgz#b27a9389481d5bfd5bec76f7bb1eb3f8f4556589"
   dependencies:
     esprima "^3.1.3"
     estraverse "^4.2.0"
@@ -3563,10 +3588,10 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     safe-buffer "^5.1.1"
 
 exec-sh@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.1.tgz#163b98a6e89e6b65b47c2a28d215bc1f63989c38"
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
   dependencies:
-    merge "^1.1.3"
+    merge "^1.2.0"
 
 execa@^0.7.0:
   version "0.7.0"
@@ -3640,16 +3665,16 @@ expect-puppeteer@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/expect-puppeteer/-/expect-puppeteer-3.2.0.tgz#b4c322e28b86e9e74f5c6d636fb1e0dde5c4a559"
 
-expect@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-22.4.3.tgz#d5a29d0a0e1fb2153557caef2674d4547e914674"
+expect@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-23.4.0.tgz#6da4ecc99c1471253e7288338983ad1ebadb60c3"
   dependencies:
     ansi-styles "^3.2.0"
-    jest-diff "^22.4.3"
-    jest-get-type "^22.4.3"
-    jest-matcher-utils "^22.4.3"
-    jest-message-util "^22.4.3"
-    jest-regex-util "^22.4.3"
+    jest-diff "^23.2.0"
+    jest-get-type "^22.1.0"
+    jest-matcher-utils "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -4047,19 +4072,12 @@ fsevents@1.1.2:
     nan "^2.3.0"
     node-pre-gyp "^0.6.36"
 
-fsevents@^1.1.2:
+fsevents@^1.1.2, fsevents@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
-
-fsevents@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.3.tgz#08292982e7059f6674c93d8b829c1e8604979ac0"
-  dependencies:
-    nan "^2.9.2"
-    node-pre-gyp "^0.9.0"
 
 fstream-ignore@^1.0.5:
   version "1.0.5"
@@ -5274,7 +5292,7 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-istanbul-api@^1.1.14:
+istanbul-api@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.3.1.tgz#4c3b05d18c0016d1022e079b98dc82c40f488954"
   dependencies:
@@ -5291,17 +5309,17 @@ istanbul-api@^1.1.14:
     mkdirp "^0.5.1"
     once "^1.4.0"
 
-istanbul-lib-coverage@^1.1.1, istanbul-lib-coverage@^1.1.2, istanbul-lib-coverage@^1.2.0:
+istanbul-lib-coverage@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
 
 istanbul-lib-hook@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz#ae556fd5a41a6e8efa0b1002b1e416dfeaf9816c"
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz#f614ec45287b2a8fc4f07f5660af787575601805"
   dependencies:
-    append-transform "^0.4.0"
+    append-transform "^1.0.0"
 
-istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.8.0:
+istanbul-lib-instrument@^1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
   dependencies:
@@ -5322,19 +5340,9 @@ istanbul-lib-report@^1.1.4:
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
-istanbul-lib-source-maps@^1.2.1:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz#20fb54b14e14b3fb6edb6aca3571fd2143db44e6"
-  dependencies:
-    debug "^3.1.0"
-    istanbul-lib-coverage "^1.1.2"
-    mkdirp "^0.5.1"
-    rimraf "^2.6.1"
-    source-map "^0.5.3"
-
 istanbul-lib-source-maps@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz#cc7ccad61629f4efff8e2f78adb8c522c9976ec7"
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz#ffe6be4e7ab86d3603e4290d54990b14506fc9b1"
   dependencies:
     debug "^3.1.0"
     istanbul-lib-coverage "^1.2.0"
@@ -5367,15 +5375,15 @@ jed@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/jed/-/jed-1.1.1.tgz#7a549bbd9ffe1585b0cd0a191e203055bee574b4"
 
-jest-changed-files@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-22.4.3.tgz#8882181e022c38bd46a2e4d18d44d19d90a90fb2"
+jest-changed-files@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.4.2.tgz#1eed688370cd5eebafe4ae93d34bb3b64968fe83"
   dependencies:
     throat "^4.0.0"
 
-jest-cli@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-22.4.3.tgz#bf16c4a5fb7edc3fa5b9bb7819e34139e88a72c7"
+jest-cli@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.4.2.tgz#49d56bcfe6cf01871bfcc4a0494e08edaf2b61d0"
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
@@ -5384,49 +5392,53 @@ jest-cli@^22.4.3:
     graceful-fs "^4.1.11"
     import-local "^1.0.0"
     is-ci "^1.0.10"
-    istanbul-api "^1.1.14"
-    istanbul-lib-coverage "^1.1.1"
-    istanbul-lib-instrument "^1.8.0"
-    istanbul-lib-source-maps "^1.2.1"
-    jest-changed-files "^22.4.3"
-    jest-config "^22.4.3"
-    jest-environment-jsdom "^22.4.3"
-    jest-get-type "^22.4.3"
-    jest-haste-map "^22.4.3"
-    jest-message-util "^22.4.3"
-    jest-regex-util "^22.4.3"
-    jest-resolve-dependencies "^22.4.3"
-    jest-runner "^22.4.3"
-    jest-runtime "^22.4.3"
-    jest-snapshot "^22.4.3"
-    jest-util "^22.4.3"
-    jest-validate "^22.4.3"
-    jest-worker "^22.4.3"
+    istanbul-api "^1.3.1"
+    istanbul-lib-coverage "^1.2.0"
+    istanbul-lib-instrument "^1.10.1"
+    istanbul-lib-source-maps "^1.2.4"
+    jest-changed-files "^23.4.2"
+    jest-config "^23.4.2"
+    jest-environment-jsdom "^23.4.0"
+    jest-get-type "^22.1.0"
+    jest-haste-map "^23.4.1"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve-dependencies "^23.4.2"
+    jest-runner "^23.4.2"
+    jest-runtime "^23.4.2"
+    jest-snapshot "^23.4.2"
+    jest-util "^23.4.0"
+    jest-validate "^23.4.0"
+    jest-watcher "^23.4.0"
+    jest-worker "^23.2.0"
     micromatch "^2.3.11"
     node-notifier "^5.2.1"
+    prompts "^0.1.9"
     realpath-native "^1.0.0"
     rimraf "^2.5.4"
     slash "^1.0.0"
     string-length "^2.0.0"
     strip-ansi "^4.0.0"
     which "^1.2.12"
-    yargs "^10.0.3"
+    yargs "^11.0.0"
 
-jest-config@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-22.4.3.tgz#0e9d57db267839ea31309119b41dc2fa31b76403"
+jest-config@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.4.2.tgz#62a105e14b8266458f2bf4d32403b2c44418fa77"
   dependencies:
+    babel-core "^6.0.0"
+    babel-jest "^23.4.2"
     chalk "^2.0.1"
     glob "^7.1.1"
-    jest-environment-jsdom "^22.4.3"
-    jest-environment-node "^22.4.3"
-    jest-get-type "^22.4.3"
-    jest-jasmine2 "^22.4.3"
-    jest-regex-util "^22.4.3"
-    jest-resolve "^22.4.3"
-    jest-util "^22.4.3"
-    jest-validate "^22.4.3"
-    pretty-format "^22.4.3"
+    jest-environment-jsdom "^23.4.0"
+    jest-environment-node "^23.4.0"
+    jest-get-type "^22.1.0"
+    jest-jasmine2 "^23.4.2"
+    jest-regex-util "^23.3.0"
+    jest-resolve "^23.4.1"
+    jest-util "^23.4.0"
+    jest-validate "^23.4.0"
+    pretty-format "^23.2.0"
 
 jest-dev-server@^3.2.0:
   version "3.2.0"
@@ -5440,39 +5452,46 @@ jest-dev-server@^3.2.0:
     terminate "^2.1.0"
     wait-port "^0.2.2"
 
-jest-diff@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-22.4.3.tgz#e18cc3feff0aeef159d02310f2686d4065378030"
+jest-diff@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.2.0.tgz#9f2cf4b51e12c791550200abc16b47130af1062a"
   dependencies:
     chalk "^2.0.1"
     diff "^3.2.0"
-    jest-get-type "^22.4.3"
-    pretty-format "^22.4.3"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.2.0"
 
 jest-docblock@^21.0.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
 
-jest-docblock@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.4.3.tgz#50886f132b42b280c903c592373bb6e93bb68b19"
+jest-docblock@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.2.0.tgz#f085e1f18548d99fdd69b20207e6fd55d91383a7"
   dependencies:
     detect-newline "^2.1.0"
 
-jest-environment-jsdom@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz#d67daa4155e33516aecdd35afd82d4abf0fa8a1e"
+jest-each@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.4.0.tgz#2fa9edd89daa1a4edc9ff9bf6062a36b71345143"
   dependencies:
-    jest-mock "^22.4.3"
-    jest-util "^22.4.3"
+    chalk "^2.0.1"
+    pretty-format "^23.2.0"
+
+jest-environment-jsdom@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz#056a7952b3fea513ac62a140a2c368c79d9e6023"
+  dependencies:
+    jest-mock "^23.2.0"
+    jest-util "^23.4.0"
     jsdom "^11.5.1"
 
-jest-environment-node@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-22.4.3.tgz#54c4eaa374c83dd52a9da8759be14ebe1d0b9129"
+jest-environment-node@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.4.0.tgz#57e80ed0841dea303167cce8cd79521debafde10"
   dependencies:
-    jest-mock "^22.4.3"
-    jest-util "^22.4.3"
+    jest-mock "^23.2.0"
+    jest-util "^23.4.0"
 
 jest-environment-puppeteer@^3.2.1:
   version "3.2.1"
@@ -5493,55 +5512,56 @@ jest-fetch-mock@^1.6.5:
     isomorphic-fetch "^2.2.1"
     promise-polyfill "^7.1.1"
 
-jest-get-type@^22.4.3:
+jest-get-type@^22.1.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
 
-jest-haste-map@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-22.4.3.tgz#25842fa2ba350200767ac27f658d58b9d5c2e20b"
+jest-haste-map@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.4.1.tgz#43a174ba7ac079ae1dd74eaf5a5fe78989474dd2"
   dependencies:
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.11"
-    jest-docblock "^22.4.3"
-    jest-serializer "^22.4.3"
-    jest-worker "^22.4.3"
+    jest-docblock "^23.2.0"
+    jest-serializer "^23.0.1"
+    jest-worker "^23.2.0"
     micromatch "^2.3.11"
     sane "^2.0.0"
 
-jest-jasmine2@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-22.4.3.tgz#4daf64cd14c793da9db34a7c7b8dcfe52a745965"
+jest-jasmine2@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.4.2.tgz#2fbf52f93e43ed4c5e7326a90bb1d785be4321ac"
   dependencies:
+    babel-traverse "^6.0.0"
     chalk "^2.0.1"
     co "^4.6.0"
-    expect "^22.4.3"
-    graceful-fs "^4.1.11"
+    expect "^23.4.0"
     is-generator-fn "^1.0.0"
-    jest-diff "^22.4.3"
-    jest-matcher-utils "^22.4.3"
-    jest-message-util "^22.4.3"
-    jest-snapshot "^22.4.3"
-    jest-util "^22.4.3"
-    source-map-support "^0.5.0"
+    jest-diff "^23.2.0"
+    jest-each "^23.4.0"
+    jest-matcher-utils "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-snapshot "^23.4.2"
+    jest-util "^23.4.0"
+    pretty-format "^23.2.0"
 
-jest-leak-detector@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz#2b7b263103afae8c52b6b91241a2de40117e5b35"
+jest-leak-detector@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.2.0.tgz#c289d961dc638f14357d4ef96e0431ecc1aa377d"
   dependencies:
-    pretty-format "^22.4.3"
+    pretty-format "^23.2.0"
 
-jest-matcher-utils@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz#4632fe428ebc73ebc194d3c7b65d37b161f710ff"
+jest-matcher-utils@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz#4d4981f23213e939e3cedf23dc34c747b5ae1913"
   dependencies:
     chalk "^2.0.1"
-    jest-get-type "^22.4.3"
-    pretty-format "^22.4.3"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.2.0"
 
-jest-message-util@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-22.4.3.tgz#cf3d38aafe4befddbfc455e57d65d5239e399eb7"
+jest-message-util@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-23.4.0.tgz#17610c50942349508d01a3d1e0bda2c079086a9f"
   dependencies:
     "@babel/code-frame" "^7.0.0-beta.35"
     chalk "^2.0.1"
@@ -5549,9 +5569,9 @@ jest-message-util@^22.4.3:
     slash "^1.0.0"
     stack-utils "^1.0.1"
 
-jest-mock@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-22.4.3.tgz#f63ba2f07a1511772cdc7979733397df770aabc7"
+jest-mock@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
 
 jest-puppeteer@^3.2.1:
   version "3.2.1"
@@ -5560,113 +5580,130 @@ jest-puppeteer@^3.2.1:
     expect-puppeteer "^3.2.0"
     jest-environment-puppeteer "^3.2.1"
 
-jest-regex-util@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-22.4.3.tgz#a826eb191cdf22502198c5401a1fc04de9cef5af"
+jest-regex-util@^23.3.0:
+  version "23.3.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.3.0.tgz#5f86729547c2785c4002ceaa8f849fe8ca471bc5"
 
-jest-resolve-dependencies@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz#e2256a5a846732dc3969cb72f3c9ad7725a8195e"
+jest-resolve-dependencies@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.4.2.tgz#0675ba876a5b819deffc449ad72e9985c2592048"
   dependencies:
-    jest-regex-util "^22.4.3"
+    jest-regex-util "^23.3.0"
+    jest-snapshot "^23.4.2"
 
-jest-resolve@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-22.4.3.tgz#0ce9d438c8438229aa9b916968ec6b05c1abb4ea"
+jest-resolve@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.4.1.tgz#7f3c17104732a2c0c940a01256025ed745814982"
   dependencies:
-    browser-resolve "^1.11.2"
+    browser-resolve "^1.11.3"
     chalk "^2.0.1"
+    realpath-native "^1.0.0"
 
-jest-runner@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-22.4.3.tgz#298ddd6a22b992c64401b4667702b325e50610c3"
+jest-runner@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.4.2.tgz#579a88524ac52c846075b0129a21c7b483e75a7e"
   dependencies:
     exit "^0.1.2"
-    jest-config "^22.4.3"
-    jest-docblock "^22.4.3"
-    jest-haste-map "^22.4.3"
-    jest-jasmine2 "^22.4.3"
-    jest-leak-detector "^22.4.3"
-    jest-message-util "^22.4.3"
-    jest-runtime "^22.4.3"
-    jest-util "^22.4.3"
-    jest-worker "^22.4.3"
+    graceful-fs "^4.1.11"
+    jest-config "^23.4.2"
+    jest-docblock "^23.2.0"
+    jest-haste-map "^23.4.1"
+    jest-jasmine2 "^23.4.2"
+    jest-leak-detector "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-runtime "^23.4.2"
+    jest-util "^23.4.0"
+    jest-worker "^23.2.0"
+    source-map-support "^0.5.6"
     throat "^4.0.0"
 
-jest-runtime@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-22.4.3.tgz#b69926c34b851b920f666c93e86ba2912087e3d0"
+jest-runtime@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.4.2.tgz#00c3bb8385253d401a394a27d1112d3615e5a65c"
   dependencies:
     babel-core "^6.0.0"
-    babel-jest "^22.4.3"
-    babel-plugin-istanbul "^4.1.5"
+    babel-plugin-istanbul "^4.1.6"
     chalk "^2.0.1"
     convert-source-map "^1.4.0"
     exit "^0.1.2"
+    fast-json-stable-stringify "^2.0.0"
     graceful-fs "^4.1.11"
-    jest-config "^22.4.3"
-    jest-haste-map "^22.4.3"
-    jest-regex-util "^22.4.3"
-    jest-resolve "^22.4.3"
-    jest-util "^22.4.3"
-    jest-validate "^22.4.3"
-    json-stable-stringify "^1.0.1"
+    jest-config "^23.4.2"
+    jest-haste-map "^23.4.1"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve "^23.4.1"
+    jest-snapshot "^23.4.2"
+    jest-util "^23.4.0"
+    jest-validate "^23.4.0"
     micromatch "^2.3.11"
     realpath-native "^1.0.0"
     slash "^1.0.0"
     strip-bom "3.0.0"
     write-file-atomic "^2.1.0"
-    yargs "^10.0.3"
+    yargs "^11.0.0"
 
-jest-serializer@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-22.4.3.tgz#a679b81a7f111e4766235f4f0c46d230ee0f7436"
+jest-serializer@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.1.tgz#a3776aeb311e90fe83fab9e533e85102bd164165"
 
-jest-snapshot@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-22.4.3.tgz#b5c9b42846ffb9faccb76b841315ba67887362d2"
+jest-snapshot@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-23.4.2.tgz#8fa6130feb5a527dac73e5fa80d86f29f7c42ab6"
   dependencies:
+    babel-types "^6.0.0"
     chalk "^2.0.1"
-    jest-diff "^22.4.3"
-    jest-matcher-utils "^22.4.3"
+    jest-diff "^23.2.0"
+    jest-matcher-utils "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-resolve "^23.4.1"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    pretty-format "^22.4.3"
+    pretty-format "^23.2.0"
+    semver "^5.5.0"
 
-jest-util@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-22.4.3.tgz#c70fec8eec487c37b10b0809dc064a7ecf6aafac"
+jest-util@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.4.0.tgz#4d063cb927baf0a23831ff61bec2cbbf49793561"
   dependencies:
     callsites "^2.0.0"
     chalk "^2.0.1"
     graceful-fs "^4.1.11"
     is-ci "^1.0.10"
-    jest-message-util "^22.4.3"
+    jest-message-util "^23.4.0"
     mkdirp "^0.5.1"
+    slash "^1.0.0"
     source-map "^0.6.0"
 
-jest-validate@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-22.4.3.tgz#0780954a5a7daaeec8d3c10834b9280865976b30"
+jest-validate@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.4.0.tgz#d96eede01ef03ac909c009e9c8e455197d48c201"
   dependencies:
     chalk "^2.0.1"
-    jest-config "^22.4.3"
-    jest-get-type "^22.4.3"
+    jest-get-type "^22.1.0"
     leven "^2.1.0"
-    pretty-format "^22.4.3"
+    pretty-format "^23.2.0"
 
-jest-worker@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-22.4.3.tgz#5c421417cba1c0abf64bf56bd5fb7968d79dd40b"
+jest-watcher@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-23.4.0.tgz#d2e28ce74f8dad6c6afc922b92cabef6ed05c91c"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    string-length "^2.0.0"
+
+jest-worker@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.2.0.tgz#faf706a8da36fae60eb26957257fa7b5d8ea02b9"
   dependencies:
     merge-stream "^1.0.1"
 
-jest@^22.0.6:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-22.4.3.tgz#2261f4b117dc46d9a4a1a673d2150958dee92f16"
+jest@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-23.4.2.tgz#1fae3ed832192143070ae85156b25cea891a1260"
   dependencies:
     import-local "^1.0.0"
-    jest-cli "^22.4.3"
+    jest-cli "^23.4.2"
 
 jetpack-id@1.0.0:
   version "1.0.0"
@@ -5687,16 +5724,9 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.5.1, js-yaml@^3.5.3, js-yaml@^3.9.1:
+js-yaml@^3.5.1, js-yaml@^3.5.3, js-yaml@^3.7.0, js-yaml@^3.9.1:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^3.7.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -5753,34 +5783,34 @@ jscodeshift@^0.5.0:
     write-file-atomic "^1.2.0"
 
 jsdom@^11.5.1:
-  version "11.10.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.10.0.tgz#a42cd54e88895dc765f03f15b807a474962ac3b5"
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
   dependencies:
-    abab "^1.0.4"
-    acorn "^5.3.0"
+    abab "^2.0.0"
+    acorn "^5.5.3"
     acorn-globals "^4.1.0"
     array-equal "^1.0.0"
     cssom ">= 0.3.2 < 0.4.0"
-    cssstyle ">= 0.2.37 < 0.3.0"
+    cssstyle "^1.0.0"
     data-urls "^1.0.0"
-    domexception "^1.0.0"
-    escodegen "^1.9.0"
+    domexception "^1.0.1"
+    escodegen "^1.9.1"
     html-encoding-sniffer "^1.0.2"
-    left-pad "^1.2.0"
-    nwmatcher "^1.4.3"
+    left-pad "^1.3.0"
+    nwsapi "^2.0.7"
     parse5 "4.0.0"
     pn "^1.1.0"
-    request "^2.83.0"
+    request "^2.87.0"
     request-promise-native "^1.0.5"
     sax "^1.2.4"
     symbol-tree "^3.2.2"
-    tough-cookie "^2.3.3"
+    tough-cookie "^2.3.4"
     w3c-hr-time "^1.0.1"
     webidl-conversions "^4.0.2"
     whatwg-encoding "^1.0.3"
     whatwg-mimetype "^2.1.0"
-    whatwg-url "^6.4.0"
-    ws "^4.0.0"
+    whatwg-url "^6.4.1"
+    ws "^5.2.0"
     xml-name-validator "^3.0.0"
 
 jsesc@^1.3.0:
@@ -5948,6 +5978,10 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+kleur@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-2.0.1.tgz#7cc64b0d188d0dcbc98bdcdfdda2cc10619ddce8"
+
 latest-version@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
@@ -5978,7 +6012,7 @@ leb@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/leb/-/leb-0.3.0.tgz#32bee9fad168328d6aea8522d833f4180eed1da3"
 
-left-pad@^1.2.0:
+left-pad@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
 
@@ -6440,7 +6474,7 @@ merge2@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.2.tgz#03212e3da8d86c4d8523cebd6318193414f94e34"
 
-merge@^1.1.3:
+merge@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
@@ -6834,21 +6868,6 @@ node-pre-gyp@^0.6.36:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-node-pre-gyp@^0.9.0:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz#f11c07516dd92f87199dbc7e1838eab7cd56c9e0"
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.0"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.1.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4"
-
 nomnom@1.8.1, nomnom@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
@@ -6953,9 +6972,9 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nwmatcher@^1.4.3:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.4.tgz#2285631f34a95f0d0395cd900c96ed39b58f346e"
+nwsapi@^2.0.7:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.8.tgz#e3603579b7e162b3dbedae4fb24e46f771d8fa24"
 
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
@@ -7726,9 +7745,9 @@ pretty-bytes@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-4.0.2.tgz#b2bf82e7350d65c6c33aa95aaa5a4f6327f61cd9"
 
-pretty-format@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"
+pretty-format@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.2.0.tgz#3b0aaa63c018a53583373c1cb3a5d96cc5e83017"
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -7778,6 +7797,13 @@ promise-polyfill@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prompts@^0.1.9:
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.14.tgz#a8e15c612c5c9ec8f8111847df3337c9cbd443b2"
+  dependencies:
+    kleur "^2.0.1"
+    sisteransi "^0.1.1"
+
 prop-types@^15.6.0:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
@@ -7816,6 +7842,10 @@ ps-tree@^1.1.0:
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
+psl@^1.1.24:
+  version "1.1.29"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
 
 public-encrypt@^4.0.0:
   version "4.0.2"
@@ -8062,8 +8092,8 @@ readline2@^1.0.1:
     mute-stream "0.0.5"
 
 realpath-native@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.0.tgz#7885721a83b43bd5327609f0ddecb2482305fdf0"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.1.tgz#07f40a0cce8f8261e2e8b7ebebf5c95965d7b633"
   dependencies:
     util.promisify "^1.0.0"
 
@@ -8753,6 +8783,10 @@ sinon@^4.0.1:
     supports-color "^5.1.0"
     type-detect "^4.0.5"
 
+sisteransi@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-0.1.1.tgz#5431447d5f7d1675aac667ccd0b865a4994cb3ce"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -9021,7 +9055,7 @@ source-map-support@0.5.3:
   dependencies:
     source-map "^0.6.0"
 
-source-map-support@0.5.6, source-map-support@~0.5.4:
+source-map-support@0.5.6, source-map-support@^0.5.6, source-map-support@~0.5.4:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
   dependencies:
@@ -9033,13 +9067,6 @@ source-map-support@^0.4.15:
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
   dependencies:
     source-map "^0.5.6"
-
-source-map-support@^0.5.0:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.5.tgz#0d4af9e00493e855402e8ec36ebed2d266fceb90"
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
 
 source-map-url@^0.4.0:
   version "0.4.0"
@@ -9661,7 +9688,14 @@ tosource@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tosource/-/tosource-1.0.0.tgz#42d88dd116618bcf00d6106dd5446f3427902ff1"
 
-tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
+tough-cookie@>=2.3.3, tough-cookie@^2.3.4:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  dependencies:
+    psl "^1.1.24"
+    punycode "^1.4.1"
+
+tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
   dependencies:
@@ -10261,9 +10295,17 @@ whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
 
-whatwg-url@6.4.1, whatwg-url@^6.4.0:
+whatwg-url@6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.1.tgz#fdb94b440fd4ad836202c16e9737d511f012fd67"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
+
+whatwg-url@^6.4.0, whatwg-url@^6.4.1:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
   dependencies:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
@@ -10409,16 +10451,15 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-4.1.0.tgz#a979b5d7d4da68bf54efe0408967c324869a7289"
-  dependencies:
-    async-limiter "~1.0.0"
-    safe-buffer "~5.1.0"
-
 ws@^5.1.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.0.tgz#9fd95e3ac7c76f6ae8bcc868a0e3f11f1290c33e"
+  dependencies:
+    async-limiter "~1.0.0"
+
+ws@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
   dependencies:
     async-limiter "~1.0.0"
 
@@ -10485,12 +10526,6 @@ yargs-parser@^7.0.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs-parser@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
-  dependencies:
-    camelcase "^4.1.0"
-
 yargs-parser@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
@@ -10532,24 +10567,7 @@ yargs@6.6.0:
     y18n "^3.2.1"
     yargs-parser "^4.2.0"
 
-yargs@^10.0.3:
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^1.1.1"
-    find-up "^2.1.0"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^8.1.0"
-
-yargs@^11.1.0:
+yargs@^11.0.0, yargs@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,6 +47,10 @@
   dependencies:
     samsam "1.3.0"
 
+"@types/jest@^23.0.0":
+  version "23.3.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.1.tgz#a4319aedb071d478e6f407d1c4578ec8156829cf"
+
 "@types/node@*":
   version "10.3.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.3.tgz#8798d9e39af2fa604f715ee6a6b19796528e46c3"
@@ -5259,7 +5263,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
-isomorphic-fetch@^2.1.1:
+isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   dependencies:
@@ -5480,6 +5484,14 @@ jest-environment-puppeteer@^3.2.1:
     lodash "^4.17.10"
     mkdirp "^0.5.1"
     rimraf "^2.6.2"
+
+jest-fetch-mock@^1.6.5:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-1.6.5.tgz#178fa1a937ef6f61fb8e8483b6d4602b17e0d96d"
+  dependencies:
+    "@types/jest" "^23.0.0"
+    isomorphic-fetch "^2.2.1"
+    promise-polyfill "^7.1.1"
 
 jest-get-type@^22.4.3:
   version "22.4.3"
@@ -7755,6 +7767,10 @@ progress@^2.0.0:
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
+
+promise-polyfill@^7.1.1:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-7.1.2.tgz#ab05301d8c28536301622d69227632269a70ca3b"
 
 "promise@>=3.2 <8", promise@^7.1.1:
   version "7.3.1"


### PR DESCRIPTION
This turned into a slightly bigger Pull Request than I usually prefer. In order to support `package.json` `bower.json` and `composer.json` files in a Pull Request diff view, I had to make changes all over the place. I'll quickly outline what I did and why this was necessary.

### Why this was not working

Our plugins for the mentions files above relay on a well formatted json object. This is the case when looking at a single file, but not in a Pull Request view which is in most cases just a subset of the actual file. 

### How I solved it

In order to fix #71 I had to ensure that we always have a valid JSON file to operate on. Therefore I added two methods to our [blob-reader](https://github.com/OctoLinker/OctoLinker/tree/master/packages/blob-reader) package. 

#### `fetchBlob`
This method allows us to fetch the raw underlay blob of the current blob. We only do this on a Pull Request view.

#### `fetchParentBlob`
Along with this method, I added a new concept of parent blobs were a blob can reference to another parent blob. We need this in order to link all values on the left and also on the right side of the diff view. 

Those two methods are called right before we invoke a plugin and as I already mentioned only on a diff view. Apart from that, I added a few missing tests.

### How to review this Pull Request best?
I would suggest to go through commit by commit.