### PR TITLE
Rerun octolinker after progressive-container has loaded

### DIFF
--- a/packages/core/octo-linker.js
+++ b/packages/core/octo-linker.js
@@ -82,10 +82,27 @@ export default class OctoLinkerCore {
   }
 
   init() {
-    injection(run.bind(null, this));
+    const runCb = run.bind(null, this);
+
+    injection(runCb);
+
+    const progressiveObserver = new MutationObserver((ch, ob) => {
+      $('.js-diff-progressive-container').each((idx, element) => {
+        ob.observe(element, {
+          childList: true,
+        });
+      });
+      runCb();
+    });
+
+    $('.js-diff-progressive-container').each((idx, element) => {
+      progressiveObserver.observe(element, {
+        childList: true,
+      });
+    });
 
     $('.js-expand').on('click', event => {
-      waitFor($(event.target).closest('tbody')[0], run.bind(null, this));
+      waitFor($(event.target).closest('tbody')[0], runCb);
     });
   }
 }


### PR DESCRIPTION
As I mentioned in #449, not all files are loaded within the document body. Github generates divs with the class `.js-diff-progressive-container`, that progressive container may load more content via fetch.

The goal of this PR is to watch for changes in `.js-diff-progressive-container` and rerun octolinker init accordingly. Beware that a `.js-diff-progressive-container`, may contain other progressive containers inside, such as this commit:

https://github.com/samuelkubai/skoolspace/commit/185017f5981fe6295cd8096dbf71f61896dd8a84

Div `#files` contains two `.js-diff-progressive-container`s at DOM ready. After scrolling, another nested `.js-diff-progressive-container` is inserted when more content is downloaded.

I can write a test if we decide to follow this route.

Closes #449 

### Checklist:

- [x] If this PR is a new feature, please provide at least one example link
- [ ] Make sure all of the significant new logic is covered by tests

