### PR TITLE
Support JS import in Vue files

### DIFF
--- a/packages/plugin-javascript/index.js
+++ b/packages/plugin-javascript/index.js
@@ -92,6 +92,7 @@ export default {
         /\.es6$/,
         // CoffeeScript
         /\.coffee$/,
+        /\.vue$/,
       ],
       githubClasses: [
         'type-javascript',
@@ -100,6 +101,7 @@ export default {
         // CoffeeScript
         'type-coffeescript',
         'highlight-source-coffee',
+        'type-vue',
       ],
     };
   },


### PR DESCRIPTION
This implements https://github.com/OctoLinker/OctoLinker/issues/496, which allows to jump to .js files from .vue.

This link should work:
https://github.com/vuejs/vue-hackernews-2.0/blob/master/src/components/Item.vue#L30

I'm not entirely sure regarding tests, can you point me how that should work?

### Checklist:

- [x] If this PR is a new feature, please provide at least one example link
- [ ] Make sure all of the significant new logic is covered by tests
