### PR TITLE
Get parent sha on PR diff view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 npm-debug.log
 lerna-debug.log
+.env
 
 dist/
 out/

--- a/e2e/automated.test.js
+++ b/e2e/automated.test.js
@@ -35,7 +35,7 @@ describe('End to End tests', () => {
             '.selected-line.blob-code .octolinker-link',
           );
         },
-        10000,
+        20000,
       );
     });
   });

--- a/e2e/automated.test.js
+++ b/e2e/automated.test.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 const fixtures = require('./fixtures.json'); // eslint-disable-line import/no-unresolved
 const diffFixtures = require('./diff-fixtures.json'); // eslint-disable-line import/no-unresolved
 
@@ -15,7 +17,39 @@ async function executeTest(url, targetUrl, selector) {
   await expect(page.url()).toEqual(expect.stringMatching(targetUrl));
 }
 
+jest.setTimeout(20000);
+
 describe('End to End tests', () => {
+  beforeAll(async () => {
+    if (!process.env.E2E_USER_NAME || !process.env.E2E_USER_PASSWORD) {
+      console.log('Run E2E tests as an anonymous user'); // eslint-disable-line
+      return;
+    }
+
+    console.log('Perform login ...'); // eslint-disable-line
+
+    await page.goto('https://github.com/login');
+    await expect(page).toFill('#login_field', process.env.E2E_USER_NAME);
+    await expect(page).toFill('#password', process.env.E2E_USER_PASSWORD);
+    await Promise.all([
+      page.waitForNavigation(),
+      expect(page).toClick('input[type=submit]'),
+    ]);
+
+    try {
+      const authError = await page.$eval('#login .flash-error', el =>
+        el.textContent.trim(),
+      );
+      throw new Error(authError);
+    } catch (error) {
+      if (!error.message.includes('failed to find element matching selector')) {
+        await expect(error).toBeUndefined();
+      }
+    }
+
+    console.log('Run E2E tests with authenticated user'); // eslint-disable-line
+  });
+
   describe('single blob', () => {
     fixtures.forEach(({ url, content, lineNumber, targetUrl }) => {
       it(`resolves ${content} to ${targetUrl}`, async () => {
@@ -26,17 +60,13 @@ describe('End to End tests', () => {
 
   describe('diff view', () => {
     diffFixtures.forEach(({ url, targetUrl }) => {
-      it(
-        `resolves ${url} to ${targetUrl}`,
-        async () => {
-          await executeTest(
-            url,
-            targetUrl,
-            '.selected-line.blob-code .octolinker-link',
-          );
-        },
-        20000,
-      );
+      it(`resolves ${url} to ${targetUrl}`, async () => {
+        await executeTest(
+          url,
+          targetUrl,
+          '.selected-line.blob-code .octolinker-link',
+        );
+      });
     });
   });
 });

--- a/e2e/diff-fixtures.json
+++ b/e2e/diff-fixtures.json
@@ -6,5 +6,13 @@
   {
     "url": "https://github.com/OctoLinker/OctoLinker/commit/b97dfbfdbf3dee5f4836426e6dac6d6f473461db?diff=split#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L23",
     "targetUrl": "https://github.com/eslint/eslint"
+  },
+  {
+    "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L59",
+    "targetUrl": "https://github.com/webpack/webpack"
+  },
+  {
+    "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R59",
+    "targetUrl": "https://github.com/webpack/webpack"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "codecov": "^3.0.4",
     "copy-webpack-plugin": "^4.4.2",
     "css-loader": "^0.28.7",
+    "dotenv": "^6.0.0",
     "eslint": "^4.8.0",
     "eslint-config-airbnb": "^16.0.0",
     "eslint-config-prettier": "^2.6.0",

--- a/packages/blob-reader/helper.js
+++ b/packages/blob-reader/helper.js
@@ -28,7 +28,22 @@ function isGist() {
 }
 
 function getParentSha() {
+  // Pull request diff view
+  const input = document.querySelector('[name="comparison_start_oid"]');
+
+  if (input && input.value) {
+    return input.value;
+  }
+
+  // Pull request diff for unauthenticated users
+  const url = document.querySelector('.js-load-contents');
+  if (url && url.dataset.contentsUrl) {
+    return url.dataset.contentsUrl.match(/base_sha=([0-9a-z]+)/)[1];
+  }
+
+  // Commit diff view
   const el = document.querySelector('.sha-block .sha[data-hotkey]');
+
   return el ? el.textContent : null;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3061,6 +3061,10 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.0.0.tgz#24e37c041741c5f4b25324958ebbc34bca965935"
+
 dtrace-provider@~0.8:
   version "0.8.7"
   resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.7.tgz#dc939b4d3e0620cfe0c1cd803d0d2d7ed04ffd04"


### PR DESCRIPTION
That was a journey to get this Pull Request working.

At the beginning I discovered that the selector that I was using to get the parents commit sha from, isn't available on a Pull Request. Then I found out that GitHub returns different HTML markup when user is signed-in or signed-out. Last but not least, I figured out that Travis CI secretes are tied to the repository and that forks don't have access to the encrypted variables. 

For authenticated user we get the parent sha from a hidden input field named `comparison_start_oid`. For anonymous users we extract the sha from a URL I found in the markup (this is mainly needed to get CI working). On the master branch we run E2E tests as an authenticated user to have a real world environment. 