### PR TITLE
Use eslint rather than webpack for e2e testing 

### DIFF
--- a/e2e/diff-fixtures.json
+++ b/e2e/diff-fixtures.json
@@ -8,11 +8,11 @@
     "targetUrl": "https://github.com/eslint/eslint"
   },
   {
-    "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L59",
-    "targetUrl": "https://github.com/webpack/webpack"
+    "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L42",
+    "targetUrl": "https://github.com/eslint/eslint"
   },
   {
-    "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R59",
-    "targetUrl": "https://github.com/webpack/webpack"
+    "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R42",
+    "targetUrl": "https://github.com/eslint/eslint"
   }
 ]


### PR DESCRIPTION
Webpack readme is overloaded with images wich is most likely the root cause why our e2e tests failing from time to time. 