### PR TITLE
Add support for linking to Docker entrypoint files

### DIFF
--- a/e2e/fixtures/docker/Dockerfile
+++ b/e2e/fixtures/docker/Dockerfile
@@ -1,0 +1,5 @@
+// @OctoLinkerResolve(https://hub.docker.com/_/php/)
+FROM php:php:5.6-apache
+
+// @OctoLinkerResolve(<root>/docker/docker-entrypoint.sh)
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -73,6 +73,10 @@ export const DOCKER_FROM = regex`
   FROM \s (?<$1>[^\n]*)
 `;
 
+export const DOCKER_ENTRYPOINT = regex`
+  ENTRYPOINT \s \[${captureQuotedWord}\]
+`;
+
 export const VIM_PLUGIN = regex`
   ${diffSigns}
   (

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -240,6 +240,10 @@ const fixtures = {
       // 'FROM\nfoo',
     ],
   },
+  DOCKER_ENTRYPOINT: {
+    valid: [['ENTRYPOINT ["foo-bar.sh"]', ['foo-bar.sh']]],
+    invalid: ['ENTRYPOINTfoobar'],
+  },
   VIM_PLUGIN: {
     valid: [
       ["Plugin 'VundleVim/Vundle.vim'", ['VundleVim/Vundle.vim']],

--- a/packages/plugin-docker/__tests__/index.js
+++ b/packages/plugin-docker/__tests__/index.js
@@ -1,46 +1,45 @@
-import assert from 'assert';
 import dockerImage from '../index';
 
 describe('docker-image', () => {
   const path = '/blob/path/dummy';
 
   it('resolves foo to https://hub.docker.com/_/foo', () => {
-    assert.deepEqual(dockerImage.resolve(path, ['foo']), [
+    expect(dockerImage.resolve(path, ['foo'])).toEqual([
       '{BASE_URL}/blob/path/foo',
       'https://hub.docker.com/_/foo',
     ]);
   });
 
   it('resolves foo:1.2.3 to https://hub.docker.com/_/foo', () => {
-    assert.deepEqual(dockerImage.resolve(path, ['foo:1.2.3']), [
+    expect(dockerImage.resolve(path, ['foo:1.2.3'])).toEqual([
       '{BASE_URL}/blob/path/foo:1.2.3',
       'https://hub.docker.com/_/foo',
     ]);
   });
 
   it('resolves foo:1.2.3-alpha to https://hub.docker.com/_/foo', () => {
-    assert.deepEqual(dockerImage.resolve(path, ['foo:1.2.3-alpha']), [
+    expect(dockerImage.resolve(path, ['foo:1.2.3-alpha'])).toEqual([
       '{BASE_URL}/blob/path/foo:1.2.3-alpha',
       'https://hub.docker.com/_/foo',
     ]);
   });
 
   it('resolves foo/bar to https://hub.docker.com/r/foo/bar', () => {
-    assert.deepEqual(dockerImage.resolve(path, ['foo/bar']), [
+    expect(dockerImage.resolve(path, ['foo/bar'])).toEqual([
       '{BASE_URL}/blob/path/foo/bar',
       'https://hub.docker.com/r/foo/bar',
     ]);
   });
 
   it('resolves foo/bar:1.2.3 to https://hub.docker.com/r/foo/bar', () => {
-    assert.deepEqual(dockerImage.resolve(path, ['foo/bar:1.2.3']), [
+    expect(dockerImage.resolve(path, ['foo/bar:1.2.3'])).toEqual([
       '{BASE_URL}/blob/path/foo/bar:1.2.3',
       'https://hub.docker.com/r/foo/bar',
     ]);
   });
 
   it('resolves foobar.sh to "{BASE_URL}/blob/path/foobar.sh" ', () => {
-    assert.deepEqual(dockerImage.resolve(path, ['foobar.sh']), [
+    expect(dockerImage.resolve(path, ['foobar.sh'])).toEqual([
       '{BASE_URL}/blob/path/foobar.sh',
       'https://hub.docker.com/_/foobar.sh',
     ]);

--- a/packages/plugin-docker/__tests__/index.js
+++ b/packages/plugin-docker/__tests__/index.js
@@ -1,35 +1,48 @@
+import assert from 'assert';
 import dockerImage from '../index';
 
 describe('docker-image', () => {
   const path = '/blob/path/dummy';
 
   it('resolves foo to https://hub.docker.com/_/foo', () => {
-    expect(dockerImage.resolve(path, ['foo'])).toBe(
+    assert.deepEqual(dockerImage.resolve(path, ['foo']), [
+      '{BASE_URL}/blob/path/foo',
       'https://hub.docker.com/_/foo',
-    );
+    ]);
   });
 
   it('resolves foo:1.2.3 to https://hub.docker.com/_/foo', () => {
-    expect(dockerImage.resolve(path, ['foo:1.2.3'])).toBe(
+    assert.deepEqual(dockerImage.resolve(path, ['foo:1.2.3']), [
+      '{BASE_URL}/blob/path/foo:1.2.3',
       'https://hub.docker.com/_/foo',
-    );
+    ]);
   });
 
   it('resolves foo:1.2.3-alpha to https://hub.docker.com/_/foo', () => {
-    expect(dockerImage.resolve(path, ['foo:1.2.3-alpha'])).toBe(
+    assert.deepEqual(dockerImage.resolve(path, ['foo:1.2.3-alpha']), [
+      '{BASE_URL}/blob/path/foo:1.2.3-alpha',
       'https://hub.docker.com/_/foo',
-    );
+    ]);
   });
 
   it('resolves foo/bar to https://hub.docker.com/r/foo/bar', () => {
-    expect(dockerImage.resolve(path, ['foo/bar'])).toBe(
+    assert.deepEqual(dockerImage.resolve(path, ['foo/bar']), [
+      '{BASE_URL}/blob/path/foo/bar',
       'https://hub.docker.com/r/foo/bar',
-    );
+    ]);
   });
 
   it('resolves foo/bar:1.2.3 to https://hub.docker.com/r/foo/bar', () => {
-    expect(dockerImage.resolve(path, ['foo/bar:1.2.3'])).toBe(
+    assert.deepEqual(dockerImage.resolve(path, ['foo/bar:1.2.3']), [
+      '{BASE_URL}/blob/path/foo/bar:1.2.3',
       'https://hub.docker.com/r/foo/bar',
-    );
+    ]);
+  });
+
+  it('resolves foobar.sh to "{BASE_URL}/blob/path/foobar.sh" ', () => {
+    assert.deepEqual(dockerImage.resolve(path, ['foobar.sh']), [
+      '{BASE_URL}/blob/path/foobar.sh',
+      'https://hub.docker.com/_/foobar.sh',
+    ]);
   });
 });

--- a/packages/plugin-docker/index.js
+++ b/packages/plugin-docker/index.js
@@ -1,4 +1,8 @@
-import { DOCKER_FROM } from '@octolinker/helper-grammar-regex-collection';
+import {
+  DOCKER_FROM,
+  DOCKER_ENTRYPOINT,
+} from '@octolinker/helper-grammar-regex-collection';
+import relativeFile from '@octolinker/resolver-relative-file';
 
 export default {
   name: 'Docker',
@@ -11,7 +15,10 @@ export default {
       isOffical = false;
     }
 
-    return `https://hub.docker.com/${isOffical ? '_' : 'r'}/${imageName}`;
+    return [
+      relativeFile({ path, target }),
+      `https://hub.docker.com/${isOffical ? '_' : 'r'}/${imageName}`,
+    ];
   },
 
   getPattern() {
@@ -22,6 +29,6 @@ export default {
   },
 
   getLinkRegexes() {
-    return DOCKER_FROM;
+    return [DOCKER_FROM, DOCKER_ENTRYPOINT];
   },
 };

--- a/packages/plugin-docker/package.json
+++ b/packages/plugin-docker/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "./index.js",
   "dependencies": {
-    "@octolinker/helper-grammar-regex-collection": "1.0.0"
+    "@octolinker/helper-grammar-regex-collection": "1.0.0",
+    "@octolinker/resolver-relative-file": "1.0.0"
   }
 }


### PR DESCRIPTION
Hey OctoLinker team, thank you for the great extension and reviewing my PR. Looking forward to your feedback. :)

Adds support for linking to relative Docker entrypoint files to the Docker plugin using the relative file resolver.

Closes issue #431 

### Checklist:

- [X] If this PR is a new feature, please provide at least one example link

The ENTRYPOINT line in [docker-library/wordpress:php5.6/apache/Dockerfile@6a085d9#L59](https://github.com/docker-library/wordpress/blob/6a085d90853b8baffadbd3f0a41d6814a2513c11/php5.6/apache/Dockerfile#L59) should resolve to [docker-library/wordpress:php5.6/apache/docker-entrypoint.sh@6a085d9](https://github.com/docker-library/wordpress/blob/6a085d90853b8baffadbd3f0a41d6814a2513c11/php5.6/apache/docker-entrypoint.sh)

Official repo links (example: `
FROM php:5.6-apache` on line 1 in the same file) should still resolve to hub.docker.com

- [x] Make sure all of the significant new logic is covered by tests
