### PR TITLE
Rerun Octo-Linker when blobs are expanded

### DIFF
--- a/e2e/automated.test.js
+++ b/e2e/automated.test.js
@@ -69,4 +69,19 @@ describe('End to End tests', () => {
       });
     });
   });
+
+  describe('expanded blob', () => {
+    it('should resolve after appending new blobs', async () => {
+      const url =
+        'https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2';
+      const selector = '[data-line-number="45"] + td .octolinker-link';
+      const expandSelector = '[data-right-range="44-55"]';
+
+      await page.goto(url);
+
+      await page.click(expandSelector);
+
+      await page.waitForSelector(selector);
+    });
+  });
 });

--- a/packages/core/octo-linker.js
+++ b/packages/core/octo-linker.js
@@ -65,6 +65,16 @@ async function run(self) {
   clickHandler(matches);
 }
 
+function observeExpand(self) {
+  const observer = new MutationObserver(() => {
+    run(self);
+  });
+
+  for (const el of document.querySelectorAll('.diff-table tbody')) {
+    observer.observe(el, { childList: true });
+  }
+}
+
 export default class OctoLinkerCore {
   constructor(options) {
     initialize(this, options);
@@ -72,5 +82,6 @@ export default class OctoLinkerCore {
 
   init() {
     injection(run.bind(null, this));
+    observeExpand(this);
   }
 }


### PR DESCRIPTION
<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This is a possible implementation for #453, we observe the DOM, if any new `.blob-expanded` nodes are added, then the extension is rerun.

As far as testing goes, I will wait for feedback, I added a single test that clickes the specific `.js-expand` element and then tries to process a single line from it.

### Checklist:

- [ ] If this PR is a new feature, please provide at least one example link
- [x] Make sure all of the significant new logic is covered by tests
