### PR TITLE
Do not capture whitespace in Dockerfile image link

### DIFF
--- a/e2e/fixtures/docker/Dockerfile
+++ b/e2e/fixtures/docker/Dockerfile
@@ -1,8 +1,5 @@
 // @OctoLinkerResolve(https://hub.docker.com/_/php/)
 FROM php:php:5.6-apache
 
-// @OctoLinkerResolve(https://hub.docker.com/_/ubuntu/)
-FROM        ubuntu:16.04 AS base
-
 // @OctoLinkerResolve(<root>/docker/docker-entrypoint.sh)
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/e2e/fixtures/docker/Dockerfile
+++ b/e2e/fixtures/docker/Dockerfile
@@ -1,5 +1,8 @@
 // @OctoLinkerResolve(https://hub.docker.com/_/php/)
 FROM php:php:5.6-apache
 
+// @OctoLinkerResolve(https://hub.docker.com/_/ubuntu/)
+FROM        ubuntu:16.04 AS base
+
 // @OctoLinkerResolve(<root>/docker/docker-entrypoint.sh)
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -70,7 +70,7 @@ export const TYPESCRIPT_REFERENCE = regex`
 `;
 
 export const DOCKER_FROM = regex`
-  FROM \s (?<$1>[^\n]*)
+  FROM \s+ (?<$1>[^\n]*)
 `;
 
 export const DOCKER_ENTRYPOINT = regex`

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -233,6 +233,7 @@ const fixtures = {
       ['FROM foo', ['foo']],
       ['FROM foo:1.2.3', ['foo:1.2.3']],
       ['FROM foo:1.2.3-alpha', ['foo:1.2.3-alpha']],
+      ['FROM         foo:1.2.3-alpha', ['foo:1.2.3-alpha']],
       ['FROM foo/bar', ['foo/bar']],
     ],
     invalid: [


### PR DESCRIPTION
### Checklist:

- [x] If this PR is a new feature, please provide at least one example link

Fixes #515 - the Docker image link should not include the whitespace preceding `ubuntu:16.04 AS base` in https://github.com/jrottenberg/ffmpeg/blob/master/docker-images/4.0/ubuntu/Dockerfile#L8

- [x] Make sure all of the significant new logic is covered by tests
