### PR TITLE
Fix PR linking after markup change

### DIFF
--- a/packages/blob-reader/fixtures/github.com/blob/89f13651df126efdb4f1e3ae40183c9fdccdb4d3.html
+++ b/packages/blob-reader/fixtures/github.com/blob/89f13651df126efdb4f1e3ae40183c9fdccdb4d3.html
@@ -18,47 +18,50 @@
 
 
 
-  <link crossorigin="anonymous" media="all" integrity="sha512-qQ+v+W1uJYfDMrQ/cwCVI+AGTsn1yi4rCU6KX45obe52BoF+WiHNeQ11u63iJA05vyivY57xNbhAsyK4/j1ZIQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/frameworks-01356238c65ce56a395237b592b58668.css" />
-  <link crossorigin="anonymous" media="all" integrity="sha512-I/jquBVUOVtEQ8ehveYgKO7ocZSEM5uc5vLFYM12R0EPDDFGfJOUf2gKgR3JBad6KH8L69CxKe0xyYLhMYLOsw==" rel="stylesheet" href="https://assets-cdn.github.com/assets/github-914619a4164d34dd9bc73702931c9f3b.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-lLo2nlsdl+bHLu6PGvC2j3wfP45RnK4wKQLiPnCDcuXfU38AiD+JCdMywnF3WbJC1jaxe3lAI6AM4uJuMFBLEw==" rel="stylesheet" href="https://assets-cdn.github.com/assets/frameworks-08fc49d3bd2694c870ea23d0906f3610.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-4kfWSrzu4OShEnC5m0lqUCfKkZfG7JH0ff4wnEtubTUTZqV5pS5oUMTOvWE2DDL7ttjZ9FpnZInl/0TLO3EIiA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/github-6c1d4c04bb55a87b9cb81ffdbd683662.css" />
   
   
-  <link crossorigin="anonymous" media="all" integrity="sha512-2jE+5s+6LV2ckEshC+YTwb0A/IhES9iLMcwfkkybRMMGemXcEjAx8wdd2ZbbVr1dYBJt+fkCaR+UvXiybFr/sA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/site-99075769314a73391cea9aa2907a29f9.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-PcJMPDRp7jbbEAmTk9kaL2kRQqg69QZ26WsZf07xsPyaipKsi3wVG0805PZNYXxotPDAliKKFvNSQPhD8fp1FQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/site-50c740d9290419d070dd6213a7cd03b5.css" />
+  
   
 
   <meta name="viewport" content="width=device-width">
   
   <title>testrepo/popular-rabbit-names.js at 89f13651df126efdb4f1e3ae40183c9fdccdb4d3 · OctoLinker/testrepo · GitHub</title>
-    <meta name="description" content="GitHub is where people build software. More than 28 million people use GitHub to discover, fork, and contribute to over 85 million projects.">
+    <meta name="description" content="Contribute to OctoLinker/testrepo development by creating an account on GitHub.">
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
   <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
   <meta property="fb:app_id" content="1401488693436528">
 
     
-    <meta property="og:image" content="https://avatars3.githubusercontent.com/u/10505593?s=400&amp;v=4" /><meta property="og:site_name" content="GitHub" /><meta property="og:type" content="object" /><meta property="og:title" content="OctoLinker/testrepo" /><meta property="og:url" content="https://github.com/OctoLinker/testrepo" /><meta property="og:description" content="Contribute to testrepo development by creating an account on GitHub." />
+    <meta property="og:image" content="https://avatars3.githubusercontent.com/u/10505593?s=400&amp;v=4" /><meta property="og:site_name" content="GitHub" /><meta property="og:type" content="object" /><meta property="og:title" content="OctoLinker/testrepo" /><meta property="og:url" content="https://github.com/OctoLinker/testrepo" /><meta property="og:description" content="Contribute to OctoLinker/testrepo development by creating an account on GitHub." />
 
   <link rel="assets" href="https://assets-cdn.github.com/">
   
   <meta name="pjax-timeout" content="1000">
   
-  <meta name="request-id" content="F361:1E00:5C65791:B227E48:5B607057" data-pjax-transient>
+  <meta name="request-id" content="3C45:5678:C3F380:168B9FB:5C028246" data-pjax-transient>
 
 
   
 
   <meta name="selected-link" value="repo_source" data-pjax-transient>
 
-    <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
-  <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
-  <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
-    <meta name="google-analytics" content="UA-3769691-2">
+      <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+    <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+    <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
 
-<meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="F361:1E00:5C65791:B227E48:5B607057" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
+  <meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="3C45:5678:C3F380:168B9FB:5C028246" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
 <meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/blob/show" data-pjax-transient="true" />
 
 
 
+    <meta name="google-analytics" content="UA-3769691-2">
+
 
 <meta class="js-ga-set" name="dimension1" content="Logged Out">
+
 
 
   
@@ -67,13 +70,13 @@
     <meta name="user-login" content="">
 
       <meta name="expected-hostname" content="github.com">
-    <meta name="js-proxy-site-detection-payload" content="Yzg3YTBkYmE1N2MzMTA5YWU3NGUyMzI2YTNmZWU1MDI4OWUyYjFlZWY1ZTk3YmYzMmUwM2M5MzExOWM4ODFhZXx7InJlbW90ZV9hZGRyZXNzIjoiNzguNDMuMjUuMjEyIiwicmVxdWVzdF9pZCI6IkYzNjE6MUUwMDo1QzY1NzkxOkIyMjdFNDg6NUI2MDcwNTciLCJ0aW1lc3RhbXAiOjE1MzMwNDY4NzEsImhvc3QiOiJnaXRodWIuY29tIn0=">
+    <meta name="js-proxy-site-detection-payload" content="ZjU4NDBmZWU5OTBlYzlkMWI1NTE2OTYxYTI0MDQyN2IxNGZmNmY1MTE3OTg4ZjU5NDExOTYyNGQ3YTE0NjE0M3x7InJlbW90ZV9hZGRyZXNzIjoiNDYuMjIzLjE5My4xODEiLCJyZXF1ZXN0X2lkIjoiM0M0NTo1Njc4OkMzRjM4MDoxNjhCOUZCOjVDMDI4MjQ2IiwidGltZXN0YW1wIjoxNTQzNjY4Mjk1LCJob3N0IjoiZ2l0aHViLmNvbSJ9">
 
-    <meta name="enabled-features" content="DASHBOARD_V2_LAYOUT_OPT_IN,EXPLORE_DISCOVER_REPOSITORIES,UNIVERSE_BANNER,FREE_TRIALS,MARKETPLACE_INSIGHTS,MARKETPLACE_PLAN_RESTRICTION_EDITOR,MARKETPLACE_SEARCH,MARKETPLACE_INSIGHTS_CONVERSION_PERCENTAGES">
+    <meta name="enabled-features" content="DASHBOARD_V2_LAYOUT_OPT_IN,EXPLORE_DISCOVER_REPOSITORIES,UNIVERSE_BANNER,MARKETPLACE_PLAN_RESTRICTION_EDITOR">
 
-  <meta name="html-safe-nonce" content="716f08cb123c909e80f9058fb9927d4381a10621">
+  <meta name="html-safe-nonce" content="1a921f3b66db69b5319d9c2ce501fe8a71f3da8d">
 
-  <meta http-equiv="x-pjax-version" content="667434520185c1ed6aaeb4d9a450ac61">
+  <meta http-equiv="x-pjax-version" content="cdc9a5bb30661c6c1c8e99ce4d3646f2">
   
 
       <link href="https://github.com/OctoLinker/testrepo/commits/89f13651df126efdb4f1e3ae40183c9fdccdb4d3.atom" rel="alternate" title="Recent Commits to testrepo:89f13651df126efdb4f1e3ae40183c9fdccdb4d3" type="application/atom+xml">
@@ -97,7 +100,7 @@
 
 
 
-<link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
+  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
 
   </head>
 
@@ -113,55 +116,129 @@
     
 
 
-
         
-
-
-  <header class="Header header-logged-out  position-relative f4 py-3" role="banner" >
-    <div class="container-lg d-flex px-3">
-      <div class="d-flex flex-justify-between flex-items-center">
-        <a class="header-logo-invertocat my-0" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark; experiment:site_header_dropdowns; group:control">
-          <svg height="32" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+<header class="Header header-logged-out  position-relative f4 py-3" role="banner">
+  <div class="container-lg d-flex px-3">
+    <div class="d-flex flex-justify-between flex-items-center">
+        <a class="mr-4" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark; experiment:site_header_dropdowns; group:dropdowns">
+          <svg height="32" class="octicon octicon-mark-github text-white" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
         </a>
+    </div>
 
+    <div class="HeaderMenu HeaderMenu--logged-out d-flex flex-justify-between flex-items-center flex-auto">
+      <div class="d-none">
+        <button class="btn-link js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
+          <svg height="24" class="octicon octicon-x text-gray" viewBox="0 0 12 16" version="1.1" width="18" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+        </button>
       </div>
 
-      <div class="HeaderMenu d-flex flex-justify-between flex-auto">
-          <nav class="mt-0">
-            <ul class="d-flex list-style-none">
-                <li class="ml-2">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:features; experiment:site_header_dropdowns; group:control" data-selected-links="/features /features/project-management /features/code-review /features/project-management /features/integrations /features" href="/features">
-                    Features
-</a>                </li>
-                <li class="ml-4">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:business; experiment:site_header_dropdowns; group:control" data-selected-links="/business /business/security /business/customers /business" href="/business">
-                    Business
-</a>                </li>
+        <nav class="mt-0" aria-label="Global">
+          <ul class="d-flex list-style-none">
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
+                    Why GitHub?
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 mt-0  p-4 left-n4 position-absolute">
+                    <a href="/features" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Features <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+                    <ul class="list-style-none f5 pb-3">
+                      <li class="edge-item-fix"><a href="/features/code-review/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code review">Code review</a></li>
+                      <li class="edge-item-fix"><a href="/features/project-management/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Project management">Project management</a></li>
+                      <li class="edge-item-fix"><a href="/features/integrations" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Integrations">Integrations</a></li>
+                      <li class="edge-item-fix"><a href="/features#team-management" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team management">Team management</a></li>
+                      <li class="edge-item-fix"><a href="/features#social-coding" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Social coding">Social coding</a></li>
+                      <li class="edge-item-fix"><a href="/features#documentation" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Documentation">Documentation</a></li>
+                      <li class="edge-item-fix"><a href="/features#code-hosting" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code hosting">Code hosting</a></li>
+                    </ul>
 
-                <li class="ml-4">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:explore; experiment:site_header_dropdowns; group:control" data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship showcases showcases_search showcases_landing /explore" href="/explore">
+                    <ul class="list-style-none mb-0 border-lg-top pt-lg-3">
+                      <li class="edge-item-fix"><a href="/case-studies" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Case studies">Case Studies <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="/security" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Security">Security <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+              <li class=" mr-3 mr-lg-3">
+                <a href="/business" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Business">Business</a>
+              </li>
+
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
                     Explore
-</a>                </li>
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
 
-                <li class="ml-4">
-                      <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:marketplace; experiment:site_header_dropdowns; group:control" data-selected-links=" /marketplace" href="/marketplace">
-                        Marketplace
-</a>                </li>
-                <li class="ml-4">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:pricing; experiment:site_header_dropdowns; group:control" data-selected-links="/pricing /pricing/developer /pricing/team /pricing/business-hosted /pricing/business-enterprise /pricing" href="/pricing">
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-0 mt-0  p-4 left-n4 position-absolute">
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/explore" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Explore GitHub <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Learn &amp; contribute</h4>
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/topics" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Topics">Topics</a></li>
+                      <li class="edge-item-fix"><a href="/collections" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Collections">Collections</a></li>
+                      <li class="edge-item-fix"><a href="/trending" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Trending">Trending</a></li>
+                      <li class="edge-item-fix"><a href="https://lab.github.com/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Learning lab">Learning Lab</a></li>
+                      <li class="edge-item-fix"><a href="https://opensource.guide" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Open source guides">Open source guides</a></li>
+                    </ul>
+
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Connect with others</h4>
+                    <ul class="list-style-none mb-0">
+                      <li class="edge-item-fix"><a href="/events" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Events">Events</a></li>
+                      <li class="edge-item-fix"><a href="https://github.community" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Community forum">Community forum</a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com" class="py-2 pb-0 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to GitHub Education">GitHub Education</a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+
+              <li class=" mr-3 mr-lg-3">
+                <a href="/marketplace" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Marketplace">Marketplace</a>
+              </li>
+
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
                     Pricing
-</a>                </li>
-            </ul>
-          </nav>
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                       <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
 
-        <div class="d-flex">
-            <div class="d-lg-flex flex-items-center mr-3">
-              <div class="header-search scoped-search site-scoped-search js-site-search position-relative js-jump-to"
-  role="search combobox"
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-4 mt-0  p-4 left-n4 position-absolute">
+                    <a href="/pricing" class="pb-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Pricing">Plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/pricing/developer" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Developers">Developer</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/team" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team">Team</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/business-cloud" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Business Cloud">Business Cloud</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/enterprise" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Enterprise">Enterprise</a></li>
+                    </ul>
+
+                    <ul class="list-style-none mb-0  border-top pt-3">
+                      <li class="edge-item-fix"><a href="/pricing#feature-comparison" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Compare features">Compare plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="/nonprofit" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Nonprofits">Nonprofit <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com/discount_requests/new" class="py-2 pb-0 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover"  data-ga-click="(Logged out) Header, go to Education">Education <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+          </ul>
+        </nav>
+
+      <div class="d-flex flex-items-center px-0 text-center text-left">
+          <div class="d-lg-flex mr-3">
+            <div class="header-search scoped-search site-scoped-search js-site-search position-relative js-jump-to"
+  role="combobox"
   aria-owns="jump-to-results"
   aria-label="Search or jump to"
   aria-haspopup="listbox"
-  aria-expanded="true"
+  aria-expanded="false"
 >
   <div class="position-relative">
     <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-site-search-form" data-scope-type="Repository" data-scope-id="45358638" data-scoped-search-url="/OctoLinker/testrepo/search" data-unscoped-search-url="/search" action="/OctoLinker/testrepo/search" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
@@ -177,72 +254,138 @@
           autocapitalize="off"
           aria-autocomplete="list"
           aria-controls="jump-to-results"
-          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=xBEEYaiW3yf4Rn7jOVYpY9IKLOxUDaE3uF3vugR2CQABDZFjCBFtNfl/pC+I7c0pVbhr3F/B5gyIJcftESrLGg=="
+          aria-label="Search"
+          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=00zKoiXH8tE6Dq33fFrgW/G2v2Q38ecTzOmQHFtdb1Sn77Wr+X6JgEkqUZ3TtdrWYMxXxUgZK/ovkRSV6/zOXw=="
           spellcheck="false"
           autocomplete="off"
           >
           <input type="hidden" class="js-site-search-type-field" name="type" >
-            <img src="https://assets-cdn.github.com/images/search-shortcut-hint.svg" alt="" class="mr-2 header-search-key-slash">
+            <img src="https://assets-cdn.github.com/images/search-key-slash.svg" alt="" class="mr-2 header-search-key-slash">
 
             <div class="Box position-absolute overflow-hidden d-none jump-to-suggestions js-jump-to-suggestions-container">
-              <ul class="d-none js-jump-to-suggestions-template-container">
-                <li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item">
-                  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center p-2 jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open" href="">
-                    <div class="jump-to-octicon js-jump-to-octicon mr-2 text-center d-none"></div>
-                    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar" alt="" aria-label="Team" src="" width="28" height="28">
+              
+<ul class="d-none js-jump-to-suggestions-template-container">
+  
 
-                    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
-                    </div>
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-suggestion" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
 
-                    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
-                      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
-                        In this repository
-                      </span>
-                      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
-                        All GitHub
-                      </span>
-                      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
-                    </div>
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
 
-                    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
-                      Jump to
-                      <span class="d-inline-block ml-1 v-align-middle">↵</span>
-                    </div>
-                  </a>
-                </li>
-                <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-repo-octicon-template" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-                <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-project-octicon-template" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-                <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-search-octicon-template" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
-              </ul>
-              <ul class="d-none js-jump-to-no-results-template-container">
-                <li class="d-flex flex-justify-center flex-items-center p-3 f5 d-none">
-                  <span class="text-gray">No suggested jump to results</span>
-                </li>
-              </ul>
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
 
-              <ul id="jump-to-results" class="js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container" >
-                <li class="d-flex flex-justify-center flex-items-center p-0 f5">
-                  <img src="https://assets-cdn.github.com/images/spinners/octocat-spinner-128.gif" alt="Octocat Spinner Icon" class="m-2" width="28">
-                </li>
-              </ul>
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+</ul>
+
+<ul class="d-none js-jump-to-no-results-template-container">
+  <li class="d-flex flex-justify-center flex-items-center f5 d-none js-jump-to-suggestion p-2">
+    <span class="text-gray">No suggested jump to results</span>
+  </li>
+</ul>
+
+<ul id="jump-to-results" role="listbox" class="p-0 m-0 js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container">
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-scoped-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-global-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+
+</ul>
+
             </div>
       </label>
 </form>  </div>
 </div>
 
-            </div>
+          </div>
 
-          <span class="d-inline-block">
-              <div class="HeaderNavlink px-0 py-2 m-0">
-                <a class="text-bold text-white no-underline" href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fblob%2F89f13651df126efdb4f1e3ae40183c9fdccdb4d3%2Fsourcereader%2Fpopular-rabbit-names.js" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in; experiment:site_header_dropdowns; group:control">Sign in</a>
-                  <span class="text-gray">or</span>
-                  <a class="text-bold text-white no-underline" href="/join?source=header-repo" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up; experiment:site_header_dropdowns; group:control">Sign up</a>
-              </div>
-          </span>
-        </div>
+        <a class="HeaderMenu-link no-underline mr-3" href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fblob%2F89f13651df126efdb4f1e3ae40183c9fdccdb4d3%2Fsourcereader%2Fpopular-rabbit-names.js" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign&nbsp;in</a>
+          <a class="HeaderMenu-link d-inline-block no-underline border border-gray-dark rounded-1 px-2 py-1" href="/join" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">Sign&nbsp;up</a>
       </div>
     </div>
-  </header>
+  </div>
+</header>
 
   </div>
 
@@ -255,7 +398,7 @@
 
 
 
-  <div role="main" class="application-main ">
+  <div role="main" class="application-main " >
         <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
     <div id="js-repo-pjax-container" data-pjax-container >
       
@@ -274,9 +417,9 @@
       <ul class="pagehead-actions">
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-s"
     aria-label="You must be signed in to watch a repository" rel="nofollow">
-    <svg class="octicon octicon-eye" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
+    <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
     Watch
   </a>
   <a class="social-count" href="/OctoLinker/testrepo/watchers"
@@ -288,9 +431,9 @@
 
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-s"
     aria-label="You must be signed in to star a repository" rel="nofollow">
-    <svg class="octicon octicon-star" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
+    <svg class="octicon octicon-star v-align-text-bottom" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
     Star
   </a>
 
@@ -303,9 +446,9 @@
 
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-        class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+        class="btn btn-sm btn-with-count tooltipped tooltipped-s"
         aria-label="You must be signed in to fork a repository" rel="nofollow">
-        <svg class="octicon octicon-repo-forked" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
+        <svg class="octicon octicon-repo-forked v-align-text-bottom" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
         Fork
       </a>
 
@@ -318,7 +461,7 @@
 
       <h1 class="public ">
   <svg class="octicon octicon-repo" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-  <span class="author" itemprop="author"><a class="url fn" rel="author" href="/OctoLinker">OctoLinker</a></span><!--
+  <span class="author" itemprop="author"><a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/OctoLinker/hovercard" href="/OctoLinker">OctoLinker</a></span><!--
 --><span class="path-divider">/</span><!--
 --><strong itemprop="name"><a data-pjax="#js-repo-pjax-container" href="/OctoLinker/testrepo">testrepo</a></strong>
 
@@ -329,11 +472,11 @@
 <nav class="reponav js-repo-nav js-sidenav-container-pjax container"
      itemscope
      itemtype="http://schema.org/BreadcrumbList"
-     role="navigation"
+    aria-label="Repository"
      data-pjax="#js-repo-pjax-container">
 
   <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-    <a class="js-selected-navigation-item selected reponav-item" itemprop="url" data-hotkey="g c" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /OctoLinker/testrepo" href="/OctoLinker/testrepo">
+    <a class="js-selected-navigation-item selected reponav-item" itemprop="url" data-hotkey="g c" aria-current="page" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /OctoLinker/testrepo" href="/OctoLinker/testrepo">
       <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"/></svg>
       <span itemprop="name">Code</span>
       <meta itemprop="position" content="1">
@@ -355,6 +498,7 @@
       <meta itemprop="position" content="3">
 </a>  </span>
 
+
     <a data-hotkey="g b" class="js-selected-navigation-item reponav-item" data-selected-links="repo_projects new_repo_project repo_project /OctoLinker/testrepo/projects" href="/OctoLinker/testrepo/projects">
       <svg class="octicon octicon-project" viewBox="0 0 15 16" version="1.1" width="15" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
       Projects
@@ -362,7 +506,7 @@
 </a>
 
 
-  <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse /OctoLinker/testrepo/pulse" href="/OctoLinker/testrepo/pulse">
+  <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse alerts security /OctoLinker/testrepo/pulse" href="/OctoLinker/testrepo/pulse">
     <svg class="octicon octicon-graph" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"/></svg>
     Insights
 </a>
@@ -376,14 +520,16 @@
   <div class="repository-content ">
 
     
-  <a class="d-none js-permalink-shortcut" data-hotkey="y" href="/OctoLinker/testrepo/blob/89f13651df126efdb4f1e3ae40183c9fdccdb4d3/sourcereader/popular-rabbit-names.js">Permalink</a>
 
-  <!-- blob contrib key: blob_contributors:v21:31acb4fe0f0a466e840eba89026d27a3 -->
+  
+    <a class="d-none js-permalink-shortcut" data-hotkey="y" href="/OctoLinker/testrepo/blob/89f13651df126efdb4f1e3ae40183c9fdccdb4d3/sourcereader/popular-rabbit-names.js">Permalink</a>
 
-      <div class="signup-prompt-bg rounded-1">
+    <!-- blob contrib key: blob_contributors:v21:31acb4fe0f0a466e840eba89026d27a3 -->
+
+        <div class="signup-prompt-bg rounded-1">
       <div class="signup-prompt p-4 text-center mb-4 rounded-1">
         <div class="position-relative">
-          <!-- '"` --><!-- </textarea></xmp> --></option></form><form action="/site/dismiss_signup_prompt" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="haftg/Xc9mBSN7G3mTRJInWYoUSMxIr2FXOjNJj95YXEewkot+/jTYSBV8RzzwE/ELVg6eN0hEdi+SkO+kzXPw==" />
+          <!-- '"` --><!-- </textarea></xmp> --></option></form><form action="/site/dismiss_signup_prompt" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="yBZDPiPrrrTLf6kwPD9MFsgLOnOKsgGx6zIVGoz9fl0sBJxUQUlgEbSQVuGcPMMWq/2+xjtf6ggG685eW+B28Q==" />
             <button type="submit" class="position-absolute top-0 right-0 btn-link link-gray" data-ga-click="(Logged out) Sign up prompt, clicked Dismiss, text:dismiss">
               Dismiss
             </button>
@@ -395,8 +541,8 @@
     </div>
 
 
-  <div class="file-navigation">
-    
+    <div class="file-navigation">
+      
 <div class="select-menu branch-select-menu js-menu-container js-select-menu float-left">
   <button class=" btn btn-sm select-menu-button js-menu-target css-truncate" data-hotkey="w"
     
@@ -417,7 +563,7 @@
         <div class="select-menu-text-filter">
           <input type="text" aria-label="Filter branches/tags" id="context-commitish-filter-field" class="form-control js-filterable-field js-navigation-enable" placeholder="Filter branches/tags">
         </div>
-        <div class="select-menu-tabs">
+        <div class="select-menu-tabs" role="tablist">
           <ul>
             <li class="select-menu-tab">
               <a href="#" data-tab-filter="branches" data-filter-placeholder="Filter branches/tags" class="js-select-menu-tab" role="tab">Branches</a>
@@ -472,38 +618,39 @@
   </div>
 </div>
 
-    <div class="BtnGroup float-right">
-      <a href="/OctoLinker/testrepo/find/89f13651df126efdb4f1e3ae40183c9fdccdb4d3"
-            class="js-pjax-capture-input btn btn-sm BtnGroup-item"
-            data-pjax
-            data-hotkey="t">
-        Find file
-      </a>
-      <clipboard-copy for="blob-path" class="btn btn-sm BtnGroup-item">
-        Copy path
-      </clipboard-copy>
-    </div>
-    <div id="blob-path" class="breadcrumb">
-      <span class="repo-root js-repo-root"><span class="js-path-segment"><a data-pjax="true" rel="nofollow" href="/OctoLinker/testrepo/tree/89f13651df126efdb4f1e3ae40183c9fdccdb4d3"><span>testrepo</span></a></span></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" rel="nofollow" href="/OctoLinker/testrepo/tree/89f13651df126efdb4f1e3ae40183c9fdccdb4d3/sourcereader"><span>sourcereader</span></a></span><span class="separator">/</span><strong class="final-path">popular-rabbit-names.js</strong>
-    </div>
-  </div>
-
-
-  <include-fragment src="/OctoLinker/testrepo/contributors/89f13651df126efdb4f1e3ae40183c9fdccdb4d3/sourcereader/popular-rabbit-names.js" class="commit-tease commit-loader">
-    <div>
-      Fetching contributors&hellip;
+      <div class="BtnGroup float-right">
+        <a href="/OctoLinker/testrepo/find/89f13651df126efdb4f1e3ae40183c9fdccdb4d3"
+              class="js-pjax-capture-input btn btn-sm BtnGroup-item"
+              data-pjax
+              data-hotkey="t">
+          Find file
+        </a>
+        <clipboard-copy for="blob-path" class="btn btn-sm BtnGroup-item">
+          Copy path
+        </clipboard-copy>
+      </div>
+      <div id="blob-path" class="breadcrumb">
+        <span class="repo-root js-repo-root"><span class="js-path-segment"><a data-pjax="true" rel="nofollow" href="/OctoLinker/testrepo/tree/89f13651df126efdb4f1e3ae40183c9fdccdb4d3"><span>testrepo</span></a></span></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" rel="nofollow" href="/OctoLinker/testrepo/tree/89f13651df126efdb4f1e3ae40183c9fdccdb4d3/sourcereader"><span>sourcereader</span></a></span><span class="separator">/</span><strong class="final-path">popular-rabbit-names.js</strong>
+      </div>
     </div>
 
-    <div class="commit-tease-contributors">
-        <img alt="" class="loader-loading float-left" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32-EAF2F5.gif" width="16" height="16" />
-      <span class="loader-error">Cannot retrieve contributors at this time</span>
-    </div>
+
+    <include-fragment src="/OctoLinker/testrepo/contributors/89f13651df126efdb4f1e3ae40183c9fdccdb4d3/sourcereader/popular-rabbit-names.js" class="commit-tease commit-loader">
+      <div>
+        Fetching contributors&hellip;
+      </div>
+
+      <div class="commit-tease-contributors">
+          <img alt="" class="loader-loading float-left" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32-EAF2F5.gif" width="16" height="16" />
+        <span class="loader-error">Cannot retrieve contributors at this time</span>
+      </div>
 </include-fragment>
 
 
-  <div class="file">
-    <div class="file-header">
+    <div class="file ">
+      <div class="file-header">
   <div class="file-actions">
+
 
     <div class="BtnGroup">
       <a id="raw-url" class="btn btn-sm BtnGroup-item" href="/OctoLinker/testrepo/raw/89f13651df126efdb4f1e3ae40183c9fdccdb4d3/sourcereader/popular-rabbit-names.js">Raw</a>
@@ -529,9 +676,9 @@
   </div>
 </div>
 
-    
+      
 
-  <div itemprop="text" class="blob-wrapper data type-javascript">
+  <div itemprop="text" class="blob-wrapper data type-javascript ">
       <table class="highlight tab-size js-file-line-container" data-tab-size="8">
       <tr>
         <td id="L1" class="blob-num js-line-number" data-line-number="1"></td>
@@ -568,7 +715,9 @@
 
   </div>
 
-  </div>
+    </div>
+
+  
 
   <details class="details-reset details-overlay details-overlay-dark">
     <summary data-hotkey="l" aria-label="Jump to line"></summary>
@@ -593,22 +742,22 @@
 <div class="footer container-lg px-3" role="contentinfo">
   <div class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light ">
     <ul class="list-style-none d-flex flex-wrap ">
-      <li class="mr-3">&copy; 2018 <span title="0.20338s from unicorn-b66bb5cf9-9j9wk">GitHub</span>, Inc.</li>
+      <li class="mr-3">&copy; 2018 <span title="0.16530s from unicorn-85db9678c4-rn74h">GitHub</span>, Inc.</li>
         <li class="mr-3"><a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms">Terms</a></li>
         <li class="mr-3"><a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy">Privacy</a></li>
-        <li class="mr-3"><a href="https://help.github.com/articles/github-security/" data-ga-click="Footer, go to security, text:security">Security</a></li>
+        <li class="mr-3"><a href="/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
         <li class="mr-3"><a href="https://status.github.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
         <li><a data-ga-click="Footer, go to help, text:help" href="https://help.github.com">Help</a></li>
     </ul>
 
-    <a aria-label="Homepage" title="GitHub" class="footer-octicon" href="https://github.com">
+    <a aria-label="Homepage" title="GitHub" class="footer-octicon mr-lg-4" href="https://github.com">
       <svg height="24" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
 </a>
    <ul class="list-style-none d-flex flex-wrap ">
         <li class="mr-3"><a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact">Contact GitHub</a></li>
+        <li class="mr-3"><a href="https://github.com/pricing" data-ga-click="Footer, go to Pricing, text:Pricing">Pricing</a></li>
       <li class="mr-3"><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
       <li class="mr-3"><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
-      <li class="mr-3"><a href="https://shop.github.com" data-ga-click="Footer, go to shop, text:shop">Shop</a></li>
         <li class="mr-3"><a href="https://blog.github.com" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
         <li><a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a></li>
 
@@ -630,10 +779,10 @@
   </div>
 
 
-    <script crossorigin="anonymous" integrity="sha512-wIuAKDhvxe9wCaNR1tzCk3rtl+wXEWC28rmRpzmx0h98VEeWC6Y3xCWV1xAW6NP6eQQX+x8ZGhW6Sdut+mLRuw==" type="application/javascript" src="https://assets-cdn.github.com/assets/compat-a48960bafc17c30572990bbab3664e9c.js"></script>
-    <script crossorigin="anonymous" integrity="sha512-T5YBL6byTrSWXd5XhwPeN91OHxxm7jO3OKRwlJpSbnzS8StPr/8h7OJKbLnVFO11CIbQGfv4rsGdsyRP2hyPDw==" type="application/javascript" src="https://assets-cdn.github.com/assets/frameworks-1a53a87937bf67db3a8755ade0d1aa93.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-WnyO4VoIUwWWQOmFLjYf4UGg/c1z9VlaLN8IMuiI3uMhhl6rejyThRdLPDyePeUPW6N+38OoBMs6AkqcvWALtA==" type="application/javascript" src="https://assets-cdn.github.com/assets/compat-b66b5d97b4442a01f057c74b091c4368.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-glXpCrOqxNGPFRZ0xGRWMgpYC4Xn/c/CL82vk2eeRostCZHF7Px1wBjxv6Wohcq9+xhM1Lt7DvrkWcSvF3j28w==" type="application/javascript" src="https://assets-cdn.github.com/assets/frameworks-7fcedd2a70cd3dde438cbad4c2d08128.js"></script>
     
-    <script crossorigin="anonymous" async="async" integrity="sha512-ZrDYjGIqlGGaG1GSHOH63EE/l7t50rQzDVzGjouPFMRY7kaFss37h4UiSGfJj0BjL2gX4Yeo7xNEUVE5GHcWaQ==" type="application/javascript" src="https://assets-cdn.github.com/assets/github-a81c60bf5144275576e157b9f381c39c.js"></script>
+    <script crossorigin="anonymous" async="async" integrity="sha512-NnkR3Qo+4D5ma5koFlDfAf9bKKHnuAC5BlrEUdKfDKZo46qS4hjt+C4Uw5KtLsTBASZoMneayDVNRxQRucQXqw==" type="application/javascript" src="https://assets-cdn.github.com/assets/github-927061254931b1e409112c1baeed3a26.js"></script>
     
     
     
@@ -651,6 +800,18 @@
     </button>
   </div>
 </div>
+
+  <template id="site-details-dialog">
+  <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark" open>
+    <summary aria-haspopup="dialog" aria-label="Close dialog"></summary>
+    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast">
+      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
+        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+      </button>
+      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
+    </details-dialog>
+  </details>
+</template>
 
   <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
   <div class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large" style="width:360px;">

--- a/packages/blob-reader/fixtures/github.com/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb_split.html
+++ b/packages/blob-reader/fixtures/github.com/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb_split.html
@@ -18,17 +18,18 @@
 
 
 
-  <link crossorigin="anonymous" media="all" integrity="sha512-qQ+v+W1uJYfDMrQ/cwCVI+AGTsn1yi4rCU6KX45obe52BoF+WiHNeQ11u63iJA05vyivY57xNbhAsyK4/j1ZIQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/frameworks-01356238c65ce56a395237b592b58668.css" />
-  <link crossorigin="anonymous" media="all" integrity="sha512-I/jquBVUOVtEQ8ehveYgKO7ocZSEM5uc5vLFYM12R0EPDDFGfJOUf2gKgR3JBad6KH8L69CxKe0xyYLhMYLOsw==" rel="stylesheet" href="https://assets-cdn.github.com/assets/github-914619a4164d34dd9bc73702931c9f3b.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-lLo2nlsdl+bHLu6PGvC2j3wfP45RnK4wKQLiPnCDcuXfU38AiD+JCdMywnF3WbJC1jaxe3lAI6AM4uJuMFBLEw==" rel="stylesheet" href="https://assets-cdn.github.com/assets/frameworks-08fc49d3bd2694c870ea23d0906f3610.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-4kfWSrzu4OShEnC5m0lqUCfKkZfG7JH0ff4wnEtubTUTZqV5pS5oUMTOvWE2DDL7ttjZ9FpnZInl/0TLO3EIiA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/github-6c1d4c04bb55a87b9cb81ffdbd683662.css" />
   
   
-  <link crossorigin="anonymous" media="all" integrity="sha512-2jE+5s+6LV2ckEshC+YTwb0A/IhES9iLMcwfkkybRMMGemXcEjAx8wdd2ZbbVr1dYBJt+fkCaR+UvXiybFr/sA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/site-99075769314a73391cea9aa2907a29f9.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-PcJMPDRp7jbbEAmTk9kaL2kRQqg69QZ26WsZf07xsPyaipKsi3wVG0805PZNYXxotPDAliKKFvNSQPhD8fp1FQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/site-50c740d9290419d070dd6213a7cd03b5.css" />
+  
   
 
   <meta name="viewport" content="width=device-width">
   
   <title>my personal favorites · OctoLinker/testrepo@b0775a9 · GitHub</title>
-    <meta name="description" content="GitHub is where people build software. More than 28 million people use GitHub to discover, fork, and contribute to over 85 million projects.">
+    <meta name="description" content="Contribute to OctoLinker/testrepo development by creating an account on GitHub.">
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
   <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
   <meta property="fb:app_id" content="1401488693436528">
@@ -40,25 +41,27 @@
   
   <meta name="pjax-timeout" content="1000">
   
-  <meta name="request-id" content="F363:1E00:5C658D9:B2280D1:5B607059" data-pjax-transient>
+  <meta name="request-id" content="3C3C:5678:C3F3D2:168BA93:5C028249" data-pjax-transient>
 
 
   
 
   <meta name="selected-link" value="repo_commits" data-pjax-transient>
 
-    <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
-  <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
-  <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
-    <meta name="google-analytics" content="UA-3769691-2">
+      <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+    <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+    <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
 
-<meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="F363:1E00:5C658D9:B2280D1:5B607059" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
+  <meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="3C3C:5678:C3F3D2:168BA93:5C028249" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
 <meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/commit/show" data-pjax-transient="true" />
 
 
 
+    <meta name="google-analytics" content="UA-3769691-2">
+
 
 <meta class="js-ga-set" name="dimension1" content="Logged Out">
+
 
 
   
@@ -67,13 +70,13 @@
     <meta name="user-login" content="">
 
       <meta name="expected-hostname" content="github.com">
-    <meta name="js-proxy-site-detection-payload" content="MGEzOWU3MjhmMDkyNmI2NGIzNmM1NzM0ZDFkZjM0Mjc0Y2RhYWIyMWI1MWI0OWJiOTA3ZDRmMjVjNDA1OTU4OHx7InJlbW90ZV9hZGRyZXNzIjoiNzguNDMuMjUuMjEyIiwicmVxdWVzdF9pZCI6IkYzNjM6MUUwMDo1QzY1OEQ5OkIyMjgwRDE6NUI2MDcwNTkiLCJ0aW1lc3RhbXAiOjE1MzMwNDY4NzQsImhvc3QiOiJnaXRodWIuY29tIn0=">
+    <meta name="js-proxy-site-detection-payload" content="MDE3ZDIzMzA1YThkZjE3OTJlYzQxNmZhNTA3MTdkMzMxMDcxZjI1ZTM5NDNjN2Y5ZWJmNzU3ZmIyYmViZmZmM3x7InJlbW90ZV9hZGRyZXNzIjoiNDYuMjIzLjE5My4xODEiLCJyZXF1ZXN0X2lkIjoiM0MzQzo1Njc4OkMzRjNEMjoxNjhCQTkzOjVDMDI4MjQ5IiwidGltZXN0YW1wIjoxNTQzNjY4Mjk3LCJob3N0IjoiZ2l0aHViLmNvbSJ9">
 
-    <meta name="enabled-features" content="DASHBOARD_V2_LAYOUT_OPT_IN,EXPLORE_DISCOVER_REPOSITORIES,UNIVERSE_BANNER,FREE_TRIALS,MARKETPLACE_INSIGHTS,MARKETPLACE_PLAN_RESTRICTION_EDITOR,MARKETPLACE_SEARCH,MARKETPLACE_INSIGHTS_CONVERSION_PERCENTAGES">
+    <meta name="enabled-features" content="DASHBOARD_V2_LAYOUT_OPT_IN,EXPLORE_DISCOVER_REPOSITORIES,UNIVERSE_BANNER,MARKETPLACE_PLAN_RESTRICTION_EDITOR">
 
-  <meta name="html-safe-nonce" content="2dc79999489a95ee0cdf1b0d440120450e94dab9">
+  <meta name="html-safe-nonce" content="fe9a948ce41721a5deb5ddcc07827e2cd2296268">
 
-  <meta http-equiv="x-pjax-version" content="667434520185c1ed6aaeb4d9a450ac61">
+  <meta http-equiv="x-pjax-version" content="cdc9a5bb30661c6c1c8e99ce4d3646f2">
   
 
       <link href="/OctoLinker/testrepo/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb.diff" rel="alternate" type="text/plain+diff" data-pjax-transient="true" />
@@ -100,7 +103,7 @@
 
 
 
-<link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
+  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
 
   </head>
 
@@ -116,55 +119,129 @@
     
 
 
-
         
-
-
-  <header class="Header header-logged-out  position-relative f4 py-3" role="banner" >
-    <div class="container-lg d-flex px-3">
-      <div class="d-flex flex-justify-between flex-items-center">
-        <a class="header-logo-invertocat my-0" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark; experiment:site_header_dropdowns; group:control">
-          <svg height="32" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+<header class="Header header-logged-out  position-relative f4 py-3" role="banner">
+  <div class="container-lg d-flex px-3">
+    <div class="d-flex flex-justify-between flex-items-center">
+        <a class="mr-4" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark; experiment:site_header_dropdowns; group:dropdowns">
+          <svg height="32" class="octicon octicon-mark-github text-white" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
         </a>
+    </div>
 
+    <div class="HeaderMenu HeaderMenu--logged-out d-flex flex-justify-between flex-items-center flex-auto">
+      <div class="d-none">
+        <button class="btn-link js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
+          <svg height="24" class="octicon octicon-x text-gray" viewBox="0 0 12 16" version="1.1" width="18" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+        </button>
       </div>
 
-      <div class="HeaderMenu d-flex flex-justify-between flex-auto">
-          <nav class="mt-0">
-            <ul class="d-flex list-style-none">
-                <li class="ml-2">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:features; experiment:site_header_dropdowns; group:control" data-selected-links="/features /features/project-management /features/code-review /features/project-management /features/integrations /features" href="/features">
-                    Features
-</a>                </li>
-                <li class="ml-4">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:business; experiment:site_header_dropdowns; group:control" data-selected-links="/business /business/security /business/customers /business" href="/business">
-                    Business
-</a>                </li>
+        <nav class="mt-0" aria-label="Global">
+          <ul class="d-flex list-style-none">
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
+                    Why GitHub?
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 mt-0  p-4 left-n4 position-absolute">
+                    <a href="/features" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Features <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+                    <ul class="list-style-none f5 pb-3">
+                      <li class="edge-item-fix"><a href="/features/code-review/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code review">Code review</a></li>
+                      <li class="edge-item-fix"><a href="/features/project-management/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Project management">Project management</a></li>
+                      <li class="edge-item-fix"><a href="/features/integrations" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Integrations">Integrations</a></li>
+                      <li class="edge-item-fix"><a href="/features#team-management" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team management">Team management</a></li>
+                      <li class="edge-item-fix"><a href="/features#social-coding" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Social coding">Social coding</a></li>
+                      <li class="edge-item-fix"><a href="/features#documentation" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Documentation">Documentation</a></li>
+                      <li class="edge-item-fix"><a href="/features#code-hosting" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code hosting">Code hosting</a></li>
+                    </ul>
 
-                <li class="ml-4">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:explore; experiment:site_header_dropdowns; group:control" data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship showcases showcases_search showcases_landing /explore" href="/explore">
+                    <ul class="list-style-none mb-0 border-lg-top pt-lg-3">
+                      <li class="edge-item-fix"><a href="/case-studies" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Case studies">Case Studies <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="/security" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Security">Security <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+              <li class=" mr-3 mr-lg-3">
+                <a href="/business" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Business">Business</a>
+              </li>
+
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
                     Explore
-</a>                </li>
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
 
-                <li class="ml-4">
-                      <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:marketplace; experiment:site_header_dropdowns; group:control" data-selected-links=" /marketplace" href="/marketplace">
-                        Marketplace
-</a>                </li>
-                <li class="ml-4">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:pricing; experiment:site_header_dropdowns; group:control" data-selected-links="/pricing /pricing/developer /pricing/team /pricing/business-hosted /pricing/business-enterprise /pricing" href="/pricing">
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-0 mt-0  p-4 left-n4 position-absolute">
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/explore" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Explore GitHub <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Learn &amp; contribute</h4>
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/topics" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Topics">Topics</a></li>
+                      <li class="edge-item-fix"><a href="/collections" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Collections">Collections</a></li>
+                      <li class="edge-item-fix"><a href="/trending" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Trending">Trending</a></li>
+                      <li class="edge-item-fix"><a href="https://lab.github.com/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Learning lab">Learning Lab</a></li>
+                      <li class="edge-item-fix"><a href="https://opensource.guide" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Open source guides">Open source guides</a></li>
+                    </ul>
+
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Connect with others</h4>
+                    <ul class="list-style-none mb-0">
+                      <li class="edge-item-fix"><a href="/events" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Events">Events</a></li>
+                      <li class="edge-item-fix"><a href="https://github.community" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Community forum">Community forum</a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com" class="py-2 pb-0 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to GitHub Education">GitHub Education</a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+
+              <li class=" mr-3 mr-lg-3">
+                <a href="/marketplace" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Marketplace">Marketplace</a>
+              </li>
+
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
                     Pricing
-</a>                </li>
-            </ul>
-          </nav>
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                       <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
 
-        <div class="d-flex">
-            <div class="d-lg-flex flex-items-center mr-3">
-              <div class="header-search scoped-search site-scoped-search js-site-search position-relative js-jump-to"
-  role="search combobox"
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-4 mt-0  p-4 left-n4 position-absolute">
+                    <a href="/pricing" class="pb-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Pricing">Plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/pricing/developer" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Developers">Developer</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/team" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team">Team</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/business-cloud" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Business Cloud">Business Cloud</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/enterprise" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Enterprise">Enterprise</a></li>
+                    </ul>
+
+                    <ul class="list-style-none mb-0  border-top pt-3">
+                      <li class="edge-item-fix"><a href="/pricing#feature-comparison" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Compare features">Compare plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="/nonprofit" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Nonprofits">Nonprofit <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com/discount_requests/new" class="py-2 pb-0 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover"  data-ga-click="(Logged out) Header, go to Education">Education <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+          </ul>
+        </nav>
+
+      <div class="d-flex flex-items-center px-0 text-center text-left">
+          <div class="d-lg-flex mr-3">
+            <div class="header-search scoped-search site-scoped-search js-site-search position-relative js-jump-to"
+  role="combobox"
   aria-owns="jump-to-results"
   aria-label="Search or jump to"
   aria-haspopup="listbox"
-  aria-expanded="true"
+  aria-expanded="false"
 >
   <div class="position-relative">
     <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-site-search-form" data-scope-type="Repository" data-scope-id="45358638" data-scoped-search-url="/OctoLinker/testrepo/search" data-unscoped-search-url="/search" action="/OctoLinker/testrepo/search" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
@@ -180,72 +257,138 @@
           autocapitalize="off"
           aria-autocomplete="list"
           aria-controls="jump-to-results"
-          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=b/BmNtdFnWpcPKPDpCrIbn5UEjdTRfGkYnVQZV8/Fm55JMCEZ2NVbzcOQ8cF3G588abWpNk/S1qjNM/zbX+uSA=="
+          aria-label="Search"
+          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=vrF4ZfyFdsTCKLpwXWEE+fuGDSAx2njulkKhDEI6igqq6cDDoSiNjYMBt1t7VqvcDTLsFAi1oppwFeT/EgdH3g=="
           spellcheck="false"
           autocomplete="off"
           >
           <input type="hidden" class="js-site-search-type-field" name="type" >
-            <img src="https://assets-cdn.github.com/images/search-shortcut-hint.svg" alt="" class="mr-2 header-search-key-slash">
+            <img src="https://assets-cdn.github.com/images/search-key-slash.svg" alt="" class="mr-2 header-search-key-slash">
 
             <div class="Box position-absolute overflow-hidden d-none jump-to-suggestions js-jump-to-suggestions-container">
-              <ul class="d-none js-jump-to-suggestions-template-container">
-                <li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item">
-                  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center p-2 jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open" href="">
-                    <div class="jump-to-octicon js-jump-to-octicon mr-2 text-center d-none"></div>
-                    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar" alt="" aria-label="Team" src="" width="28" height="28">
+              
+<ul class="d-none js-jump-to-suggestions-template-container">
+  
 
-                    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
-                    </div>
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-suggestion" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
 
-                    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
-                      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
-                        In this repository
-                      </span>
-                      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
-                        All GitHub
-                      </span>
-                      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
-                    </div>
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
 
-                    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
-                      Jump to
-                      <span class="d-inline-block ml-1 v-align-middle">↵</span>
-                    </div>
-                  </a>
-                </li>
-                <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-repo-octicon-template" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-                <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-project-octicon-template" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-                <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-search-octicon-template" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
-              </ul>
-              <ul class="d-none js-jump-to-no-results-template-container">
-                <li class="d-flex flex-justify-center flex-items-center p-3 f5 d-none">
-                  <span class="text-gray">No suggested jump to results</span>
-                </li>
-              </ul>
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
 
-              <ul id="jump-to-results" class="js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container" >
-                <li class="d-flex flex-justify-center flex-items-center p-0 f5">
-                  <img src="https://assets-cdn.github.com/images/spinners/octocat-spinner-128.gif" alt="Octocat Spinner Icon" class="m-2" width="28">
-                </li>
-              </ul>
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+</ul>
+
+<ul class="d-none js-jump-to-no-results-template-container">
+  <li class="d-flex flex-justify-center flex-items-center f5 d-none js-jump-to-suggestion p-2">
+    <span class="text-gray">No suggested jump to results</span>
+  </li>
+</ul>
+
+<ul id="jump-to-results" role="listbox" class="p-0 m-0 js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container">
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-scoped-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-global-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+
+</ul>
+
             </div>
       </label>
 </form>  </div>
 </div>
 
-            </div>
+          </div>
 
-          <span class="d-inline-block">
-              <div class="HeaderNavlink px-0 py-2 m-0">
-                <a class="text-bold text-white no-underline" href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fcommit%2Fb0775a93ea27ee381858ddd9fa2bb953d5b74acb%3Fdiff%3Dsplit" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in; experiment:site_header_dropdowns; group:control">Sign in</a>
-                  <span class="text-gray">or</span>
-                  <a class="text-bold text-white no-underline" href="/join?source=header-repo" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up; experiment:site_header_dropdowns; group:control">Sign up</a>
-              </div>
-          </span>
-        </div>
+        <a class="HeaderMenu-link no-underline mr-3" href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fcommit%2Fb0775a93ea27ee381858ddd9fa2bb953d5b74acb%3Fdiff%3Dsplit" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign&nbsp;in</a>
+          <a class="HeaderMenu-link d-inline-block no-underline border border-gray-dark rounded-1 px-2 py-1" href="/join" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">Sign&nbsp;up</a>
       </div>
     </div>
-  </header>
+  </div>
+</header>
 
   </div>
 
@@ -258,7 +401,7 @@
 
 
 
-  <div role="main" class="application-main ">
+  <div role="main" class="application-main " >
         <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
     <div id="js-repo-pjax-container" data-pjax-container >
       
@@ -276,9 +419,9 @@
       <ul class="pagehead-actions">
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-s"
     aria-label="You must be signed in to watch a repository" rel="nofollow">
-    <svg class="octicon octicon-eye" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
+    <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
     Watch
   </a>
   <a class="social-count" href="/OctoLinker/testrepo/watchers"
@@ -290,9 +433,9 @@
 
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-s"
     aria-label="You must be signed in to star a repository" rel="nofollow">
-    <svg class="octicon octicon-star" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
+    <svg class="octicon octicon-star v-align-text-bottom" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
     Star
   </a>
 
@@ -305,9 +448,9 @@
 
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-        class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+        class="btn btn-sm btn-with-count tooltipped tooltipped-s"
         aria-label="You must be signed in to fork a repository" rel="nofollow">
-        <svg class="octicon octicon-repo-forked" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
+        <svg class="octicon octicon-repo-forked v-align-text-bottom" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
         Fork
       </a>
 
@@ -320,7 +463,7 @@
 
       <h1 class="public ">
   <svg class="octicon octicon-repo" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-  <span class="author" itemprop="author"><a class="url fn" rel="author" href="/OctoLinker">OctoLinker</a></span><!--
+  <span class="author" itemprop="author"><a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/OctoLinker/hovercard" href="/OctoLinker">OctoLinker</a></span><!--
 --><span class="path-divider">/</span><!--
 --><strong itemprop="name"><a data-pjax="#js-repo-pjax-container" href="/OctoLinker/testrepo">testrepo</a></strong>
 
@@ -331,11 +474,11 @@
 <nav class="reponav js-repo-nav js-sidenav-container-pjax container"
      itemscope
      itemtype="http://schema.org/BreadcrumbList"
-     role="navigation"
+    aria-label="Repository"
      data-pjax="#js-repo-pjax-container">
 
   <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-    <a class="js-selected-navigation-item selected reponav-item" itemprop="url" data-hotkey="g c" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /OctoLinker/testrepo" href="/OctoLinker/testrepo">
+    <a class="js-selected-navigation-item selected reponav-item" itemprop="url" data-hotkey="g c" aria-current="page" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /OctoLinker/testrepo" href="/OctoLinker/testrepo">
       <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"/></svg>
       <span itemprop="name">Code</span>
       <meta itemprop="position" content="1">
@@ -357,6 +500,7 @@
       <meta itemprop="position" content="3">
 </a>  </span>
 
+
     <a data-hotkey="g b" class="js-selected-navigation-item reponav-item" data-selected-links="repo_projects new_repo_project repo_project /OctoLinker/testrepo/projects" href="/OctoLinker/testrepo/projects">
       <svg class="octicon octicon-project" viewBox="0 0 15 16" version="1.1" width="15" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
       Projects
@@ -364,7 +508,7 @@
 </a>
 
 
-  <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse /OctoLinker/testrepo/pulse" href="/OctoLinker/testrepo/pulse">
+  <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse alerts security /OctoLinker/testrepo/pulse" href="/OctoLinker/testrepo/pulse">
     <svg class="octicon octicon-graph" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"/></svg>
     Insights
 </a>
@@ -401,17 +545,17 @@
 </include-fragment></div>
 
 
-  <div class="commit-meta clearfix p-2 no-wrap d-flex flex-items-center">
+  <div class="commit-meta p-2 d-flex flex-wrap">
     
 <div class="AvatarStack flex-self-start ">
   <div class="AvatarStack-body" aria-label="stefanbuck">
 
-        <a class="avatar" data-skip-pjax="true" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">
+        <a class="avatar" data-skip-pjax="true" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">
           <img height="20" width="20" alt="@stefanbuck" src="https://avatars1.githubusercontent.com/u/1393946?s=60&amp;v=4" />
 </a>  </div>
 </div>
 
-    <div class="flex-auto">
+    <div class="flex-self-start no-wrap">
       
       <a href="/OctoLinker/testrepo/commits?author=stefanbuck"
      class="commit-author tooltipped tooltipped-s user-mention"
@@ -424,7 +568,7 @@
       
 
     </div>
-    <div>
+    <div class="flex-auto no-wrap text-right">
       <span class="sha-block" data-pjax>
         1 parent
           
@@ -441,10 +585,14 @@
       <a name="diff-stat"></a>
       <div id="toc" class="details-collapse table-of-contents js-details-container Details">
   <div class="BtnGroup float-right" data-ga-load="Diff, view, Viewed Split Diff">
-  <a class="btn btn-sm BtnGroup-item" href="https://github.com/OctoLinker/testrepo/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb?diff=unified">
+  <a class="btn btn-sm BtnGroup-item"
+    
+    href="https://github.com/OctoLinker/testrepo/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb?diff=unified">
     Unified
   </a>
-  <a class="btn btn-sm selected BtnGroup-item" href="https://github.com/OctoLinker/testrepo/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb?diff=split">
+  <a class="btn btn-sm BtnGroup-item selected"
+    aria-current="true"
+    href="https://github.com/OctoLinker/testrepo/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb?diff=split">
     Split
   </a>
 </div>
@@ -480,13 +628,13 @@
   </ol>
 </div>
 
-    <div id="files" class="diff-view ">
+    <div id="files" class="diff-view">
 
   <div class="js-diff-progressive-container">
     
 <a name="diff-ab228c9a0a59a4b87f2c9b2e700f1de6"></a>
 <div id="diff-0"
-     class="file js-file js-details-container Details
+     class="file js-file js-details-container Details Details--on open
              
              
              
@@ -494,7 +642,13 @@
              
               show-inline-notes
            ">
-  <div class="file-header js-file-header" data-path="sourcereader/popular-rabbit-names.js" data-short-path="ab228c9" data-anchor="diff-ab228c9a0a59a4b87f2c9b2e700f1de6">
+  <div class="file-header file-header--expandable js-file-header"
+    data-path="sourcereader/popular-rabbit-names.js"
+    data-short-path="ab228c9"
+    data-anchor="diff-ab228c9a0a59a4b87f2c9b2e700f1de6"
+    data-file-type=".js"
+    data-file-deleted="false"
+    >
     <div class="file-actions">
 
         <span class="show-file-notes pt-1">
@@ -504,12 +658,20 @@
           </label>
         </span>
 
-          <a href="/OctoLinker/testrepo/blob/b0775a93ea27ee381858ddd9fa2bb953d5b74acb/sourcereader/popular-rabbit-names.js" class="btn btn-sm tooltipped tooltipped-nw" rel="nofollow" aria-label="View the whole file at version b0775a9 ">View</a>
+          <div class="BtnGroup">
+            <a href="/OctoLinker/testrepo/blob/b0775a93ea27ee381858ddd9fa2bb953d5b74acb/sourcereader/popular-rabbit-names.js"
+              class="btn btn-sm tooltipped tooltipped-nw BtnGroup-item"
+              rel="nofollow"
+              aria-label="View the whole file at version b0775a9"
+              >
+              View file
+            </a>
+          </div>
 
 
-      <button type="button" class="btn-octicon p-1 pr-2 js-details-target" aria-label="Toggle diff text" aria-expanded="true">
-        <svg class="octicon octicon-chevron-down Details-content--shown" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M5 11L0 6l1.5-1.5L5 8.25 8.5 4.5 10 6l-5 5z"/></svg>
-        <svg class="octicon octicon-chevron-up Details-content--hidden" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"/></svg>
+      <button type="button" class="btn-octicon p-1 pr-2 js-details-target tooltipped tooltipped-nw" aria-label="Toggle diff contents" aria-expanded="true">
+        <svg class="octicon octicon-chevron-down Details-content--hidden" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M5 11L0 6l1.5-1.5L5 8.25 8.5 4.5 10 6l-5 5z"/></svg>
+        <svg class="octicon octicon-chevron-up Details-content--shown" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"/></svg>
       </button>
     </div>
     <div class="file-info">
@@ -521,10 +683,10 @@
       
     </div>
   </div>
-  <div class="js-file-content Details-content--shown">
+  <div class="js-file-content Details-content--hidden">
 
-        <div class="data highlight js-blob-wrapper" style="overflow-x: auto">
-          <table class="diff-table tab-size  file-diff-split" data-tab-size="8">
+        <div class="data highlight js-blob-wrapper " style="overflow-x: auto">
+          <table class="diff-table js-diff-table tab-size  file-diff-split js-file-diff-split" data-tab-size="8" data-diff-anchor="diff-ab228c9a0a59a4b87f2c9b2e700f1de6">
               <colgroup>
                 <col width="40">
                 <col>
@@ -532,8 +694,8 @@
                 <col>
               </colgroup>
             
-      <tr data-position="0">
-    <td id="diff-ab228c9a0a59a4b87f2c9b2e700f1de6L0" class="blob-num blob-num-hunk" data-line-number="..."></td>
+        <tr data-position="0">
+    <td id="diff-ab228c9a0a59a4b87f2c9b2e700f1de6HL0" class="blob-num blob-num-hunk" data-line-number="..."></td>
     <td class="blob-code blob-code-inner blob-code-hunk" colspan="3">@@ -1,5 +1,6 @@</td>
   </tr>
 
@@ -681,7 +843,6 @@
 
 
 
-
           </table>
         </div>
 
@@ -724,7 +885,7 @@
 
 
 
-  <div id="all_commit_comments" class="js-quote-selection-container" >
+  <div id="all_commit_comments" class="js-quote-selection-container" data-quote-markdown=".js-comment-body">
 
     <div class="commit-comments-heading">
       
@@ -777,22 +938,22 @@
 <div class="footer container-lg px-3" role="contentinfo">
   <div class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light ">
     <ul class="list-style-none d-flex flex-wrap ">
-      <li class="mr-3">&copy; 2018 <span title="0.31651s from unicorn-664794f569-54nxn">GitHub</span>, Inc.</li>
+      <li class="mr-3">&copy; 2018 <span title="0.31319s from unicorn-8685494797-b9ld7">GitHub</span>, Inc.</li>
         <li class="mr-3"><a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms">Terms</a></li>
         <li class="mr-3"><a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy">Privacy</a></li>
-        <li class="mr-3"><a href="https://help.github.com/articles/github-security/" data-ga-click="Footer, go to security, text:security">Security</a></li>
+        <li class="mr-3"><a href="/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
         <li class="mr-3"><a href="https://status.github.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
         <li><a data-ga-click="Footer, go to help, text:help" href="https://help.github.com">Help</a></li>
     </ul>
 
-    <a aria-label="Homepage" title="GitHub" class="footer-octicon" href="https://github.com">
+    <a aria-label="Homepage" title="GitHub" class="footer-octicon mr-lg-4" href="https://github.com">
       <svg height="24" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
 </a>
    <ul class="list-style-none d-flex flex-wrap ">
         <li class="mr-3"><a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact">Contact GitHub</a></li>
+        <li class="mr-3"><a href="https://github.com/pricing" data-ga-click="Footer, go to Pricing, text:Pricing">Pricing</a></li>
       <li class="mr-3"><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
       <li class="mr-3"><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
-      <li class="mr-3"><a href="https://shop.github.com" data-ga-click="Footer, go to shop, text:shop">Shop</a></li>
         <li class="mr-3"><a href="https://blog.github.com" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
         <li><a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a></li>
 
@@ -814,10 +975,10 @@
   </div>
 
 
-    <script crossorigin="anonymous" integrity="sha512-wIuAKDhvxe9wCaNR1tzCk3rtl+wXEWC28rmRpzmx0h98VEeWC6Y3xCWV1xAW6NP6eQQX+x8ZGhW6Sdut+mLRuw==" type="application/javascript" src="https://assets-cdn.github.com/assets/compat-a48960bafc17c30572990bbab3664e9c.js"></script>
-    <script crossorigin="anonymous" integrity="sha512-T5YBL6byTrSWXd5XhwPeN91OHxxm7jO3OKRwlJpSbnzS8StPr/8h7OJKbLnVFO11CIbQGfv4rsGdsyRP2hyPDw==" type="application/javascript" src="https://assets-cdn.github.com/assets/frameworks-1a53a87937bf67db3a8755ade0d1aa93.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-WnyO4VoIUwWWQOmFLjYf4UGg/c1z9VlaLN8IMuiI3uMhhl6rejyThRdLPDyePeUPW6N+38OoBMs6AkqcvWALtA==" type="application/javascript" src="https://assets-cdn.github.com/assets/compat-b66b5d97b4442a01f057c74b091c4368.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-glXpCrOqxNGPFRZ0xGRWMgpYC4Xn/c/CL82vk2eeRostCZHF7Px1wBjxv6Wohcq9+xhM1Lt7DvrkWcSvF3j28w==" type="application/javascript" src="https://assets-cdn.github.com/assets/frameworks-7fcedd2a70cd3dde438cbad4c2d08128.js"></script>
     
-    <script crossorigin="anonymous" async="async" integrity="sha512-ZrDYjGIqlGGaG1GSHOH63EE/l7t50rQzDVzGjouPFMRY7kaFss37h4UiSGfJj0BjL2gX4Yeo7xNEUVE5GHcWaQ==" type="application/javascript" src="https://assets-cdn.github.com/assets/github-a81c60bf5144275576e157b9f381c39c.js"></script>
+    <script crossorigin="anonymous" async="async" integrity="sha512-NnkR3Qo+4D5ma5koFlDfAf9bKKHnuAC5BlrEUdKfDKZo46qS4hjt+C4Uw5KtLsTBASZoMneayDVNRxQRucQXqw==" type="application/javascript" src="https://assets-cdn.github.com/assets/github-927061254931b1e409112c1baeed3a26.js"></script>
     
     
     
@@ -835,6 +996,18 @@
     </button>
   </div>
 </div>
+
+  <template id="site-details-dialog">
+  <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark" open>
+    <summary aria-haspopup="dialog" aria-label="Close dialog"></summary>
+    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast">
+      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
+        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+      </button>
+      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
+    </details-dialog>
+  </details>
+</template>
 
   <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
   <div class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large" style="width:360px;">

--- a/packages/blob-reader/fixtures/github.com/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb_unified.html
+++ b/packages/blob-reader/fixtures/github.com/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb_unified.html
@@ -18,17 +18,18 @@
 
 
 
-  <link crossorigin="anonymous" media="all" integrity="sha512-qQ+v+W1uJYfDMrQ/cwCVI+AGTsn1yi4rCU6KX45obe52BoF+WiHNeQ11u63iJA05vyivY57xNbhAsyK4/j1ZIQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/frameworks-01356238c65ce56a395237b592b58668.css" />
-  <link crossorigin="anonymous" media="all" integrity="sha512-I/jquBVUOVtEQ8ehveYgKO7ocZSEM5uc5vLFYM12R0EPDDFGfJOUf2gKgR3JBad6KH8L69CxKe0xyYLhMYLOsw==" rel="stylesheet" href="https://assets-cdn.github.com/assets/github-914619a4164d34dd9bc73702931c9f3b.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-lLo2nlsdl+bHLu6PGvC2j3wfP45RnK4wKQLiPnCDcuXfU38AiD+JCdMywnF3WbJC1jaxe3lAI6AM4uJuMFBLEw==" rel="stylesheet" href="https://assets-cdn.github.com/assets/frameworks-08fc49d3bd2694c870ea23d0906f3610.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-4kfWSrzu4OShEnC5m0lqUCfKkZfG7JH0ff4wnEtubTUTZqV5pS5oUMTOvWE2DDL7ttjZ9FpnZInl/0TLO3EIiA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/github-6c1d4c04bb55a87b9cb81ffdbd683662.css" />
   
   
-  <link crossorigin="anonymous" media="all" integrity="sha512-2jE+5s+6LV2ckEshC+YTwb0A/IhES9iLMcwfkkybRMMGemXcEjAx8wdd2ZbbVr1dYBJt+fkCaR+UvXiybFr/sA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/site-99075769314a73391cea9aa2907a29f9.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-PcJMPDRp7jbbEAmTk9kaL2kRQqg69QZ26WsZf07xsPyaipKsi3wVG0805PZNYXxotPDAliKKFvNSQPhD8fp1FQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/site-50c740d9290419d070dd6213a7cd03b5.css" />
+  
   
 
   <meta name="viewport" content="width=device-width">
   
   <title>my personal favorites · OctoLinker/testrepo@b0775a9 · GitHub</title>
-    <meta name="description" content="GitHub is where people build software. More than 28 million people use GitHub to discover, fork, and contribute to over 85 million projects.">
+    <meta name="description" content="Contribute to OctoLinker/testrepo development by creating an account on GitHub.">
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
   <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
   <meta property="fb:app_id" content="1401488693436528">
@@ -40,25 +41,27 @@
   
   <meta name="pjax-timeout" content="1000">
   
-  <meta name="request-id" content="F362:1E01:7718A40:DE5481E:5B607058" data-pjax-transient>
+  <meta name="request-id" content="3C11:567A:E5AD52:1A35D56:5C028247" data-pjax-transient>
 
 
   
 
   <meta name="selected-link" value="repo_commits" data-pjax-transient>
 
-    <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
-  <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
-  <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
-    <meta name="google-analytics" content="UA-3769691-2">
+      <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+    <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+    <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
 
-<meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="F362:1E01:7718A40:DE5481E:5B607058" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
+  <meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="3C11:567A:E5AD52:1A35D56:5C028247" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
 <meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/commit/show" data-pjax-transient="true" />
 
 
 
+    <meta name="google-analytics" content="UA-3769691-2">
+
 
 <meta class="js-ga-set" name="dimension1" content="Logged Out">
+
 
 
   
@@ -67,13 +70,13 @@
     <meta name="user-login" content="">
 
       <meta name="expected-hostname" content="github.com">
-    <meta name="js-proxy-site-detection-payload" content="Mzk3M2I5NzU2NGRhYTg5Njg4NTIxMTQ0NTE5NWMyNWY5NGNkODU1MTliZGY5YWM0N2VkNTJmNGU0MjFiOWVjZXx7InJlbW90ZV9hZGRyZXNzIjoiNzguNDMuMjUuMjEyIiwicmVxdWVzdF9pZCI6IkYzNjI6MUUwMTo3NzE4QTQwOkRFNTQ4MUU6NUI2MDcwNTgiLCJ0aW1lc3RhbXAiOjE1MzMwNDY4NzIsImhvc3QiOiJnaXRodWIuY29tIn0=">
+    <meta name="js-proxy-site-detection-payload" content="YjAyMDk3NDUwMmI1MjZmYjRlYmI0NTFkOTgyOTI5ZGRhMDIzZWI4ZGI4MGYzZmZiMWVkNzM3YzE2ZWRhMDRjM3x7InJlbW90ZV9hZGRyZXNzIjoiNDYuMjIzLjE5My4xODEiLCJyZXF1ZXN0X2lkIjoiM0MxMTo1NjdBOkU1QUQ1MjoxQTM1RDU2OjVDMDI4MjQ3IiwidGltZXN0YW1wIjoxNTQzNjY4Mjk2LCJob3N0IjoiZ2l0aHViLmNvbSJ9">
 
-    <meta name="enabled-features" content="DASHBOARD_V2_LAYOUT_OPT_IN,EXPLORE_DISCOVER_REPOSITORIES,UNIVERSE_BANNER,FREE_TRIALS,MARKETPLACE_INSIGHTS,MARKETPLACE_PLAN_RESTRICTION_EDITOR,MARKETPLACE_SEARCH,MARKETPLACE_INSIGHTS_CONVERSION_PERCENTAGES">
+    <meta name="enabled-features" content="DASHBOARD_V2_LAYOUT_OPT_IN,EXPLORE_DISCOVER_REPOSITORIES,UNIVERSE_BANNER,MARKETPLACE_PLAN_RESTRICTION_EDITOR">
 
-  <meta name="html-safe-nonce" content="12c7ae98ee2ed0e12e60f9066ee05ba293c3f503">
+  <meta name="html-safe-nonce" content="28b3495945047ca7b9d666e280bc33152e0d7a26">
 
-  <meta http-equiv="x-pjax-version" content="667434520185c1ed6aaeb4d9a450ac61">
+  <meta http-equiv="x-pjax-version" content="cdc9a5bb30661c6c1c8e99ce4d3646f2">
   
 
       <link href="/OctoLinker/testrepo/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb.diff" rel="alternate" type="text/plain+diff" data-pjax-transient="true" />
@@ -100,7 +103,7 @@
 
 
 
-<link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
+  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
 
   </head>
 
@@ -116,218 +119,129 @@
     
 
 
-
         
+<header class="Header header-logged-out  position-relative f4 py-3" role="banner">
+  <div class="container-lg d-flex px-3">
+    <div class="d-flex flex-justify-between flex-items-center">
+        <a class="mr-4" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark; experiment:site_header_dropdowns; group:dropdowns">
+          <svg height="32" class="octicon octicon-mark-github text-white" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+        </a>
+    </div>
 
-  <header class="Header header-logged-out  position-relative f4 py-3" role="banner" data-ga-load="(Logged out) Header, view, experiment:site_header_dropdowns; group:dropdowns">
-    <div class="container-lg d-flex px-3">
-      <div class="d-flex flex-justify-between flex-items-center">
-          <a class="mr-5" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark; experiment:site_header_dropdowns; group:dropdowns">
-            <svg height="32" class="octicon octicon-mark-github text-white" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
-          </a>
+    <div class="HeaderMenu HeaderMenu--logged-out d-flex flex-justify-between flex-items-center flex-auto">
+      <div class="d-none">
+        <button class="btn-link js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
+          <svg height="24" class="octicon octicon-x text-gray" viewBox="0 0 12 16" version="1.1" width="18" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+        </button>
       </div>
 
-      <div class="HeaderMenu HeaderMenu--experiment d-flex flex-justify-between flex-items-center flex-auto">
-        <div class="d-none">
-          <button class="btn-link js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
-            <svg height="24" class="octicon octicon-x text-gray" viewBox="0 0 12 16" version="1.1" width="18" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
-          </button>
-        </div>
+        <nav class="mt-0" aria-label="Global">
+          <ul class="d-flex list-style-none">
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
+                    Why GitHub?
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 mt-0  p-4 left-n4 position-absolute">
+                    <a href="/features" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Features <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+                    <ul class="list-style-none f5 pb-3">
+                      <li class="edge-item-fix"><a href="/features/code-review/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code review">Code review</a></li>
+                      <li class="edge-item-fix"><a href="/features/project-management/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Project management">Project management</a></li>
+                      <li class="edge-item-fix"><a href="/features/integrations" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Integrations">Integrations</a></li>
+                      <li class="edge-item-fix"><a href="/features#team-management" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team management">Team management</a></li>
+                      <li class="edge-item-fix"><a href="/features#social-coding" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Social coding">Social coding</a></li>
+                      <li class="edge-item-fix"><a href="/features#documentation" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Documentation">Documentation</a></li>
+                      <li class="edge-item-fix"><a href="/features#code-hosting" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code hosting">Code hosting</a></li>
+                    </ul>
 
-          <nav class="">
-            <ul class="d-flex list-style-none">
-                <li class="HeaderMenu-item dropdown mr-5">
-                  <details class="details-expanded details-reset js-dropdown-details ">
-                    <summary class="HeaderMenu-target text-white">
-                      <div class="d-flex flex-items-baseline flex-justify-between">
-                        <span class="d-inline-block mr-1">Features</span>
-                        <span class="dropdown-caret"></span>
-                      </div>
-                    </summary>
-                    <div class="dropdown-menu dropdown-menu-s p-4 ml-n4 mt-3 mt-lg-2">
-                      <a href="/features" class="d-block d-lg-flex flex-items-center flex-justify-between f5 link-gray-dark text-bold mb-2" data-ga-click="(Logged out) Header, go to Features, experiment:site_header_dropdowns; group:dropdowns"><span>Features overview</span> <svg height="16" class="octicon octicon-chevron-right text-gray-dark" viewBox="0 0 8 16" version="1.1" width="8" aria-hidden="true"><path fill-rule="evenodd" d="M7.5 8l-5 5L1 11.5 4.75 8 1 4.5 2.5 3l5 5z"/></svg></a>
-                      <hr class="border border-dashed my-3 d-none d-lg-block">
-                      <ul class="list-style-none f5">
-                        <li class="mb-2"><a href="/features/code-review/" class="d-block link-gray" data-ga-click="(Logged out) Header, go to Code review, experiment:site_header_dropdowns; group:dropdowns">Code review</a></li>
-                        <li class="mb-2"><a href="/features/project-management/" class="d-block link-gray" data-ga-click="(Logged out) Header, go to Project management, experiment:site_header_dropdowns; group:dropdowns">Project management</a></li>
-                        <li class="mb-2"><a href="/features/integrations" class="d-block link-gray" data-ga-click="(Logged out) Header, go to Integrations, experiment:site_header_dropdowns; group:dropdowns">Integrations</a></li>
-                        <li class="mb-2"><a href="/features#team-management" class="d-block link-gray" data-ga-click="(Logged out) Header, go to Team management, experiment:site_header_dropdowns; group:dropdowns">Team management</a></li>
-                        <li class="mb-2"><a href="/features#social-coding" class="d-block link-gray" data-ga-click="(Logged out) Header, go to Social coding, experiment:site_header_dropdowns; group:dropdowns">Social coding</a></li>
-                        <li class="mb-2"><a href="/features#documentation" class="d-block link-gray" data-ga-click="(Logged out) Header, go to Documentation, experiment:site_header_dropdowns; group:dropdowns">Documentation</a></li>
-                        <li class="mb-2"><a href="/features#code-hosting" class="d-block link-gray" data-ga-click="(Logged out) Header, go to Code hosting, experiment:site_header_dropdowns; group:dropdowns">Code hosting</a></li>
-                      </ul>
-                    </div>
-                  </details>
-                </li>
-                <li class="HeaderMenu-item dropdown platform-nav mr-5">
-                  <details class="details-expanded details-reset js-dropdown-details ">
-                    <summary class="HeaderMenu-target text-white">
-                      <div class="d-flex flex-items-baseline flex-justify-between">
-                        <span class="d-inline-block mr-1">Platform</span>
-                        <span class="dropdown-caret"></span>
-                      </div>
-                    </summary>
-                    <div class="dropdown-menu dropdown-menu-s p-4 ml-n4 mt-3 mt-lg-2">
-                      <div class="d-flex gutter-spacious ">
-                        <div class="position-relative col-8">
-                          <dl class="my-0">
-                            <a href="/marketplace" class="d-flex mb-3 link-gray-dark no-underline" data-ga-click="(Logged out) Header, go to Marketplace, experiment:site_header_dropdowns; group:dropdowns">
-                              <div class="mr-3">
-                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 70.92 56.98" class="d-block" width="34"><title>Asset 1</title><g data-name="Layer 2"><path d="M6.18 57H1a1 1 0 0 1 0-2h5.18a1 1 0 0 1 0 2zM69.92 57h-5.18a1 1 0 1 1 0-2h5.18a1 1 0 0 1 0 2z" fill="#2088ff"></path><path d="M29.67 56.47a1 1 0 0 1-1-1V34.84H16v20.23a1 1 0 0 1-2 0V33.84a1 1 0 0 1 1-1h14.67a1 1 0 0 1 1 1v21.63a1 1 0 0 1-1 1z" fill="#79b8ff"></path><path d="M64.74 57H6.18a1 1 0 0 1-1-1v-8.65a1 1 0 0 1 2 0V55h56.56V33.84a1 1 0 0 1 2 0V56a1 1 0 0 1-1 1zM6.18 41.24a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1h58.58a1 1 0 0 1 1 1v10.52a1 1 0 1 1-2 0V2H7.18v38.24a1 1 0 0 1-1 1z" fill="#2088ff"></path><path d="M56.82 45.94H36.34a1 1 0 0 1-1-1v-11.1a1 1 0 0 1 1-1h20.48a1 1 0 0 1 1 1v11.1a1 1 0 0 1-1 1zm-19.48-2h18.48v-9.1H37.34z" fill="#79b8ff"></path><path d="M31.55 27.5a7.84 7.84 0 0 1-5.21-2.42c-1.06-1-11.87-9.74-12-9.83a1 1 0 0 1 .66-1.78h43.66a1 1 0 0 1 .64.24l11.26 9.48a1 1 0 0 1-1.29 1.53l-11-9.25H17.81c3.26 2.65 9.08 7.4 9.88 8.12a6 6 0 0 0 3.87 1.9 3.3 3.3 0 0 0 3-1.95 1 1 0 1 1 1.82.82 5.3 5.3 0 0 1-4.83 3.14z" fill="#2088ff"></path><path d="M40.24 27.5a5.26 5.26 0 0 1-1.86-.34 1 1 0 0 1 .71-1.87 3.26 3.26 0 0 0 1.16.21 3.3 3.3 0 0 0 3-1.95 1 1 0 1 1 1.82.82 5.3 5.3 0 0 1-4.83 3.13zM48.82 27.5a5.26 5.26 0 0 1-1.82-.34 1 1 0 0 1 .71-1.87 3.26 3.26 0 0 0 1.16.21 3.3 3.3 0 0 0 3-1.95 1 1 0 1 1 1.82.82 5.3 5.3 0 0 1-4.87 3.13zM57.41 27.5a5.26 5.26 0 0 1-1.86-.34 1 1 0 0 1 .71-1.87 3.26 3.26 0 0 0 1.16.21 3.3 3.3 0 0 0 3-1.95 1 1 0 1 1 1.82.82 5.3 5.3 0 0 1-4.83 3.13zM66 27.5a5.26 5.26 0 0 1-1.86-.34 1 1 0 0 1 .71-1.87 3.26 3.26 0 0 0 1.15.21 3.3 3.3 0 0 0 3-2 1 1 0 0 1 1.82.82A5.31 5.31 0 0 1 66 27.5zM15 27.22a1 1 0 0 1-1-1V14.71a1 1 0 0 1 2 0v11.51a1 1 0 0 1-1 1z" fill="#2088ff"></path><path d="M44.16 25a1 1 0 0 1-.65-.24L38.07 20a1 1 0 0 1 1.3-1.52l5.43 4.67a1 1 0 0 1-.64 1.85zM35.52 25a1 1 0 0 1-.65-.24L29.44 20a1 1 0 0 1 1.3-1.52l5.43 4.67a1 1 0 0 1-.65 1.85zM52.74 25a1 1 0 0 1-.65-.24L46.66 20A1 1 0 0 1 48 18.53l5.43 4.67a1 1 0 0 1-.69 1.8zM61.33 25a1 1 0 0 1-.65-.24L55.25 20a1 1 0 0 1 1.3-1.52L62 23.2a1 1 0 0 1-.67 1.8zM22.23 8.42H6.51a1 1 0 0 1 0-2h15.72a1 1 0 0 1 0 2zM64.76 8.42H58.4a1 1 0 0 1 0-2h6.36a1 1 0 0 1 0 2z" fill="#2088ff"></path><path d="M46.58 45.72a1 1 0 0 1-1-1V34.1a1 1 0 0 1 2 0v10.62a1 1 0 0 1-1 1z" fill="#79b8ff"></path></g></svg>
+                    <ul class="list-style-none mb-0 border-lg-top pt-lg-3">
+                      <li class="edge-item-fix"><a href="/case-studies" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Case studies">Case Studies <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="/security" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Security">Security <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+              <li class=" mr-3 mr-lg-3">
+                <a href="/business" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Business">Business</a>
+              </li>
 
-                              </div>
-                              <div>
-                                <dt class="f4">Marketplace</dt>
-                                <dd class="f6 text-gray">Find developer tools that work with GitHub</dd>
-                              </div>
-                            </a>
-                            <a href="https://developer.github.com" class="d-flex mb-3 link-gray-dark no-underline" data-ga-click="(Logged out) Header, go to Developers, experiment:site_header_dropdowns; group:dropdowns">
-                              <div class="mr-3">
-                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 61.23 60.12" class="d-block" width="34"><title>Asset 1</title><g data-name="Layer 2"><path fill="none" stroke="#79b8ff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M14.75 13.22H3.52M18.02 6.33H6.54"></path><path fill="none" stroke="#2088ff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M56.96 51.89H45.73M60.23 44.99H48.75"></path><circle cx="22.5" cy="37.62" r="7.48" transform="rotate(-45 22.502 37.62)" fill="none" stroke="#2088ff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></circle><path d="M36.72 29.79l1.35 3.4 5.93 2V40l-5.92 2.08-1.44 3.39 2.83 5.58L36 54.54l-5.66-2.7L27 53.22l-2 5.9h-4.89L18 53.18l-3.36-1.4L9 54.58 5.58 51.1l2.7-5.66-1.38-3.37-5.9-2v-4.89l5.92-2.08 1.44-3.39-2.82-5.57L9 20.69l5.66 2.7L18 22l2-5.9h4.89L27 22l3.36 1.4L36 20.66l3.45 3.48z" fill="none" stroke="#2088ff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M7.22 22.48L9 20.69l5.66 2.7L18 22l2-5.9h4.89L27 22l3.36 1.4L36 20.66l3.45 3.48-2.7 5.66 1.35 3.4 5.93 2L44 40l-5.92 2.08-1.44 3.39 2.83 5.58-1.83 1.82" fill="none" stroke="#2088ff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" opacity=".1"></path><path d="M37.22 14.11a6.05 6.05 0 1 1 8.56 8.56M30.07 12l-2.29-4.51 2.81-2.79 4.58 2.19 2.72-1.12L39.5 1h4l1.64 4.8 2.71 1.14 4.54-2.26 2.79 2.81L53 12.06l1.09 2.75 4.8 1.58v4L54.09 22l-1.16 2.74 2.29 4.51-2.82 2.83-4.58-2.19" fill="none" stroke="#79b8ff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path><path d="M29.14 6.14l1.45-1.44 4.58 2.19 2.72-1.12L39.5 1h4l1.64 4.8 2.71 1.14 4.54-2.26 2.79 2.81L53 12.06l1.09 2.75 4.8 1.58v4L54.09 22l-1.16 2.74 2.29 4.51-1.48 1.47" fill="none" stroke="#79b8ff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" opacity=".1"></path></g></svg>
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
+                    Explore
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
 
-                              </div>
-                              <div>
-                                <dt class="f4">GitHub API</dt>
-                                <dd class="f6 text-gray">Start building on the GitHub platform</dd>
-                              </div>
-                            </a>
-                            <a href="https://partner.github.com/?source=github-header-loggedout&experiment=site_header_dropdowns&group=dropdowns" class="d-flex mb-3 link-gray-dark no-underline" data-ga-click="(Logged out) Header, go to Partner program, experiment:site_header_dropdowns; group:dropdowns">
-                              <div class="mr-3">
-                                <!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  --><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0px" y="0px" viewBox="0 0 37 23" style="enable-background:new 0 0 37 23;" xml:space="preserve" class="d-block" width="34">
-<style type="text/css">
-	.st0{fill:none;stroke:#79B8FF;stroke-linecap:round;stroke-linejoin:round;}
-	.st1{fill:none;stroke:#2088FF;stroke-linecap:round;stroke-linejoin:round;}
-</style>
-<path class="st0" d="M6,1l4.5,1.4L5.3,15.2L1,12.9L6,1z"></path>
-<path class="st1" d="M30.9,1.2L36,12.8l-3.9,2.6l-5.2-13L30.9,1.2z"></path>
-<path class="st1" d="M5.2,11.7c0-0.6-0.5-1-1-1c-0.6,0-1,0.5-1,1c0,0.6,0.5,1,1,1"></path>
-<path class="st0" d="M29.7,4.6c0.4,0,0.8-0.3,0.8-0.8v0c0-0.4-0.3-0.8-0.8-0.8h0c-0.4,0-0.8,0.3-0.8,0.8v0C29,4.3,29.3,4.6,29.7,4.6  L29.7,4.6z"></path>
-<path class="st0" d="M6.2,13.4c0,0,2.4,0.8,3.9,2.3L6.2,13.4z M9.6,4.8c0,0,4.3,2.3,6.9,2.8L9.6,4.8z"></path>
-<path class="st1" d="M30.4,11.5l-3.2,2.6"></path>
-<path class="st0" d="M19.7,9l8.7,6.2c0.4,0.3,1.1,1.2,0.4,2.2c-0.7,0.9-1.5,0.2-1.5,0.2l-6-4.2"></path>
-<path class="st1" d="M27.5,4.8c0,0-2,1.6-3.3,1.4c-1.3-0.2-4.7-0.9-4.7-0.9c-0.7,0.8-3.7,3.5-4.6,3.6c0,0-0.2,1.5,1.6,1.3  c1.7-0.2,2.7-0.9,3.7-1.7"></path>
-<path class="st0" d="M24.6,18.9c0,0,0.2,0.9-0.2,1.4c-0.2,0.3-0.7,0.6-1.3,0.3l-3.7-2.5L24.6,18.9z M27.1,17.6c0,0,0.1,0.9-0.5,1.4  c-0.3,0.3-0.8,0.6-1.5,0.3l-5.9-4.3L27.1,17.6z"></path>
-<path class="st0" d="M22.4,20.1c0,0,0,0.6-0.2,1.1c-0.2,0.3-0.4,0.6-1.1,0.4l-2.8-1.9"></path>
-<path class="st1" d="M17.8,17c0.3-0.3,1.6-0.2,1.4,1c-0.3,1.2-1.7,2.4-2.1,2.6c-0.4,0.2-1.4,0.2-1.4-0.7L17.8,17z M14.3,14.6  c0,0-0.7-1.5-1.5-1.2c-0.8,0.3-2.8,2-2.8,2.7c0,0.7,1,1.5,1.9,0.8L14.3,14.6z"></path>
-<path class="st1" d="M16.1,15.8c0.2-0.3,1.8-0.4,1.5,1.1c-0.3,1.4-2.1,2.7-2.4,2.9c-0.3,0.1-1.7,0.3-1.9-0.9"></path>
-<path class="st1" d="M15.9,16.1c0,0,0.5-0.9-0.1-1.5c-0.6-0.6-1.2-0.2-1.6,0.2c-0.3,0.3-2.9,2.8-2.9,2.8s0.5,1.8,1.7,1.3  C14.2,18.5,15.9,16.1,15.9,16.1z"></path>
-</svg>
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-0 mt-0  p-4 left-n4 position-absolute">
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/explore" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Explore GitHub <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
 
-                              </div>
-                              <div>
-                                <dt class="f4">Partner program</dt>
-                                <dd class="f6 text-gray">Help millions of developers do their best work</dd>
-                              </div>
-                            </a>
-                          </dl>
-                          <div class="d-none d-lg-block border-left position-absolute top-0 right-0 bottom-0"></div>
-                        </div>
-                        <div class="col-4">
-                          <strong class="d-block f5 text-bold mb-2 text-gray-dark">Apps by GitHub</strong>
-                          <ul class="list-style-none f5">
-                            <li class="mb-2"><a href="https://desktop.github.com/" class="link-gray" data-ga-click="(Logged out) Header, go to Desktop, experiment:site_header_dropdowns; group:dropdowns">Desktop <span style="color: #959da5;">&#8599;</span></a></li>
-                            <li class="mb-2"><a href="https://atom.io/" class="link-gray" data-ga-click="(Logged out) Header, go to Atom, experiment:site_header_dropdowns; group:dropdowns">Atom <span style="color: #959da5;">&#8599;</span></a></li>
-                            <li class="mb-2"><a href="https://visualstudio.github.com/" class="link-gray" data-ga-click="(Logged out) Header, go to Visual Studio, experiment:site_header_dropdowns; group:dropdowns">Visual Studio <span style="color: #959da5;">&#8599;</span></a></li>
-                            <li class="mb-2"><a href="https://unity.github.com/" class="link-gray" data-ga-click="(Logged out) Header, go to Unity Extension, experiment:site_header_dropdowns; group:dropdowns">Unity Extension <span style="color: #959da5;">&#8599;</span></a></li>
-                          </ul>
-                        </div>
-                      </div>
-                    </div>
-                  </details>
-                </li>
-                <li class="HeaderMenu-item dropdown mr-5">
-                  <details class="details-expanded details-reset js-dropdown-details ">
-                    <summary class="HeaderMenu-target text-white">
-                      <div class="d-flex flex-items-baseline flex-justify-between">
-                        <span class="d-inline-block mr-1">Business</span>
-                        <span class="dropdown-caret"></span>
-                      </div>
-                    </summary>
-                    <div class="dropdown-menu dropdown-menu-s p-4 ml-n4 mt-3 mt-lg-2">
-                      <a href="/business" class="d-block d-lg-flex flex-items-center flex-justify-between f5 link-gray-dark text-bold mb-2" data-ga-click="(Logged out) Header, go to Business, experiment:site_header_dropdowns; group:dropdowns"><span>Business overview</span> <svg height="16" class="octicon octicon-chevron-right text-gray-dark" viewBox="0 0 8 16" version="1.1" width="8" aria-hidden="true"><path fill-rule="evenodd" d="M7.5 8l-5 5L1 11.5 4.75 8 1 4.5 2.5 3l5 5z"/></svg></a>
-                      <hr class="border border-dashed my-3 d-none d-lg-block">
-                      <ul class="list-style-none f5">
-                        <li class="mb-2"><a href="/business/customers" class="d-block link-gray" data-ga-click="(Logged out) Header, go to Customers, experiment:site_header_dropdowns; group:dropdowns">Customers</a></li>
-                        <li class="mb-2"><a href="/business/security" class="d-block link-gray" data-ga-click="(Logged out) Header, go to Security, experiment:site_header_dropdowns; group:dropdowns">Security</a></li>
-                        <li class="mb-2"><a href="https://enterprise.github.com/contact" class="d-block link-gray" data-ga-click="(Logged out) Header, go to Contact, experiment:site_header_dropdowns; group:dropdowns">Contact</a></li>
-                      </ul>
-                    </div>
-                  </details>
-                </li>
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Learn &amp; contribute</h4>
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/topics" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Topics">Topics</a></li>
+                      <li class="edge-item-fix"><a href="/collections" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Collections">Collections</a></li>
+                      <li class="edge-item-fix"><a href="/trending" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Trending">Trending</a></li>
+                      <li class="edge-item-fix"><a href="https://lab.github.com/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Learning lab">Learning Lab</a></li>
+                      <li class="edge-item-fix"><a href="https://opensource.guide" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Open source guides">Open source guides</a></li>
+                    </ul>
 
-                <li class="HeaderMenu-item dropdown mr-5">
-                  <details class="details-expanded details-reset js-dropdown-details ">
-                    <summary class="HeaderMenu-target text-white">
-                      <div class="d-flex flex-items-baseline flex-justify-between">
-                        <span class="d-inline-block mr-1">Explore</span>
-                        <span class="dropdown-caret"></span>
-                      </div>
-                    </summary>
-                    <div class="dropdown-menu dropdown-menu-s p-4 ml-n4 mt-3 mt-lg-2">
-                      <ul class="list-style-none f5">
-                        <li class="mb-2"><a href="/explore" class="d-lg-flex flex-items-center flex-justify-between link-gray-dark text-bold" data-ga-click="(Logged out) Header, go to Explore GitHub, experiment:site_header_dropdowns; group:dropdowns"><span>Explore GitHub</span> <svg height="16" class="octicon octicon-chevron-right text-gray-dark" viewBox="0 0 8 16" version="1.1" width="8" aria-hidden="true"><path fill-rule="evenodd" d="M7.5 8l-5 5L1 11.5 4.75 8 1 4.5 2.5 3l5 5z"/></svg></a></li>
-                        <li class="mb-3"><a href="/trending" class="link-gray d-block" data-ga-click="(Logged out) Header, go to Trending, experiment:site_header_dropdowns; group:dropdowns">Trending</a></li>
-                      </ul>
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Connect with others</h4>
+                    <ul class="list-style-none mb-0">
+                      <li class="edge-item-fix"><a href="/events" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Events">Events</a></li>
+                      <li class="edge-item-fix"><a href="https://github.community" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Community forum">Community forum</a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com" class="py-2 pb-0 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to GitHub Education">GitHub Education</a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
 
-                      <hr class="border border-dashed my-3 d-none d-lg-block">
+              <li class=" mr-3 mr-lg-3">
+                <a href="/marketplace" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Marketplace">Marketplace</a>
+              </li>
 
-                      <strong class="d-block f5 text-bold mb-2 text-gray-dark">Learn</strong>
-                      <ul class="list-style-none f5">
-                        <li class="mb-2"><a href="/topics" class="link-gray d-block" data-ga-click="(Logged out) Header, go to Topics, experiment:site_header_dropdowns; group:dropdowns">Topics</a></li>
-                        <li class="mb-2"><a href="/collections" class="link-gray d-block" data-ga-click="(Logged out) Header, go to Collections, experiment:site_header_dropdowns; group:dropdowns">Collections</a></li>
-                        <li class="mb-2"><a href="https://lab.github.com/" class="link-gray d-block" data-ga-click="(Logged out) Header, go to Learning Lab, experiment:site_header_dropdowns; group:dropdowns">Learning Lab <span style="color: #959da5;">&#8599;</span></a></li>
-                        <li class="mb-3"><a href="https://opensource.guide/" class="link-gray d-block" data-ga-click="(Logged out) Header, go to Open source guides, experiment:site_header_dropdowns; group:dropdowns">Open source guides <span style="color: #959da5;">&#8599;</span></a></li>
-                      </ul>
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
+                    Pricing
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                       <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
 
-                      <hr class="border border-dashed my-3 d-none d-lg-block">
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-4 mt-0  p-4 left-n4 position-absolute">
+                    <a href="/pricing" class="pb-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Pricing">Plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/pricing/developer" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Developers">Developer</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/team" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team">Team</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/business-cloud" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Business Cloud">Business Cloud</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/enterprise" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Enterprise">Enterprise</a></li>
+                    </ul>
 
-                      <strong class="d-block f5 text-bold mb-2 text-gray-dark">Connect</strong>
-                      <ul class="list-style-none f5">
-                        <li class="mb-2"><a href="/events" class="link-gray d-block" data-ga-click="(Logged out) Header, go to Events, experiment:site_header_dropdowns; group:dropdowns">Events</a></li>
-                        <li class="mb-2"><a href="https://github.community/" class="link-gray d-block" data-ga-click="(Logged out) Header, go to Community forum, experiment:site_header_dropdowns; group:dropdowns">Community forum <span style="color: #959da5;">&#8599;</span></a></li>
-                        <li class="mb-3"><a href="https://education.github.community/" class="link-gray d-block" data-ga-click="(Logged out) Header, go to Education community, experiment:site_header_dropdowns; group:dropdowns">Education community <span style="color: #959da5;">&#8599;</span></a></li>
-                      </ul>
-                    </div>
-                  </details>
-                </li>
+                    <ul class="list-style-none mb-0  border-top pt-3">
+                      <li class="edge-item-fix"><a href="/pricing#feature-comparison" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Compare features">Compare plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="/nonprofit" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Nonprofits">Nonprofit <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com/discount_requests/new" class="py-2 pb-0 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover"  data-ga-click="(Logged out) Header, go to Education">Education <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+          </ul>
+        </nav>
 
-                <li class="HeaderMenu-item dropdown mr-5">
-                  <details class="details-expanded details-reset js-dropdown-details ">
-                    <summary class="HeaderMenu-target text-white">
-                      <div class="d-flex flex-items-baseline flex-justify-between">
-                        <span class="d-inline-block mr-1">Pricing</span>
-                        <span class="dropdown-caret"></span>
-                      </div>
-                    </summary>
-                    <div class="dropdown-menu dropdown-menu-s p-4 ml-n4 mt-3 mt-lg-2">
-                      <a href="/pricing" class="d-block d-lg-flex flex-items-center flex-justify-between f5 link-gray-dark text-bold mb-3" data-ga-click="(Logged out) Header, go to Pricing, experiment:site_header_dropdowns; group:dropdowns"><span>Pricing overview</span> <svg height="16" class="octicon octicon-chevron-right text-gray-dark" viewBox="0 0 8 16" version="1.1" width="8" aria-hidden="true"><path fill-rule="evenodd" d="M7.5 8l-5 5L1 11.5 4.75 8 1 4.5 2.5 3l5 5z"/></svg></a>
-                      <hr class="border border-dashed my-3 d-none d-lg-block">
-                      <strong class="d-block f5 text-bold text-gray-dark mb-2">Plans</strong>
-                      <ul class="list-style-none f5">
-                        <li class="mb-2"><a href="/pricing/developer" class="link-gray d-block" data-ga-click="(Logged out) Header, go to Developer, experiment:site_header_dropdowns; group:dropdowns">Developer</a></li>
-                        <li class="mb-2"><a href="/pricing/team" class="link-gray d-block" data-ga-click="(Logged out) Header, go to Team, experiment:site_header_dropdowns; group:dropdowns">Team</a></li>
-                        <li class="mb-2"><a href="/pricing/business-hosted" class="link-gray d-block" data-ga-click="(Logged out) Header, go to Business, experiment:site_header_dropdowns; group:dropdowns">Business</a></li>
-                        <li class="mb-3"><a href="/pricing#feature-comparison" class="link-gray d-block" data-ga-click="(Logged out) Header, go to Compare plans, experiment:site_header_dropdowns; group:dropdowns">Compare plans</a></li>
-                      </ul>
-                      <hr class="border border-dashed my-3 d-none d-lg-block">
-                      <ul class="list-style-none f5">
-                        <li class="mb-2"><a href="https://github.com/nonprofit" class="link-gray-dark" data-ga-click="(Logged out) Header, go to Nonprofits, experiment:site_header_dropdowns; group:dropdowns">Nonprofits</a></li>
-                        <li class="mb-2"><a href="https://education.github.com/discount_requests/new" class="link-gray-dark" data-ga-click="(Logged out) Header, go to Education, experiment:site_header_dropdowns; group:dropdowns">Education <span style="color: #959da5;">&#8599;</span></a></li>
-                      </ul>
-                    </div>
-                  </details>
-                </li>
-            </ul>
-          </nav>
-
-        <div class="d-flex flex-items-center">
-            <div class="d-flex mr-3 flex-items-center">
-              <div class="header-search scoped-search site-scoped-search js-site-search position-relative js-jump-to"
-  role="search combobox"
+      <div class="d-flex flex-items-center px-0 text-center text-left">
+          <div class="d-lg-flex mr-3">
+            <div class="header-search scoped-search site-scoped-search js-site-search position-relative js-jump-to"
+  role="combobox"
   aria-owns="jump-to-results"
   aria-label="Search or jump to"
   aria-haspopup="listbox"
-  aria-expanded="true"
+  aria-expanded="false"
 >
   <div class="position-relative">
     <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-site-search-form" data-scope-type="Repository" data-scope-id="45358638" data-scoped-search-url="/OctoLinker/testrepo/search" data-unscoped-search-url="/search" action="/OctoLinker/testrepo/search" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
@@ -343,68 +257,138 @@
           autocapitalize="off"
           aria-autocomplete="list"
           aria-controls="jump-to-results"
-          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=lC5a2uYzjrnhB8V3stOiSfGxgs0CubNSNtvVCFBF8EDoqQP4/Lj4atOWktarkWbQchYTLZkKMEGdD3RfHI3zAg=="
+          aria-label="Search"
+          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=a4pBhxvhzKA0hOmnwa+HCWChKrqHOmpRIL9LzP1OQ0iChTCYm4UrEt95Vy4mVbzYuSZi00c8lh6TFcNpe7lQUw=="
           spellcheck="false"
           autocomplete="off"
           >
           <input type="hidden" class="js-site-search-type-field" name="type" >
-            <img src="https://assets-cdn.github.com/images/search-shortcut-hint.svg" alt="" class="mr-2 header-search-key-slash">
+            <img src="https://assets-cdn.github.com/images/search-key-slash.svg" alt="" class="mr-2 header-search-key-slash">
 
             <div class="Box position-absolute overflow-hidden d-none jump-to-suggestions js-jump-to-suggestions-container">
-              <ul class="d-none js-jump-to-suggestions-template-container">
-                <li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item">
-                  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center p-2 jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open" href="">
-                    <div class="jump-to-octicon js-jump-to-octicon mr-2 text-center d-none"></div>
-                    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar" alt="" aria-label="Team" src="" width="28" height="28">
+              
+<ul class="d-none js-jump-to-suggestions-template-container">
+  
 
-                    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
-                    </div>
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-suggestion" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
 
-                    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
-                      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
-                        In this repository
-                      </span>
-                      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
-                        All GitHub
-                      </span>
-                      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
-                    </div>
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
 
-                    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
-                      Jump to
-                      <span class="d-inline-block ml-1 v-align-middle">↵</span>
-                    </div>
-                  </a>
-                </li>
-                <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-repo-octicon-template" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-                <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-project-octicon-template" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-                <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-search-octicon-template" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
-              </ul>
-              <ul class="d-none js-jump-to-no-results-template-container">
-                <li class="d-flex flex-justify-center flex-items-center p-3 f5 d-none">
-                  <span class="text-gray">No suggested jump to results</span>
-                </li>
-              </ul>
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
 
-              <ul id="jump-to-results" class="js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container" >
-                <li class="d-flex flex-justify-center flex-items-center p-0 f5">
-                  <img src="https://assets-cdn.github.com/images/spinners/octocat-spinner-128.gif" alt="Octocat Spinner Icon" class="m-2" width="28">
-                </li>
-              </ul>
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+</ul>
+
+<ul class="d-none js-jump-to-no-results-template-container">
+  <li class="d-flex flex-justify-center flex-items-center f5 d-none js-jump-to-suggestion p-2">
+    <span class="text-gray">No suggested jump to results</span>
+  </li>
+</ul>
+
+<ul id="jump-to-results" role="listbox" class="p-0 m-0 js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container">
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-scoped-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-global-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+
+</ul>
+
             </div>
       </label>
 </form>  </div>
 </div>
 
-            </div>
+          </div>
 
-          <a class="HeaderMenu-target text-white no-underline mr-3" href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fcommit%2Fb0775a93ea27ee381858ddd9fa2bb953d5b74acb%3Fdiff%3Dunified" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in; experiment:site_header_dropdowns; group:dropdowns">Sign&nbsp;in</a>
-            <a class="HeaderMenu-target d-inline-block text-white no-underline border border-gray-dark rounded-2 px-2 py-1" href="/join" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up; experiment:site_header_dropdowns; group:dropdowns">Sign&nbsp;up</a>
-        </div>
+        <a class="HeaderMenu-link no-underline mr-3" href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fcommit%2Fb0775a93ea27ee381858ddd9fa2bb953d5b74acb%3Fdiff%3Dunified" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign&nbsp;in</a>
+          <a class="HeaderMenu-link d-inline-block no-underline border border-gray-dark rounded-1 px-2 py-1" href="/join" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">Sign&nbsp;up</a>
       </div>
     </div>
-  </header>
-
+  </div>
+</header>
 
   </div>
 
@@ -417,7 +401,7 @@
 
 
 
-  <div role="main" class="application-main ">
+  <div role="main" class="application-main " >
         <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
     <div id="js-repo-pjax-container" data-pjax-container >
       
@@ -435,9 +419,9 @@
       <ul class="pagehead-actions">
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-s"
     aria-label="You must be signed in to watch a repository" rel="nofollow">
-    <svg class="octicon octicon-eye" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
+    <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
     Watch
   </a>
   <a class="social-count" href="/OctoLinker/testrepo/watchers"
@@ -449,9 +433,9 @@
 
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-s"
     aria-label="You must be signed in to star a repository" rel="nofollow">
-    <svg class="octicon octicon-star" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
+    <svg class="octicon octicon-star v-align-text-bottom" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
     Star
   </a>
 
@@ -464,9 +448,9 @@
 
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-        class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+        class="btn btn-sm btn-with-count tooltipped tooltipped-s"
         aria-label="You must be signed in to fork a repository" rel="nofollow">
-        <svg class="octicon octicon-repo-forked" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
+        <svg class="octicon octicon-repo-forked v-align-text-bottom" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
         Fork
       </a>
 
@@ -479,7 +463,7 @@
 
       <h1 class="public ">
   <svg class="octicon octicon-repo" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-  <span class="author" itemprop="author"><a class="url fn" rel="author" href="/OctoLinker">OctoLinker</a></span><!--
+  <span class="author" itemprop="author"><a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/OctoLinker/hovercard" href="/OctoLinker">OctoLinker</a></span><!--
 --><span class="path-divider">/</span><!--
 --><strong itemprop="name"><a data-pjax="#js-repo-pjax-container" href="/OctoLinker/testrepo">testrepo</a></strong>
 
@@ -490,11 +474,11 @@
 <nav class="reponav js-repo-nav js-sidenav-container-pjax container"
      itemscope
      itemtype="http://schema.org/BreadcrumbList"
-     role="navigation"
+    aria-label="Repository"
      data-pjax="#js-repo-pjax-container">
 
   <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-    <a class="js-selected-navigation-item selected reponav-item" itemprop="url" data-hotkey="g c" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /OctoLinker/testrepo" href="/OctoLinker/testrepo">
+    <a class="js-selected-navigation-item selected reponav-item" itemprop="url" data-hotkey="g c" aria-current="page" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /OctoLinker/testrepo" href="/OctoLinker/testrepo">
       <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"/></svg>
       <span itemprop="name">Code</span>
       <meta itemprop="position" content="1">
@@ -516,6 +500,7 @@
       <meta itemprop="position" content="3">
 </a>  </span>
 
+
     <a data-hotkey="g b" class="js-selected-navigation-item reponav-item" data-selected-links="repo_projects new_repo_project repo_project /OctoLinker/testrepo/projects" href="/OctoLinker/testrepo/projects">
       <svg class="octicon octicon-project" viewBox="0 0 15 16" version="1.1" width="15" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
       Projects
@@ -523,7 +508,7 @@
 </a>
 
 
-  <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse /OctoLinker/testrepo/pulse" href="/OctoLinker/testrepo/pulse">
+  <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse alerts security /OctoLinker/testrepo/pulse" href="/OctoLinker/testrepo/pulse">
     <svg class="octicon octicon-graph" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"/></svg>
     Insights
 </a>
@@ -560,17 +545,17 @@
 </include-fragment></div>
 
 
-  <div class="commit-meta clearfix p-2 no-wrap d-flex flex-items-center">
+  <div class="commit-meta p-2 d-flex flex-wrap">
     
 <div class="AvatarStack flex-self-start ">
   <div class="AvatarStack-body" aria-label="stefanbuck">
 
-        <a class="avatar" data-skip-pjax="true" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">
+        <a class="avatar" data-skip-pjax="true" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">
           <img height="20" width="20" alt="@stefanbuck" src="https://avatars1.githubusercontent.com/u/1393946?s=60&amp;v=4" />
 </a>  </div>
 </div>
 
-    <div class="flex-auto">
+    <div class="flex-self-start no-wrap">
       
       <a href="/OctoLinker/testrepo/commits?author=stefanbuck"
      class="commit-author tooltipped tooltipped-s user-mention"
@@ -583,7 +568,7 @@
       
 
     </div>
-    <div>
+    <div class="flex-auto no-wrap text-right">
       <span class="sha-block" data-pjax>
         1 parent
           
@@ -600,10 +585,14 @@
       <a name="diff-stat"></a>
       <div id="toc" class="details-collapse table-of-contents js-details-container Details">
   <div class="BtnGroup float-right" data-ga-load="Diff, view, Viewed Unified Diff">
-  <a class="btn btn-sm selected BtnGroup-item" href="https://github.com/OctoLinker/testrepo/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb?diff=unified">
+  <a class="btn btn-sm BtnGroup-item selected"
+    aria-current="true"
+    href="https://github.com/OctoLinker/testrepo/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb?diff=unified">
     Unified
   </a>
-  <a class="btn btn-sm BtnGroup-item" href="https://github.com/OctoLinker/testrepo/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb?diff=split">
+  <a class="btn btn-sm BtnGroup-item"
+    
+    href="https://github.com/OctoLinker/testrepo/commit/b0775a93ea27ee381858ddd9fa2bb953d5b74acb?diff=split">
     Split
   </a>
 </div>
@@ -639,13 +628,13 @@
   </ol>
 </div>
 
-    <div id="files" class="diff-view ">
+    <div id="files" class="diff-view">
 
   <div class="js-diff-progressive-container">
     
 <a name="diff-ab228c9a0a59a4b87f2c9b2e700f1de6"></a>
 <div id="diff-0"
-     class="file js-file js-details-container Details
+     class="file js-file js-details-container Details Details--on open
              
              
              
@@ -653,7 +642,13 @@
              
               show-inline-notes
            ">
-  <div class="file-header js-file-header" data-path="sourcereader/popular-rabbit-names.js" data-short-path="ab228c9" data-anchor="diff-ab228c9a0a59a4b87f2c9b2e700f1de6">
+  <div class="file-header file-header--expandable js-file-header"
+    data-path="sourcereader/popular-rabbit-names.js"
+    data-short-path="ab228c9"
+    data-anchor="diff-ab228c9a0a59a4b87f2c9b2e700f1de6"
+    data-file-type=".js"
+    data-file-deleted="false"
+    >
     <div class="file-actions">
 
         <span class="show-file-notes pt-1">
@@ -663,12 +658,20 @@
           </label>
         </span>
 
-          <a href="/OctoLinker/testrepo/blob/b0775a93ea27ee381858ddd9fa2bb953d5b74acb/sourcereader/popular-rabbit-names.js" class="btn btn-sm tooltipped tooltipped-nw" rel="nofollow" aria-label="View the whole file at version b0775a9 ">View</a>
+          <div class="BtnGroup">
+            <a href="/OctoLinker/testrepo/blob/b0775a93ea27ee381858ddd9fa2bb953d5b74acb/sourcereader/popular-rabbit-names.js"
+              class="btn btn-sm tooltipped tooltipped-nw BtnGroup-item"
+              rel="nofollow"
+              aria-label="View the whole file at version b0775a9"
+              >
+              View file
+            </a>
+          </div>
 
 
-      <button type="button" class="btn-octicon p-1 pr-2 js-details-target" aria-label="Toggle diff text" aria-expanded="true">
-        <svg class="octicon octicon-chevron-down Details-content--shown" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M5 11L0 6l1.5-1.5L5 8.25 8.5 4.5 10 6l-5 5z"/></svg>
-        <svg class="octicon octicon-chevron-up Details-content--hidden" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"/></svg>
+      <button type="button" class="btn-octicon p-1 pr-2 js-details-target tooltipped tooltipped-nw" aria-label="Toggle diff contents" aria-expanded="true">
+        <svg class="octicon octicon-chevron-down Details-content--hidden" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M5 11L0 6l1.5-1.5L5 8.25 8.5 4.5 10 6l-5 5z"/></svg>
+        <svg class="octicon octicon-chevron-up Details-content--shown" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"/></svg>
       </button>
     </div>
     <div class="file-info">
@@ -680,14 +683,14 @@
       
     </div>
   </div>
-  <div class="js-file-content Details-content--shown">
+  <div class="js-file-content Details-content--hidden">
 
-        <div class="data highlight js-blob-wrapper" style="overflow-x: auto">
-          <table class="diff-table tab-size  " data-tab-size="8">
+        <div class="data highlight js-blob-wrapper " style="overflow-x: auto">
+          <table class="diff-table js-diff-table tab-size  " data-tab-size="8" data-diff-anchor="diff-ab228c9a0a59a4b87f2c9b2e700f1de6">
             
-      <tr data-position="0">
-    <td id="diff-ab228c9a0a59a4b87f2c9b2e700f1de6L0" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
-    <td id="diff-ab228c9a0a59a4b87f2c9b2e700f1de6R0" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
+        <tr data-position="0">
+    <td id="diff-ab228c9a0a59a4b87f2c9b2e700f1de6HL0" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
+    <td id="diff-ab228c9a0a59a4b87f2c9b2e700f1de6HR0" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
     <td class="blob-code blob-code-inner blob-code-hunk">@@ -1,5 +1,6 @@</td>
   </tr>
 
@@ -843,7 +846,7 @@
 
 
 
-  <div id="all_commit_comments" class="js-quote-selection-container" >
+  <div id="all_commit_comments" class="js-quote-selection-container" data-quote-markdown=".js-comment-body">
 
     <div class="commit-comments-heading">
       
@@ -896,22 +899,22 @@
 <div class="footer container-lg px-3" role="contentinfo">
   <div class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light ">
     <ul class="list-style-none d-flex flex-wrap ">
-      <li class="mr-3">&copy; 2018 <span title="0.30125s from unicorn-866872178-5b7jc">GitHub</span>, Inc.</li>
+      <li class="mr-3">&copy; 2018 <span title="0.24100s from unicorn-8685494797-vcphf">GitHub</span>, Inc.</li>
         <li class="mr-3"><a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms">Terms</a></li>
         <li class="mr-3"><a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy">Privacy</a></li>
-        <li class="mr-3"><a href="https://help.github.com/articles/github-security/" data-ga-click="Footer, go to security, text:security">Security</a></li>
+        <li class="mr-3"><a href="/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
         <li class="mr-3"><a href="https://status.github.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
         <li><a data-ga-click="Footer, go to help, text:help" href="https://help.github.com">Help</a></li>
     </ul>
 
-    <a aria-label="Homepage" title="GitHub" class="footer-octicon" href="https://github.com">
+    <a aria-label="Homepage" title="GitHub" class="footer-octicon mr-lg-4" href="https://github.com">
       <svg height="24" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
 </a>
    <ul class="list-style-none d-flex flex-wrap ">
         <li class="mr-3"><a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact">Contact GitHub</a></li>
+        <li class="mr-3"><a href="https://github.com/pricing" data-ga-click="Footer, go to Pricing, text:Pricing">Pricing</a></li>
       <li class="mr-3"><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
       <li class="mr-3"><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
-      <li class="mr-3"><a href="https://shop.github.com" data-ga-click="Footer, go to shop, text:shop">Shop</a></li>
         <li class="mr-3"><a href="https://blog.github.com" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
         <li><a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a></li>
 
@@ -933,10 +936,10 @@
   </div>
 
 
-    <script crossorigin="anonymous" integrity="sha512-wIuAKDhvxe9wCaNR1tzCk3rtl+wXEWC28rmRpzmx0h98VEeWC6Y3xCWV1xAW6NP6eQQX+x8ZGhW6Sdut+mLRuw==" type="application/javascript" src="https://assets-cdn.github.com/assets/compat-a48960bafc17c30572990bbab3664e9c.js"></script>
-    <script crossorigin="anonymous" integrity="sha512-T5YBL6byTrSWXd5XhwPeN91OHxxm7jO3OKRwlJpSbnzS8StPr/8h7OJKbLnVFO11CIbQGfv4rsGdsyRP2hyPDw==" type="application/javascript" src="https://assets-cdn.github.com/assets/frameworks-1a53a87937bf67db3a8755ade0d1aa93.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-WnyO4VoIUwWWQOmFLjYf4UGg/c1z9VlaLN8IMuiI3uMhhl6rejyThRdLPDyePeUPW6N+38OoBMs6AkqcvWALtA==" type="application/javascript" src="https://assets-cdn.github.com/assets/compat-b66b5d97b4442a01f057c74b091c4368.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-glXpCrOqxNGPFRZ0xGRWMgpYC4Xn/c/CL82vk2eeRostCZHF7Px1wBjxv6Wohcq9+xhM1Lt7DvrkWcSvF3j28w==" type="application/javascript" src="https://assets-cdn.github.com/assets/frameworks-7fcedd2a70cd3dde438cbad4c2d08128.js"></script>
     
-    <script crossorigin="anonymous" async="async" integrity="sha512-ZrDYjGIqlGGaG1GSHOH63EE/l7t50rQzDVzGjouPFMRY7kaFss37h4UiSGfJj0BjL2gX4Yeo7xNEUVE5GHcWaQ==" type="application/javascript" src="https://assets-cdn.github.com/assets/github-a81c60bf5144275576e157b9f381c39c.js"></script>
+    <script crossorigin="anonymous" async="async" integrity="sha512-NnkR3Qo+4D5ma5koFlDfAf9bKKHnuAC5BlrEUdKfDKZo46qS4hjt+C4Uw5KtLsTBASZoMneayDVNRxQRucQXqw==" type="application/javascript" src="https://assets-cdn.github.com/assets/github-927061254931b1e409112c1baeed3a26.js"></script>
     
     
     
@@ -954,6 +957,18 @@
     </button>
   </div>
 </div>
+
+  <template id="site-details-dialog">
+  <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark" open>
+    <summary aria-haspopup="dialog" aria-label="Close dialog"></summary>
+    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast">
+      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
+        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+      </button>
+      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
+    </details-dialog>
+  </details>
+</template>
 
   <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
   <div class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large" style="width:360px;">

--- a/packages/blob-reader/fixtures/github.com/gist/113827963013e98c6196db51cd889c39.html
+++ b/packages/blob-reader/fixtures/github.com/gist/113827963013e98c6196db51cd889c39.html
@@ -19,47 +19,50 @@
 
 
 
-  <link crossorigin="anonymous" media="all" integrity="sha512-qQ+v+W1uJYfDMrQ/cwCVI+AGTsn1yi4rCU6KX45obe52BoF+WiHNeQ11u63iJA05vyivY57xNbhAsyK4/j1ZIQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/frameworks-01356238c65ce56a395237b592b58668.css" />
-  <link crossorigin="anonymous" media="all" integrity="sha512-I/jquBVUOVtEQ8ehveYgKO7ocZSEM5uc5vLFYM12R0EPDDFGfJOUf2gKgR3JBad6KH8L69CxKe0xyYLhMYLOsw==" rel="stylesheet" href="https://assets-cdn.github.com/assets/github-914619a4164d34dd9bc73702931c9f3b.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-lLo2nlsdl+bHLu6PGvC2j3wfP45RnK4wKQLiPnCDcuXfU38AiD+JCdMywnF3WbJC1jaxe3lAI6AM4uJuMFBLEw==" rel="stylesheet" href="https://assets-cdn.github.com/assets/frameworks-08fc49d3bd2694c870ea23d0906f3610.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-4kfWSrzu4OShEnC5m0lqUCfKkZfG7JH0ff4wnEtubTUTZqV5pS5oUMTOvWE2DDL7ttjZ9FpnZInl/0TLO3EIiA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/github-6c1d4c04bb55a87b9cb81ffdbd683662.css" />
   
   
-  <link crossorigin="anonymous" media="all" integrity="sha512-2jE+5s+6LV2ckEshC+YTwb0A/IhES9iLMcwfkkybRMMGemXcEjAx8wdd2ZbbVr1dYBJt+fkCaR+UvXiybFr/sA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/site-99075769314a73391cea9aa2907a29f9.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-PcJMPDRp7jbbEAmTk9kaL2kRQqg69QZ26WsZf07xsPyaipKsi3wVG0805PZNYXxotPDAliKKFvNSQPhD8fp1FQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/site-50c740d9290419d070dd6213a7cd03b5.css" />
+  
   
 
   <meta name="viewport" content="width=device-width">
   
   <title>package.json · GitHub</title>
-    <meta name="description" content="GitHub is where people build software. More than 28 million people use GitHub to discover, fork, and contribute to over 85 million projects.">
+    <meta name="description" content="GitHub Gist: instantly share code, notes, and snippets.">
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch-gist.xml" title="Gist">
   <link rel="fluid-icon" href="https://gist.github.com/fluidicon.png" title="GitHub">
   <meta property="fb:app_id" content="1401488693436528">
 
     
-    <meta property="og:image" content="https://avatars2.githubusercontent.com/u/6473925?s=400&amp;v=4" /><meta property="og:site_name" content="Gist" /><meta property="og:type" content="object" /><meta property="og:title" content="package.json" /><meta property="og:url" content="https://gist.github.com/josephfrazier/113827963013e98c6196db51cd889c39" />
+    <meta property="og:image" content="https://avatars2.githubusercontent.com/u/6473925?s=400&amp;v=4" /><meta property="og:site_name" content="Gist" /><meta property="og:type" content="article" /><meta property="og:title" content="package.json" /><meta property="og:url" content="https://gist.github.com/josephfrazier/113827963013e98c6196db51cd889c39" /><meta property="og:description" content="GitHub Gist: instantly share code, notes, and snippets." /><meta property="article:author" content="262588213843476" /><meta property="article:publisher" content="262588213843476" />
 
   <link rel="assets" href="https://assets-cdn.github.com/">
   
   <meta name="pjax-timeout" content="1000">
   
-  <meta name="request-id" content="F364:1DFF:3FAC7A1:7E9D2EE:5B60705B" data-pjax-transient>
+  <meta name="request-id" content="3CB4:5677:45517C:877ECE:5C02824A" data-pjax-transient>
 
 
   
 
   <meta name="selected-link" value="gist_code" data-pjax-transient>
 
-    <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
-  <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
-  <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
-    <meta name="google-analytics" content="UA-3769691-4">
+      <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+    <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+    <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
 
-<meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="gist" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="F364:1DFF:3FAC7A1:7E9D2EE:5B60705B" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
+  <meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="gist" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="3CB4:5677:45517C:877ECE:5C02824A" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
 <meta name="analytics-location" content="/&lt;user-name&gt;/&lt;gist-id&gt;" data-pjax-transient="true" /><meta name="octolytics-location" content="/&lt;user-name&gt;/&lt;gist-id&gt;" data-pjax-transient="true" />
 
 
 
+    <meta name="google-analytics" content="UA-3769691-4">
+
 
 <meta class="js-ga-set" name="dimension1" content="Logged Out">
+
 
 
     <meta name="octolytics-dimension-public" content="false" /><meta name="octolytics-dimension-gist_id" content="38678393" /><meta name="octolytics-dimension-gist_name" content="113827963013e98c6196db51cd889c39" /><meta name="octolytics-dimension-anonymous" content="false" /><meta name="octolytics-dimension-owner_id" content="6473925" /><meta name="octolytics-dimension-owner_login" content="josephfrazier" /><meta name="octolytics-dimension-forked" content="false" />
@@ -73,18 +76,18 @@
     <meta name="user-login" content="">
 
       <meta name="expected-hostname" content="gist.github.com">
-    <meta name="js-proxy-site-detection-payload" content="MjM4NTRhMTk3NDRhYmY1NGIxZWU1Mzg2MTY4MDQ2OGZiNWM5MjIwZGJiOTA4MzY3ZWI3MmUwMWI1M2JkODdlZHx7InJlbW90ZV9hZGRyZXNzIjoiNzguNDMuMjUuMjEyIiwicmVxdWVzdF9pZCI6IkYzNjQ6MURGRjozRkFDN0ExOjdFOUQyRUU6NUI2MDcwNUIiLCJ0aW1lc3RhbXAiOjE1MzMwNDY4NzUsImhvc3QiOiJnaXRodWIuY29tIn0=">
+    <meta name="js-proxy-site-detection-payload" content="NTk2MmU1MDJmMDMwNDRmNzUwYTNlOWU0NDdiNjdiNTMyMDM4OWIxY2FjZDgyYmI4MWViNzNmNTg2ZjE2MTY3YXx7InJlbW90ZV9hZGRyZXNzIjoiNDYuMjIzLjE5My4xODEiLCJyZXF1ZXN0X2lkIjoiM0NCNDo1Njc3OjQ1NTE3Qzo4NzdFQ0U6NUMwMjgyNEEiLCJ0aW1lc3RhbXAiOjE1NDM2NjgyOTgsImhvc3QiOiJnaXRodWIuY29tIn0=">
 
-    <meta name="enabled-features" content="DASHBOARD_V2_LAYOUT_OPT_IN,EXPLORE_DISCOVER_REPOSITORIES,UNIVERSE_BANNER,FREE_TRIALS,MARKETPLACE_INSIGHTS,MARKETPLACE_PLAN_RESTRICTION_EDITOR,MARKETPLACE_SEARCH,MARKETPLACE_INSIGHTS_CONVERSION_PERCENTAGES">
+    <meta name="enabled-features" content="DASHBOARD_V2_LAYOUT_OPT_IN,EXPLORE_DISCOVER_REPOSITORIES,UNIVERSE_BANNER,MARKETPLACE_PLAN_RESTRICTION_EDITOR">
 
-  <meta name="html-safe-nonce" content="b185f5094dacccee253cbd5d4bd7374f9a00fb36">
+  <meta name="html-safe-nonce" content="f2592db629c9ce48412ecd5e5c974e65cf0e656d">
 
-  <meta http-equiv="x-pjax-version" content="667434520185c1ed6aaeb4d9a450ac61">
+  <meta http-equiv="x-pjax-version" content="cdc9a5bb30661c6c1c8e99ce4d3646f2">
   
 
       <link href="/josephfrazier.atom" rel="alternate" title="atom" type="application/atom+xml">
   <meta name="robots" content="noindex, follow" />
-  <link crossorigin="anonymous" media="all" integrity="sha512-s5izTjOSqgRu8SWxiugZc3QB9arQpe/P6HS93znFSHjMupRGyaFjCxEyVVl0Y2Uy5JiP+na/w2pFN4Eqoky7uA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/gist-11b2ff91c36fc9775998eb84a7a2716c.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-06RIdj0Y59rnCMw3n7F+X92u/X/gVZQIXf+0sPuOm1BmZejSEDAK9BDMPfASUTeEfqJOby7mQ9VyVv01abrfSA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/gist-f441ad31a21ec676a63a57163679fa17.css" />
 
 
 
@@ -100,7 +103,6 @@
 
 
 
-<link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
 
   </head>
 
@@ -116,13 +118,12 @@
     
 
 
-
         <div class="Header gist-header header-logged-out" role="banner">
   <div class="container-lg px-3 clearfix">
     <div class="d-flex flex-justify-between">
       <div class="d-flex">
         <a class="header-logo-wordmark" data-hotkey="g d" aria-label="Gist Homepage" href="/">
-          <svg width="78" height="28" class="octicon octicon-logo-github" viewBox="0 0 45 16" version="1.1" aria-hidden="true"><path fill-rule="evenodd" d="M18.53 12.03h-.02c.009 0 .015.01.024.011h.006l-.01-.01zm.004.011c-.093.001-.327.05-.574.05-.78 0-1.05-.36-1.05-.83V8.13h1.59c.09 0 .16-.08.16-.19v-1.7c0-.09-.08-.17-.16-.17h-1.59V3.96c0-.08-.05-.13-.14-.13h-2.16c-.09 0-.14.05-.14.13v2.17s-1.09.27-1.16.28c-.08.02-.13.09-.13.17v1.36c0 .11.08.19.17.19h1.11v3.28c0 2.44 1.7 2.69 2.86 2.69.53 0 1.17-.17 1.27-.22.06-.02.09-.09.09-.16v-1.5a.177.177 0 0 0-.146-.18zm23.696-2.2c0-1.81-.73-2.05-1.5-1.97-.6.04-1.08.34-1.08.34v3.52s.49.34 1.22.36c1.03.03 1.36-.34 1.36-2.25zm2.43-.16c0 3.43-1.11 4.41-3.05 4.41-1.64 0-2.52-.83-2.52-.83s-.04.46-.09.52c-.03.06-.08.08-.14.08h-1.48c-.1 0-.19-.08-.19-.17l.02-11.11c0-.09.08-.17.17-.17h2.13c.09 0 .17.08.17.17v3.77s.82-.53 2.02-.53l-.01-.02c1.2 0 2.97.45 2.97 3.88zm-8.72-3.61h-2.1c-.11 0-.17.08-.17.19v5.44s-.55.39-1.3.39-.97-.34-.97-1.09V6.25c0-.09-.08-.17-.17-.17h-2.14c-.09 0-.17.08-.17.17v5.11c0 2.2 1.23 2.75 2.92 2.75 1.39 0 2.52-.77 2.52-.77s.05.39.08.45c.02.05.09.09.16.09h1.34c.11 0 .17-.08.17-.17l.02-7.47c0-.09-.08-.17-.19-.17zm-23.7-.01h-2.13c-.09 0-.17.09-.17.2v7.34c0 .2.13.27.3.27h1.92c.2 0 .25-.09.25-.27V6.23c0-.09-.08-.17-.17-.17zm-1.05-3.38c-.77 0-1.38.61-1.38 1.38 0 .77.61 1.38 1.38 1.38.75 0 1.36-.61 1.36-1.38 0-.77-.61-1.38-1.36-1.38zm16.49-.25h-2.11c-.09 0-.17.08-.17.17v4.09h-3.31V2.6c0-.09-.08-.17-.17-.17h-2.13c-.09 0-.17.08-.17.17v11.11c0 .09.09.17.17.17h2.13c.09 0 .17-.08.17-.17V8.96h3.31l-.02 4.75c0 .09.08.17.17.17h2.13c.09 0 .17-.08.17-.17V2.6c0-.09-.08-.17-.17-.17zM8.81 7.35v5.74c0 .04-.01.11-.06.13 0 0-1.25.89-3.31.89-2.49 0-5.44-.78-5.44-5.92S2.58 1.99 5.1 2c2.18 0 3.06.49 3.2.58.04.05.06.09.06.14L7.94 4.5c0 .09-.09.2-.2.17-.36-.11-.9-.33-2.17-.33-1.47 0-3.05.42-3.05 3.73s1.5 3.7 2.58 3.7c.92 0 1.25-.11 1.25-.11v-2.3H4.88c-.11 0-.19-.08-.19-.17V7.35c0-.09.08-.17.19-.17h3.74c.11 0 .19.08.19.17z"/></svg>
+          <svg width="78" height="28" class="octicon octicon-logo-github" viewBox="0 0 45 16" version="1.1" aria-hidden="true"><path fill-rule="evenodd" d="M18.53 12.03h-.02c.009 0 .015.01.024.011h.006l-.01-.01zm.004.011c-.093.001-.327.05-.574.05-.78 0-1.05-.36-1.05-.83V8.13h1.59c.09 0 .16-.08.16-.19v-1.7c0-.09-.08-.17-.16-.17h-1.59V3.96c0-.08-.05-.13-.14-.13h-2.16c-.09 0-.14.05-.14.13v2.17s-1.09.27-1.16.28c-.08.02-.13.09-.13.17v1.36c0 .11.08.19.17.19h1.11v3.28c0 2.44 1.7 2.69 2.86 2.69.53 0 1.17-.17 1.27-.22.06-.02.09-.09.09-.16v-1.5a.177.177 0 0 0-.146-.18zM42.23 9.84c0-1.81-.73-2.05-1.5-1.97-.6.04-1.08.34-1.08.34v3.52s.49.34 1.22.36c1.03.03 1.36-.34 1.36-2.25zm2.43-.16c0 3.43-1.11 4.41-3.05 4.41-1.64 0-2.52-.83-2.52-.83s-.04.46-.09.52c-.03.06-.08.08-.14.08h-1.48c-.1 0-.19-.08-.19-.17l.02-11.11c0-.09.08-.17.17-.17h2.13c.09 0 .17.08.17.17v3.77s.82-.53 2.02-.53l-.01-.02c1.2 0 2.97.45 2.97 3.88zm-8.72-3.61h-2.1c-.11 0-.17.08-.17.19v5.44s-.55.39-1.3.39-.97-.34-.97-1.09V6.25c0-.09-.08-.17-.17-.17h-2.14c-.09 0-.17.08-.17.17v5.11c0 2.2 1.23 2.75 2.92 2.75 1.39 0 2.52-.77 2.52-.77s.05.39.08.45c.02.05.09.09.16.09h1.34c.11 0 .17-.08.17-.17l.02-7.47c0-.09-.08-.17-.19-.17zm-23.7-.01h-2.13c-.09 0-.17.09-.17.2v7.34c0 .2.13.27.3.27h1.92c.2 0 .25-.09.25-.27V6.23c0-.09-.08-.17-.17-.17zm-1.05-3.38c-.77 0-1.38.61-1.38 1.38 0 .77.61 1.38 1.38 1.38.75 0 1.36-.61 1.36-1.38 0-.77-.61-1.38-1.36-1.38zm16.49-.25h-2.11c-.09 0-.17.08-.17.17v4.09h-3.31V2.6c0-.09-.08-.17-.17-.17h-2.13c-.09 0-.17.08-.17.17v11.11c0 .09.09.17.17.17h2.13c.09 0 .17-.08.17-.17V8.96h3.31l-.02 4.75c0 .09.08.17.17.17h2.13c.09 0 .17-.08.17-.17V2.6c0-.09-.08-.17-.17-.17zM8.81 7.35v5.74c0 .04-.01.11-.06.13 0 0-1.25.89-3.31.89-2.49 0-5.44-.78-5.44-5.92S2.58 1.99 5.1 2c2.18 0 3.06.49 3.2.58.04.05.06.09.06.14L7.94 4.5c0 .09-.09.2-.2.17-.36-.11-.9-.33-2.17-.33-1.47 0-3.05.42-3.05 3.73s1.5 3.7 2.58 3.7c.92 0 1.25-.11 1.25-.11v-2.3H4.88c-.11 0-.19-.08-.19-.17V7.35c0-.09.08-.17.19-.17h3.74c.11 0 .19.08.19.17z"/></svg>
           <svg width="40" height="28" class="octicon octicon-logo-gist" viewBox="0 0 25 16" version="1.1" aria-hidden="true"><path fill-rule="evenodd" d="M4.7 8.73h2.45v4.02c-.55.27-1.64.34-2.53.34-2.56 0-3.47-2.2-3.47-5.05 0-2.85.91-5.06 3.48-5.06 1.28 0 2.06.23 3.28.73V2.66C7.27 2.33 6.25 2 4.63 2 1.13 2 0 4.69 0 8.03c0 3.34 1.11 6.03 4.63 6.03 1.64 0 2.81-.27 3.59-.64V7.73H4.7v1zm6.39 3.72V6.06h-1.05v6.28c0 1.25.58 1.72 1.72 1.72v-.89c-.48 0-.67-.16-.67-.7v-.02zm.25-8.72c0-.44-.33-.78-.78-.78s-.77.34-.77.78.33.78.77.78.78-.34.78-.78zm4.34 5.69c-1.5-.13-1.78-.48-1.78-1.17 0-.77.33-1.34 1.88-1.34 1.05 0 1.66.16 2.27.36v-.94c-.69-.3-1.52-.39-2.25-.39-2.2 0-2.92 1.2-2.92 2.31 0 1.08.47 1.88 2.73 2.08 1.55.13 1.77.63 1.77 1.34 0 .73-.44 1.42-2.06 1.42-1.11 0-1.86-.19-2.33-.36v.94c.5.2 1.58.39 2.33.39 2.38 0 3.14-1.2 3.14-2.41 0-1.28-.53-2.03-2.75-2.23h-.03zm8.58-2.47v-.86h-2.42v-2.5l-1.08.31v2.11l-1.56.44v.48h1.56v5c0 1.53 1.19 2.13 2.5 2.13.19 0 .52-.02.69-.05v-.89c-.19.03-.41.03-.61.03-.97 0-1.5-.39-1.5-1.34V6.94h2.42v.02-.01z"/></svg>
 </a>
         <div class="site-search js-site-search" role="search">
@@ -171,7 +172,7 @@
 
 
 
-  <div role="main" class="application-main ">
+  <div role="main" class="application-main " >
         <div itemscope itemtype="http://schema.org/Code">
     <div id="gist-pjax-container" class="gist-content-wrapper" data-pjax-container>
       
@@ -179,7 +180,6 @@
 
   <div class="gist-detail-intro gist-banner">
     <div class="container">
-      <a class="btn btn-outline float-right" href="/">Create a gist now</a>
       <p class="lead">
         Instantly share code, notes, and snippets.
       </p>
@@ -276,7 +276,7 @@
                     Share
                   </span>
                     <span class="description">
-                      Copy sharable URL for this gist.
+                      Copy sharable link for this gist.
                     </span>
                 </div>
               </button>
@@ -313,7 +313,8 @@
     <input
       id="gist-share-url"
       type="text"
-      class="form-control input-monospace input-sm js-url-field"
+      data-autoselect
+      class="form-control input-monospace input-sm"
       value="&lt;script src=&quot;https://gist.github.com/josephfrazier/113827963013e98c6196db51cd889c39.js&quot;&gt;&lt;/script&gt;"
       aria-label="Clone this repository at &lt;script src=&quot;https://gist.github.com/josephfrazier/113827963013e98c6196db51cd889c39.js&quot;&gt;&lt;/script&gt;"
       readonly>
@@ -346,7 +347,7 @@
      role="navigation"
      data-pjax="#gist-pjax-container">
 
-  <a class="js-selected-navigation-item selected reponav-item" aria-label="Code" data-pjax="true" data-hotkey="g c" data-selected-links="gist_code /josephfrazier/113827963013e98c6196db51cd889c39" href="/josephfrazier/113827963013e98c6196db51cd889c39">
+  <a class="js-selected-navigation-item selected reponav-item" aria-label="Code" data-pjax="true" data-hotkey="g c" aria-current="page" data-selected-links="gist_code /josephfrazier/113827963013e98c6196db51cd889c39" href="/josephfrazier/113827963013e98c6196db51cd889c39">
     <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"/></svg>
     Code
 </a>
@@ -369,9 +370,7 @@
   <div class="repository-content gist-content">
     
   <div>
-    <div class="repository-meta js-details-container Details">
-</div>
-
+    
 
         <div class="js-gist-file-update-container js-task-list-container file-box">
   <div id="file-package-json" class="file">
@@ -393,7 +392,7 @@
       </div>
     
 
-  <div itemprop="text" class="blob-wrapper data type-json">
+  <div itemprop="text" class="blob-wrapper data type-json ">
       <table class="highlight tab-size js-file-line-container" data-tab-size="8">
       <tr>
         <td id="file-package-json-L1" class="blob-num js-line-number" data-line-number="1"></td>
@@ -689,7 +688,7 @@
 
 
     <a name="comments"></a>
-    <div class="discussion-timeline gist-discussion-timeline js-quote-selection-container" >
+    <div class="discussion-timeline gist-discussion-timeline js-quote-selection-container" data-quote-markdown=".js-comment-body">
       <div class="js-discussion js-socket-channel" data-channel="marked-as-read:gist:38678393">
         
 
@@ -728,22 +727,22 @@
 <div class="footer container-lg px-3" role="contentinfo">
   <div class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light ">
     <ul class="list-style-none d-flex flex-wrap ">
-      <li class="mr-3">&copy; 2018 <span title="0.17752s from unicorn-664794f569-k5g2p">GitHub</span>, Inc.</li>
+      <li class="mr-3">&copy; 2018 <span title="0.17886s from unicorn-8685494797-9c9zn">GitHub</span>, Inc.</li>
         <li class="mr-3"><a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms">Terms</a></li>
         <li class="mr-3"><a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy">Privacy</a></li>
-        <li class="mr-3"><a href="https://help.github.com/articles/github-security/" data-ga-click="Footer, go to security, text:security">Security</a></li>
+        <li class="mr-3"><a href="/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
         <li class="mr-3"><a href="https://status.github.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
         <li><a data-ga-click="Footer, go to help, text:help" href="https://help.github.com">Help</a></li>
     </ul>
 
-    <a aria-label="Homepage" title="GitHub" class="footer-octicon" href="https://github.com">
+    <a aria-label="Homepage" title="GitHub" class="footer-octicon mr-lg-4" href="https://github.com">
       <svg height="24" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
 </a>
    <ul class="list-style-none d-flex flex-wrap ">
         <li class="mr-3"><a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact">Contact GitHub</a></li>
+        <li class="mr-3"><a href="https://github.com/pricing" data-ga-click="Footer, go to Pricing, text:Pricing">Pricing</a></li>
       <li class="mr-3"><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
       <li class="mr-3"><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
-      <li class="mr-3"><a href="https://shop.github.com" data-ga-click="Footer, go to shop, text:shop">Shop</a></li>
         <li class="mr-3"><a href="https://blog.github.com" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
         <li><a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a></li>
 
@@ -765,12 +764,12 @@
   </div>
 
 
-    <script crossorigin="anonymous" integrity="sha512-wIuAKDhvxe9wCaNR1tzCk3rtl+wXEWC28rmRpzmx0h98VEeWC6Y3xCWV1xAW6NP6eQQX+x8ZGhW6Sdut+mLRuw==" type="application/javascript" src="https://assets-cdn.github.com/assets/compat-a48960bafc17c30572990bbab3664e9c.js"></script>
-    <script crossorigin="anonymous" integrity="sha512-T5YBL6byTrSWXd5XhwPeN91OHxxm7jO3OKRwlJpSbnzS8StPr/8h7OJKbLnVFO11CIbQGfv4rsGdsyRP2hyPDw==" type="application/javascript" src="https://assets-cdn.github.com/assets/frameworks-1a53a87937bf67db3a8755ade0d1aa93.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-WnyO4VoIUwWWQOmFLjYf4UGg/c1z9VlaLN8IMuiI3uMhhl6rejyThRdLPDyePeUPW6N+38OoBMs6AkqcvWALtA==" type="application/javascript" src="https://assets-cdn.github.com/assets/compat-b66b5d97b4442a01f057c74b091c4368.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-glXpCrOqxNGPFRZ0xGRWMgpYC4Xn/c/CL82vk2eeRostCZHF7Px1wBjxv6Wohcq9+xhM1Lt7DvrkWcSvF3j28w==" type="application/javascript" src="https://assets-cdn.github.com/assets/frameworks-7fcedd2a70cd3dde438cbad4c2d08128.js"></script>
     
-    <script crossorigin="anonymous" async="async" integrity="sha512-ZrDYjGIqlGGaG1GSHOH63EE/l7t50rQzDVzGjouPFMRY7kaFss37h4UiSGfJj0BjL2gX4Yeo7xNEUVE5GHcWaQ==" type="application/javascript" src="https://assets-cdn.github.com/assets/github-a81c60bf5144275576e157b9f381c39c.js"></script>
+    <script crossorigin="anonymous" async="async" integrity="sha512-NnkR3Qo+4D5ma5koFlDfAf9bKKHnuAC5BlrEUdKfDKZo46qS4hjt+C4Uw5KtLsTBASZoMneayDVNRxQRucQXqw==" type="application/javascript" src="https://assets-cdn.github.com/assets/github-927061254931b1e409112c1baeed3a26.js"></script>
     
-      <script crossorigin="anonymous" async="async" integrity="sha512-xb7yJjXsp33WQgcXi+fhko6aQ3e5E47OLRp+Pu8KSdfWAfCKXoHZpIYA8iGkOqcFGnmL/jiU52T3KAJpHqhrYw==" type="application/javascript" src="https://assets-cdn.github.com/assets/gist-b7fe8af8ddfde5d0d098834871c22a23.js"></script>
+      <script crossorigin="anonymous" async="async" integrity="sha512-eR87/Pk7Jaw26DpCL/zF+dWc1KE26Y5nwOqXOphUGXqCimL+fgkbzm9ijFsy91uLIoxrXgfExnaVaChxmEbFSw==" type="application/javascript" src="https://assets-cdn.github.com/assets/gist-f0a060fe3a6c5e3b1ecd21baab6c9bf3.js"></script>
 
     
   <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner d-none">
@@ -787,6 +786,18 @@
     </button>
   </div>
 </div>
+
+  <template id="site-details-dialog">
+  <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark" open>
+    <summary aria-haspopup="dialog" aria-label="Close dialog"></summary>
+    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast">
+      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
+        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+      </button>
+      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
+    </details-dialog>
+  </details>
+</template>
 
   <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
   <div class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large" style="width:360px;">

--- a/packages/blob-reader/fixtures/github.com/issue/code.html
+++ b/packages/blob-reader/fixtures/github.com/issue/code.html
@@ -18,11 +18,12 @@
 
 
 
-  <link crossorigin="anonymous" media="all" integrity="sha512-qQ+v+W1uJYfDMrQ/cwCVI+AGTsn1yi4rCU6KX45obe52BoF+WiHNeQ11u63iJA05vyivY57xNbhAsyK4/j1ZIQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/frameworks-01356238c65ce56a395237b592b58668.css" />
-  <link crossorigin="anonymous" media="all" integrity="sha512-I/jquBVUOVtEQ8ehveYgKO7ocZSEM5uc5vLFYM12R0EPDDFGfJOUf2gKgR3JBad6KH8L69CxKe0xyYLhMYLOsw==" rel="stylesheet" href="https://assets-cdn.github.com/assets/github-914619a4164d34dd9bc73702931c9f3b.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-lLo2nlsdl+bHLu6PGvC2j3wfP45RnK4wKQLiPnCDcuXfU38AiD+JCdMywnF3WbJC1jaxe3lAI6AM4uJuMFBLEw==" rel="stylesheet" href="https://assets-cdn.github.com/assets/frameworks-08fc49d3bd2694c870ea23d0906f3610.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-4kfWSrzu4OShEnC5m0lqUCfKkZfG7JH0ff4wnEtubTUTZqV5pS5oUMTOvWE2DDL7ttjZ9FpnZInl/0TLO3EIiA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/github-6c1d4c04bb55a87b9cb81ffdbd683662.css" />
   
   
-  <link crossorigin="anonymous" media="all" integrity="sha512-2jE+5s+6LV2ckEshC+YTwb0A/IhES9iLMcwfkkybRMMGemXcEjAx8wdd2ZbbVr1dYBJt+fkCaR+UvXiybFr/sA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/site-99075769314a73391cea9aa2907a29f9.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-PcJMPDRp7jbbEAmTk9kaL2kRQqg69QZ26WsZf07xsPyaipKsi3wVG0805PZNYXxotPDAliKKFvNSQPhD8fp1FQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/site-50c740d9290419d070dd6213a7cd03b5.css" />
+  
   
 
   <meta name="viewport" content="width=device-width">
@@ -40,7 +41,7 @@
   
   <meta name="pjax-timeout" content="1000">
   
-  <meta name="request-id" content="F367:1DFF:3FAC9D6:7E9D77A:5B607060" data-pjax-transient>
+  <meta name="request-id" content="3C7F:5678:C3F578:168BD9F:5C02824E" data-pjax-transient>
 
     <meta name="hovercard-subject-tag" content="issue:185246647" data-pjax-transient>
 
@@ -48,18 +49,20 @@
 
   <meta name="selected-link" value="repo_issues" data-pjax-transient>
 
-    <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
-  <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
-  <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
-    <meta name="google-analytics" content="UA-3769691-2">
+      <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+    <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+    <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
 
-<meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="F367:1DFF:3FAC9D6:7E9D77A:5B607060" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
+  <meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="3C7F:5678:C3F578:168BD9F:5C02824E" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
 <meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/issues/show" data-pjax-transient="true" />
 
 
 
+    <meta name="google-analytics" content="UA-3769691-2">
+
 
 <meta class="js-ga-set" name="dimension1" content="Logged Out">
+
 
 
   
@@ -68,13 +71,13 @@
     <meta name="user-login" content="">
 
       <meta name="expected-hostname" content="github.com">
-    <meta name="js-proxy-site-detection-payload" content="OGEyZjU2YTA2M2QyZGI5YThhN2Q0NTYzMWNhMjUzODM1MTdiMThmMDdlZTI3OGE5OTUyMDg5MDYwODBlZDUwOXx7InJlbW90ZV9hZGRyZXNzIjoiNzguNDMuMjUuMjEyIiwicmVxdWVzdF9pZCI6IkYzNjc6MURGRjozRkFDOUQ2OjdFOUQ3N0E6NUI2MDcwNjAiLCJ0aW1lc3RhbXAiOjE1MzMwNDY4ODEsImhvc3QiOiJnaXRodWIuY29tIn0=">
+    <meta name="js-proxy-site-detection-payload" content="ZWIzODU3Y2U0ZDNiYmQyOTUwZWYxNzEyYTA0MmIxODQ4YzcxZjZkN2U2NTRmNDgzMGQxZTc1ODM0MTdlM2Y1MHx7InJlbW90ZV9hZGRyZXNzIjoiNDYuMjIzLjE5My4xODEiLCJyZXF1ZXN0X2lkIjoiM0M3Rjo1Njc4OkMzRjU3ODoxNjhCRDlGOjVDMDI4MjRFIiwidGltZXN0YW1wIjoxNTQzNjY4MzAzLCJob3N0IjoiZ2l0aHViLmNvbSJ9">
 
-    <meta name="enabled-features" content="DASHBOARD_V2_LAYOUT_OPT_IN,EXPLORE_DISCOVER_REPOSITORIES,UNIVERSE_BANNER,FREE_TRIALS,MARKETPLACE_INSIGHTS,MARKETPLACE_PLAN_RESTRICTION_EDITOR,MARKETPLACE_SEARCH,MARKETPLACE_INSIGHTS_CONVERSION_PERCENTAGES">
+    <meta name="enabled-features" content="DASHBOARD_V2_LAYOUT_OPT_IN,EXPLORE_DISCOVER_REPOSITORIES,UNIVERSE_BANNER,MARKETPLACE_PLAN_RESTRICTION_EDITOR">
 
-  <meta name="html-safe-nonce" content="376218282ddb584cabaeb024ae8dd174c733b8d6">
+  <meta name="html-safe-nonce" content="7068b71be76f64ec48545bc0683082aea68ed7ee">
 
-  <meta http-equiv="x-pjax-version" content="667434520185c1ed6aaeb4d9a450ac61">
+  <meta http-equiv="x-pjax-version" content="cdc9a5bb30661c6c1c8e99ce4d3646f2">
   
 
       <link href="https://github.com/OctoLinker/testrepo/commits/master.atom" rel="alternate" title="Recent Commits to testrepo:master" type="application/atom+xml">
@@ -97,7 +100,7 @@
 
 
 
-<link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
+  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
 
   </head>
 
@@ -113,55 +116,129 @@
     
 
 
-
         
-
-
-  <header class="Header header-logged-out  position-relative f4 py-3" role="banner" data-ga-load="(Logged out) Header, view, experiment:site_header_dropdowns; group:control">
-    <div class="container-lg d-flex px-3">
-      <div class="d-flex flex-justify-between flex-items-center">
-        <a class="header-logo-invertocat my-0" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark; experiment:site_header_dropdowns; group:control">
-          <svg height="32" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+<header class="Header header-logged-out  position-relative f4 py-3" role="banner">
+  <div class="container-lg d-flex px-3">
+    <div class="d-flex flex-justify-between flex-items-center">
+        <a class="mr-4" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark; experiment:site_header_dropdowns; group:dropdowns">
+          <svg height="32" class="octicon octicon-mark-github text-white" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
         </a>
+    </div>
 
+    <div class="HeaderMenu HeaderMenu--logged-out d-flex flex-justify-between flex-items-center flex-auto">
+      <div class="d-none">
+        <button class="btn-link js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
+          <svg height="24" class="octicon octicon-x text-gray" viewBox="0 0 12 16" version="1.1" width="18" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+        </button>
       </div>
 
-      <div class="HeaderMenu d-flex flex-justify-between flex-auto">
-          <nav class="mt-0">
-            <ul class="d-flex list-style-none">
-                <li class="ml-2">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:features; experiment:site_header_dropdowns; group:control" data-selected-links="/features /features/project-management /features/code-review /features/project-management /features/integrations /features" href="/features">
-                    Features
-</a>                </li>
-                <li class="ml-4">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:business; experiment:site_header_dropdowns; group:control" data-selected-links="/business /business/security /business/customers /business" href="/business">
-                    Business
-</a>                </li>
+        <nav class="mt-0" aria-label="Global">
+          <ul class="d-flex list-style-none">
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
+                    Why GitHub?
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 mt-0  p-4 left-n4 position-absolute">
+                    <a href="/features" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Features <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+                    <ul class="list-style-none f5 pb-3">
+                      <li class="edge-item-fix"><a href="/features/code-review/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code review">Code review</a></li>
+                      <li class="edge-item-fix"><a href="/features/project-management/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Project management">Project management</a></li>
+                      <li class="edge-item-fix"><a href="/features/integrations" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Integrations">Integrations</a></li>
+                      <li class="edge-item-fix"><a href="/features#team-management" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team management">Team management</a></li>
+                      <li class="edge-item-fix"><a href="/features#social-coding" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Social coding">Social coding</a></li>
+                      <li class="edge-item-fix"><a href="/features#documentation" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Documentation">Documentation</a></li>
+                      <li class="edge-item-fix"><a href="/features#code-hosting" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code hosting">Code hosting</a></li>
+                    </ul>
 
-                <li class="ml-4">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:explore; experiment:site_header_dropdowns; group:control" data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship showcases showcases_search showcases_landing /explore" href="/explore">
+                    <ul class="list-style-none mb-0 border-lg-top pt-lg-3">
+                      <li class="edge-item-fix"><a href="/case-studies" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Case studies">Case Studies <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="/security" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Security">Security <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+              <li class=" mr-3 mr-lg-3">
+                <a href="/business" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Business">Business</a>
+              </li>
+
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
                     Explore
-</a>                </li>
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
 
-                <li class="ml-4">
-                      <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:marketplace; experiment:site_header_dropdowns; group:control" data-selected-links=" /marketplace" href="/marketplace">
-                        Marketplace
-</a>                </li>
-                <li class="ml-4">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:pricing; experiment:site_header_dropdowns; group:control" data-selected-links="/pricing /pricing/developer /pricing/team /pricing/business-hosted /pricing/business-enterprise /pricing" href="/pricing">
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-0 mt-0  p-4 left-n4 position-absolute">
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/explore" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Explore GitHub <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Learn &amp; contribute</h4>
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/topics" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Topics">Topics</a></li>
+                      <li class="edge-item-fix"><a href="/collections" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Collections">Collections</a></li>
+                      <li class="edge-item-fix"><a href="/trending" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Trending">Trending</a></li>
+                      <li class="edge-item-fix"><a href="https://lab.github.com/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Learning lab">Learning Lab</a></li>
+                      <li class="edge-item-fix"><a href="https://opensource.guide" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Open source guides">Open source guides</a></li>
+                    </ul>
+
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Connect with others</h4>
+                    <ul class="list-style-none mb-0">
+                      <li class="edge-item-fix"><a href="/events" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Events">Events</a></li>
+                      <li class="edge-item-fix"><a href="https://github.community" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Community forum">Community forum</a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com" class="py-2 pb-0 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to GitHub Education">GitHub Education</a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+
+              <li class=" mr-3 mr-lg-3">
+                <a href="/marketplace" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Marketplace">Marketplace</a>
+              </li>
+
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
                     Pricing
-</a>                </li>
-            </ul>
-          </nav>
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                       <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
 
-        <div class="d-flex">
-            <div class="d-lg-flex flex-items-center mr-3">
-              <div class="header-search scoped-search site-scoped-search js-site-search position-relative js-jump-to"
-  role="search combobox"
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-4 mt-0  p-4 left-n4 position-absolute">
+                    <a href="/pricing" class="pb-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Pricing">Plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/pricing/developer" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Developers">Developer</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/team" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team">Team</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/business-cloud" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Business Cloud">Business Cloud</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/enterprise" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Enterprise">Enterprise</a></li>
+                    </ul>
+
+                    <ul class="list-style-none mb-0  border-top pt-3">
+                      <li class="edge-item-fix"><a href="/pricing#feature-comparison" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Compare features">Compare plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="/nonprofit" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Nonprofits">Nonprofit <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com/discount_requests/new" class="py-2 pb-0 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover"  data-ga-click="(Logged out) Header, go to Education">Education <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+          </ul>
+        </nav>
+
+      <div class="d-flex flex-items-center px-0 text-center text-left">
+          <div class="d-lg-flex mr-3">
+            <div class="header-search scoped-search site-scoped-search js-site-search position-relative js-jump-to"
+  role="combobox"
   aria-owns="jump-to-results"
   aria-label="Search or jump to"
   aria-haspopup="listbox"
-  aria-expanded="true"
+  aria-expanded="false"
 >
   <div class="position-relative">
     <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-site-search-form" data-scope-type="Repository" data-scope-id="45358638" data-scoped-search-url="/OctoLinker/testrepo/search" data-unscoped-search-url="/search" action="/OctoLinker/testrepo/search" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
@@ -177,72 +254,138 @@
           autocapitalize="off"
           aria-autocomplete="list"
           aria-controls="jump-to-results"
-          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=duLUSsTrYD/l8KENGVyQKPmjyJrccm4syg8h8lDm+RErgAW4+0OX/d9iibg884oF/1mcJ75roGFUrwEIEVDTnw=="
+          aria-label="Search"
+          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=ZUg/6vMwphibjz8oWginDQ95qA+VR8CjYkCLgD02k9yb3DUlGT6Riax9K/9a5HYKQXWw2DUZ+WIIqnyYqARqOA=="
           spellcheck="false"
           autocomplete="off"
           >
           <input type="hidden" class="js-site-search-type-field" name="type" >
-            <img src="https://assets-cdn.github.com/images/search-shortcut-hint.svg" alt="" class="mr-2 header-search-key-slash">
+            <img src="https://assets-cdn.github.com/images/search-key-slash.svg" alt="" class="mr-2 header-search-key-slash">
 
             <div class="Box position-absolute overflow-hidden d-none jump-to-suggestions js-jump-to-suggestions-container">
-              <ul class="d-none js-jump-to-suggestions-template-container">
-                <li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item">
-                  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center p-2 jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open" href="">
-                    <div class="jump-to-octicon js-jump-to-octicon mr-2 text-center d-none"></div>
-                    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar" alt="" aria-label="Team" src="" width="28" height="28">
+              
+<ul class="d-none js-jump-to-suggestions-template-container">
+  
 
-                    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
-                    </div>
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-suggestion" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
 
-                    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
-                      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
-                        In this repository
-                      </span>
-                      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
-                        All GitHub
-                      </span>
-                      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
-                    </div>
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
 
-                    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
-                      Jump to
-                      <span class="d-inline-block ml-1 v-align-middle">↵</span>
-                    </div>
-                  </a>
-                </li>
-                <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-repo-octicon-template" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-                <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-project-octicon-template" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-                <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-search-octicon-template" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
-              </ul>
-              <ul class="d-none js-jump-to-no-results-template-container">
-                <li class="d-flex flex-justify-center flex-items-center p-3 f5 d-none">
-                  <span class="text-gray">No suggested jump to results</span>
-                </li>
-              </ul>
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
 
-              <ul id="jump-to-results" class="js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container" >
-                <li class="d-flex flex-justify-center flex-items-center p-0 f5">
-                  <img src="https://assets-cdn.github.com/images/spinners/octocat-spinner-128.gif" alt="Octocat Spinner Icon" class="m-2" width="28">
-                </li>
-              </ul>
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+</ul>
+
+<ul class="d-none js-jump-to-no-results-template-container">
+  <li class="d-flex flex-justify-center flex-items-center f5 d-none js-jump-to-suggestion p-2">
+    <span class="text-gray">No suggested jump to results</span>
+  </li>
+</ul>
+
+<ul id="jump-to-results" role="listbox" class="p-0 m-0 js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container">
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-scoped-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-global-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+
+</ul>
+
             </div>
       </label>
 </form>  </div>
 </div>
 
-            </div>
+          </div>
 
-          <span class="d-inline-block">
-              <div class="HeaderNavlink px-0 py-2 m-0">
-                <a class="text-bold text-white no-underline" href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fissues%2F2" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in; experiment:site_header_dropdowns; group:control">Sign in</a>
-                  <span class="text-gray">or</span>
-                  <a class="text-bold text-white no-underline" href="/join?source=experiment-header-control-repo" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up; experiment:site_header_dropdowns; group:control">Sign up</a>
-              </div>
-          </span>
-        </div>
+        <a class="HeaderMenu-link no-underline mr-3" href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fissues%2F2" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign&nbsp;in</a>
+          <a class="HeaderMenu-link d-inline-block no-underline border border-gray-dark rounded-1 px-2 py-1" href="/join" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">Sign&nbsp;up</a>
       </div>
     </div>
-  </header>
+  </div>
+</header>
 
   </div>
 
@@ -255,27 +398,10 @@
 
 
 
-  <div role="main" class="application-main ">
+  <div role="main" class="application-main " >
         <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
     <div id="js-repo-pjax-container" data-pjax-container >
       
-<style type="text/css" media="screen" id="issue-labels-style">
-  span.labelstyle-fc2929, .linked-labelstyle-fc2929 {  background-color: #fc2929 !important;  color: #000000 !important;}.labelstyle-fc2929.selected {  background-color: #fc2929 !important;  color: #000000 !important;}.label-select-menu .labelstyle-fc2929.selected {  background: rgba(252, 41, 41, 0.12) !important;  color: #991818 !important;}
-
-span.labelstyle-cccccc, .linked-labelstyle-cccccc {  background-color: #cccccc !important;  color: #000000 !important;}.labelstyle-cccccc.selected {  background-color: #cccccc !important;  color: #000000 !important;}.label-select-menu .labelstyle-cccccc.selected {  background: rgba(204, 204, 204, 0.12) !important;  color: #999999 !important;}
-
-span.labelstyle-84b6eb, .linked-labelstyle-84b6eb {  background-color: #84b6eb !important;  color: #000000 !important;}.labelstyle-84b6eb.selected {  background-color: #84b6eb !important;  color: #000000 !important;}.label-select-menu .labelstyle-84b6eb.selected {  background: rgba(132, 182, 235, 0.12) !important;  color: #557699 !important;}
-
-span.labelstyle-159818, .linked-labelstyle-159818 {  background-color: #159818 !important;  color: #000000 !important;}.labelstyle-159818.selected {  background-color: #159818 !important;  color: #000000 !important;}.label-select-menu .labelstyle-159818.selected {  background: rgba(21, 152, 24, 0.12) !important;  color: #159918 !important;}
-
-span.labelstyle-e6e6e6, .linked-labelstyle-e6e6e6 {  background-color: #e6e6e6 !important;  color: #000000 !important;}.labelstyle-e6e6e6.selected {  background-color: #e6e6e6 !important;  color: #000000 !important;}.label-select-menu .labelstyle-e6e6e6.selected {  background: rgba(230, 230, 230, 0.12) !important;  color: #999999 !important;}
-
-span.labelstyle-cc317c, .linked-labelstyle-cc317c {  background-color: #cc317c !important;  color: #ffffff !important;}.labelstyle-cc317c.selected {  background-color: #cc317c !important;  color: #ffffff !important;}.label-select-menu .labelstyle-cc317c.selected {  background: rgba(204, 49, 124, 0.12) !important;  color: #99245c !important;}
-
-span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !important;  color: #000000 !important;}.labelstyle-ffffff.selected {  background-color: #ffffff !important;  color: #000000 !important;}.label-select-menu .labelstyle-ffffff.selected {  background: rgba(255, 255, 255, 0.12) !important;  color: #999999 !important;}
-</style>
-
-
 
 
 
@@ -289,9 +415,9 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
       <ul class="pagehead-actions">
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-s"
     aria-label="You must be signed in to watch a repository" rel="nofollow">
-    <svg class="octicon octicon-eye" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
+    <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
     Watch
   </a>
   <a class="social-count" href="/OctoLinker/testrepo/watchers"
@@ -303,9 +429,9 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-s"
     aria-label="You must be signed in to star a repository" rel="nofollow">
-    <svg class="octicon octicon-star" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
+    <svg class="octicon octicon-star v-align-text-bottom" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
     Star
   </a>
 
@@ -318,9 +444,9 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-        class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+        class="btn btn-sm btn-with-count tooltipped tooltipped-s"
         aria-label="You must be signed in to fork a repository" rel="nofollow">
-        <svg class="octicon octicon-repo-forked" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
+        <svg class="octicon octicon-repo-forked v-align-text-bottom" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
         Fork
       </a>
 
@@ -333,7 +459,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 
       <h1 class="public ">
   <svg class="octicon octicon-repo" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-  <span class="author" itemprop="author"><a class="url fn" rel="author" href="/OctoLinker">OctoLinker</a></span><!--
+  <span class="author" itemprop="author"><a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/OctoLinker/hovercard" href="/OctoLinker">OctoLinker</a></span><!--
 --><span class="path-divider">/</span><!--
 --><strong itemprop="name"><a data-pjax="#js-repo-pjax-container" href="/OctoLinker/testrepo">testrepo</a></strong>
 
@@ -344,7 +470,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 <nav class="reponav js-repo-nav js-sidenav-container-pjax container"
      itemscope
      itemtype="http://schema.org/BreadcrumbList"
-     role="navigation"
+    aria-label="Repository"
      data-pjax="#js-repo-pjax-container">
 
   <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
@@ -355,7 +481,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 </a>  </span>
 
     <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-      <a itemprop="url" data-hotkey="g i" class="js-selected-navigation-item selected reponav-item" data-selected-links="repo_issues repo_labels repo_milestones /OctoLinker/testrepo/issues" href="/OctoLinker/testrepo/issues">
+      <a itemprop="url" data-hotkey="g i" class="js-selected-navigation-item selected reponav-item" aria-current="page" data-selected-links="repo_issues repo_labels repo_milestones /OctoLinker/testrepo/issues" href="/OctoLinker/testrepo/issues">
         <svg class="octicon octicon-issue-opened" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"/></svg>
         <span itemprop="name">Issues</span>
         <span class="Counter">1</span>
@@ -370,6 +496,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
       <meta itemprop="position" content="3">
 </a>  </span>
 
+
     <a data-hotkey="g b" class="js-selected-navigation-item reponav-item" data-selected-links="repo_projects new_repo_project repo_project /OctoLinker/testrepo/projects" href="/OctoLinker/testrepo/projects">
       <svg class="octicon octicon-project" viewBox="0 0 15 16" version="1.1" width="15" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
       Projects
@@ -377,7 +504,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 </a>
 
 
-  <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse /OctoLinker/testrepo/pulse" href="/OctoLinker/testrepo/pulse">
+  <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse alerts security /OctoLinker/testrepo/pulse" href="/OctoLinker/testrepo/pulse">
     <svg class="octicon octicon-graph" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"/></svg>
     Insights
 </a>
@@ -391,12 +518,12 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
   <div class="repository-content ">
 
     
-  <div class="issues-listing" data-pjax>
+  <div class="issues-listing js-check-all-container" data-pjax>
     
       <div class="signup-prompt-bg rounded-1">
       <div class="signup-prompt p-4 text-center mb-4 rounded-1">
         <div class="position-relative">
-          <!-- '"` --><!-- </textarea></xmp> --></option></form><form action="/site/dismiss_signup_prompt" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="M/FRLHSrk3QkqHei5N7ay2xWNJ6DWXboSCqDiA43eQDjwFS/Qi2OYzc6YY6gU3n+vkv552bG3aw+YCkEBjcLNQ==" />
+          <!-- '"` --><!-- </textarea></xmp> --></option></form><form action="/site/dismiss_signup_prompt" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="6FaiIZJSG8xeMqGwF07cigK7E57bCQD0GDcjI3VLCG37xTJ0LUs1JOoVawlaun/OWmR/HhZ1RCH69dlOFPaJ3g==" />
             <button type="submit" class="position-absolute top-0 right-0 btn-link link-gray" data-ga-click="(Logged out) Sign up prompt, clicked Dismiss, text:dismiss">
               Dismiss
             </button>
@@ -408,14 +535,17 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
     </div>
 
 
-    <div id="show_issue" class="js-issues-results">
+    <div id="show_issue"
+         class="js-issues-results js-socket-channel js-updatable-content"
+         data-channel="issue:185246647:timeline">
 
     
   <div
     id="partial-discussion-header"
     class="gh-header js-details-container Details js-socket-channel js-updatable-content issue"
     data-channel="issue:185246647"
-    data-url="/OctoLinker/testrepo/issues/2/show_partial?partial=issues%2Ftitle">
+    data-url="/OctoLinker/testrepo/issues/2/show_partial?partial=issues%2Ftitle"
+    data-gid="MDU6SXNzdWUxODUyNDY2NDc=">
 
   <div class="gh-header-show ">
       <div class="gh-header-actions">
@@ -440,20 +570,20 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
   <strong>Have a question about this project?</strong> Sign up for a free GitHub account to open an issue and contact its maintainers and the community.
   </p>
 
-  <form class="js-signup-form" autocomplete="off" action="/join?return_to=%2FOctoLinker%2Ftestrepo%2Fissues%2Fnew" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="JMgg2u/DyBMPaeWOP41XSaeEdW8m0f5X8J9CpgMC3tjlUTWuQr3/5NYtjgZV4deBcVvJUF5HPXTLL5TkFHhJjQ==" />    <auto-check src="/signup_check/username" csrf="FuEy3EwiKQ7TcKPPZV+bssTXnZqicYCwquU9hTjGe9w187jl5IkvIER83gt/N+3G1/ODkqLY33KJ/N0NpASj/g==">
-      <dl class="form-group"><dt class="input-label"><label name="user[login]" data-facebox-id="user-login-issues" autocapitalize="off" autofocus="autofocus" for="user_login_issues">Pick a username</label></dt><dd><input name="user[login]" data-facebox-id="user-login-issues" autocapitalize="off" autofocus="autofocus" class="form-control" type="text" id="user_login_issues" /></dd></dl>
+  <form class="js-signup-form" autocomplete="off" action="/join?return_to=%2FOctoLinker%2Ftestrepo%2Fissues%2Fnew" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="HyLr1PEy9l3wuhkp0cn1eB7EIcmr46rn3FtM0wKoeip8WEfV2j+YeOhLsiiB0rBQnsxrIEEDnI6HZ/hQET8usQ==" />    <auto-check src="/signup_check/username" csrf="/uBzRB4tEfk/9wA4UdTw6aA2NVtaEEhl247Qmf8nIxHMjTz4FKmpCUDc0eDeGQxP48bk8lW5YiG4wac1la6LDw==">
+      <dl class="form-group"><dt class="input-label"><label name="user[login]" autocapitalize="off" autofocus="autofocus" for="user_login_issues">Pick a username</label></dt><dd><input name="user[login]" autocapitalize="off" autofocus="autofocus" class="form-control" type="text" id="user_login_issues" /></dd></dl>
     </auto-check>
 
-    <auto-check src="/signup_check/email" csrf="wOrw4VZdKuPPrX0ZZdwDZGv+7G/VlyHSAOvMiIzsgQBbCHeBbv/3PEfnUWh/8dgPKDdqKy5knTVttu4kcQkLjQ==">
-      <dl class="form-group"><dt class="input-label"><label name="user[email]" data-facebox-id="user-email-issues" autocapitalize="off" for="user_email_issues">Email Address</label></dt><dd><input name="user[email]" data-facebox-id="user-email-issues" autocapitalize="off" class="form-control" type="text" id="user_email_issues" /></dd></dl>
+    <auto-check src="/signup_check/email" csrf="pdPVidw27Uh4ZKYxx+Mlvcjd3qNnqXul7UNOl2f6TeQjK+ExmIeib5narKlyZGc1A0cQbey5meIwKMsUXuurXw==">
+      <dl class="form-group"><dt class="input-label"><label name="user[email]" autocapitalize="off" for="user_email_issues">Email Address</label></dt><dd><input name="user[email]" autocapitalize="off" class="form-control" type="text" id="user_email_issues" /></dd></dl>
     </auto-check>
 
-    <dl class="form-group"><dt class="input-label"><label name="user[password]" data-facebox-id="user-password-issues" for="user_password_issues">Password</label></dt><dd><input name="user[password]" data-facebox-id="user-password-issues" class="form-control" type="password" id="user_password_issues" /></dd></dl>
+    <dl class="form-group"><dt class="input-label"><label name="user[password]" for="user_password_issues">Password</label></dt><dd><input name="user[password]" class="form-control" type="password" id="user_password_issues" /></dd></dl>
 
     <input type="hidden" name="source" class="js-signup-source" value="modal-issues">
-    <input type="text" name="required_field_1975" id="required_field_1975" hidden="hidden" class="form-control" />
-<input type="hidden" name="timestamp" value="1533046881291" class="form-control" />
-<input type="hidden" name="timestamp_secret" value="1e9d94649abf3f61d1e23134de6fab0b3cfe1de71074fee856f2e11a4e0ac5e8" class="form-control" />
+    <input type="text" name="required_field_c3c2" id="required_field_c3c2" hidden="hidden" class="form-control" />
+<input type="hidden" name="timestamp" value="1543668303568" class="form-control" />
+<input type="hidden" name="timestamp_secret" value="73248e4b8e44bc6b18ea1e1d0afa59e43d6bb6ed22d0a4cc60dba4e95d0822e7" class="form-control" />
 
 
     <button class="btn btn-primary mt-2 btn-block" type="submit" data-ga-click="(Logged out) New issue modal, clicked Sign up, text:sign-up">Sign up for GitHub</button>
@@ -485,7 +615,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
         </div>
     </div>
     <div class="TableObject-item TableObject-item--primary">
-        <a class="author" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>  opened this <span class="noun">Issue</span>
+        <a class="author" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>  opened this <span class="noun">Issue</span>
         <relative-time datetime="2016-10-25T22:05:33Z">Oct 25, 2016</relative-time>
         &middot; 0 comments
     </div>
@@ -499,44 +629,43 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
         <div id="partial-discussion-sidebar"
   class="js-socket-channel js-updatable-content"
   data-channel="issue:185246647"
+  data-gid="MDU6SXNzdWUxODUyNDY2NDc="
   data-url="/OctoLinker/testrepo/issues/2/show_partial?partial=issues%2Fsidebar">
 
 
   <div class="discussion-sidebar-item sidebar-assignee js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/issues/2?partial=issues%2Fsidebar%2Fshow%2Fassignees" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="rV7JCdcWxoUwwDbOniCrhYH9/zW1qmodHPkq+iGdbsJYWxChFlNaNf16HVAnIZOMikgbNEwgrJUAy8u612Izuw==" />
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/issues/2?partial=issues%2Fsidebar%2Fshow%2Fassignees" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="E6xhMl/GvpuB4ex0xmrdndJlhT27rTjmNIlE+TpW7FrLxT8dUBDBweG7f6TkXlE92D8u0buBVWtG2gU1OqtRfQ==" />
     
 
   <div class="discussion-sidebar-heading text-bold">
     Assignees
   </div>
 
-    <span class="css-truncate">
+    <span class="css-truncate js-issue-assignees">
     No one assigned
 </span>
 
 </form></div>
 
   <div class="discussion-sidebar-item sidebar-labels js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/issues/2?partial=issues%2Fsidebar%2Fshow%2Flabels" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="smdJSjH0E1wUSIu63xse9n9oTZzvDkt7vr86xleeywhHYpDi8LGP7NnyoCRmGib/dN2pnRaEjfOijduGoWGWcQ==" />
-    <div class="js-issue-labels-container">
-      
+  
+
+
 
   <div class="discussion-sidebar-heading text-bold">
     Labels
   </div>
 
-
-    </div>
-    <div aria-live="polite" aria-label="Labels">
-      <div class="labels css-truncate">
+  <div aria-live="polite" aria-label="Labels">
+    <div class="labels css-truncate js-issue-labels">
     None yet
 </div>
 
-    </div>
-</form></div>
+  </div>
+</div>
 
     <div class="discussion-sidebar-item js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/projects/issues/2" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="8igCRieIYPlkTEwCkGvz8bfO58PUN9jPtWYz6+w/Q+Sfb5qcf5eSbeMe63aaOcrEDXBe/HEjf6dadOFopEL9CQ==" />
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/projects/issues/2" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="nhSgW7rrar/USJElPAylInRYY7JpXwhSIEZMote2V7MLheNIDcCC9ll9mcxRJuw1qgjQJ5+/wvr3gwNF0U/Hkw==" />
     
 
   <div class="discussion-sidebar-heading text-bold">
@@ -551,7 +680,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 </form></div>
 
   <div class="discussion-sidebar-item sidebar-milestone js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/issues/2/set_milestone?partial=issues%2Fsidebar%2Fshow%2Fmilestone" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="CDcm783bexWIRhBiYkcX3m+bhXRlb5DVmIz8/mTiEsBBXAe2ZKQbxanwO/1OX69EAwy7opUs3gmCwRZHuzJCjg==" />
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/issues/2/set_milestone?partial=issues%2Fsidebar%2Fshow%2Fmilestone" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="a4gS+6kt13DvHs8A2GUOzweuAllcgiMe9hF2Eltfn0r13oFd5CcXnRFFrdoliXVXcvgLeugDAw8zMu42MTaOWw==" />
     
 
   <div class="discussion-sidebar-heading text-bold">
@@ -570,7 +699,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
       1 participant
     </div>
     <div class="participation-avatars d-flex flex-wrap">
-        <a class="participant-avatar" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">
+        <a class="participant-avatar" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">
           <img class="avatar" src="https://avatars3.githubusercontent.com/u/1393946?s=52&amp;v=4" width="26" height="26" alt="@stefanbuck" /> 
 </a>    </div>
   </div>
@@ -579,28 +708,37 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 
   
 
+
+
+    
+
 </div>
 
       </div>
 
-      <div class="discussion-timeline js-quote-selection-container" >
+      <div class="discussion-timeline js-quote-selection-container" data-quote-markdown=".js-comment-body" data-issue-and-pr-hovercards-enabled >
 
         <div class="js-discussion js-socket-channel" data-channel="marked-as-read:issue:185246647">
 
-          <div class="timeline-comment-wrapper js-comment-container mt-0">
-            
+          
+<div class="timeline-comment-wrapper js-comment-container mt-0 js-socket-channel"
+  data-gid="MDU6SXNzdWUxODUyNDY2NDc="
+  data-url="/_render_node/MDU6SXNzdWUxODUyNDY2NDc=/issues/body"
+  data-channel="issue:185246647">
+
+  
 
 <div class="avatar-parent-child timeline-comment-avatar">
-    <a class="d-inline-block" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar rounded-1" height="44" width="44" alt="@stefanbuck" src="https://avatars0.githubusercontent.com/u/1393946?s=88&amp;v=4" /></a>
+    <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar rounded-1" height="44" width="44" alt="@stefanbuck" src="https://avatars0.githubusercontent.com/u/1393946?s=88&amp;v=4" /></a>
 
 </div>
 
 
-            
-<div class="timeline-comment-group js-minimizable-comment-group" id="issue-185246647">
+  
+<div class="timeline-comment-group js-minimizable-comment-group js-targetable-comment" id="issue-185246647">
   <div class="unminimized-comment comment previewable-edit js-comment js-task-list-container timeline-comment  "
        data-body-version="5a63c883d34b98d594568a4ddef560b6"
-       data-unfurl-authenticity-token="xDHrpEwY1NRngWHGzumP7CyOWOzCt5iF/CA8g8k83PCnn9HcweaIZnJEMA0uT18XzoI59k01Ey9IJnlwWUneWw==">
+       data-unfurl-authenticity-token="ziT+NZwExm/1w+7gcC1pAoQ06kHM0qhUMoqAYvdugq1r0hqW5wpa0eZqw6kKAS9o2DaTxPOqn5cEFbfh02rPKg==">
 
     
 <div class="timeline-comment-header clearfix">
@@ -613,7 +751,41 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 
 
 
-<!-- Closes div if we are showing the kebab menu -->
+
+
+
+
+
+
+
+
+<details class="details-overlay details-reset position-relative d-inline-block js-dropdown-details " id="details-issue-185246647">
+  <summary
+    class="btn-link timeline-comment-action"
+    aria-haspopup="true"
+    aria-label="Show options">
+    <svg aria-label="Show options" class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/></svg>
+  </summary>
+  <div class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" role="menu">
+        <clipboard-copy
+    class="dropdown-item btn-link"
+    for="issue-185246647-permalink"
+    aria-label="Copy link"
+    data-toggle-for="details-issue-185246647"
+    role="menuitem">
+    Copy link
+  </clipboard-copy>
+
+        <button
+    type="button"
+    class="dropdown-item btn-link d-none js-comment-quote-reply"
+    data-toggle-for="details-issue-185246647">
+    Quote reply
+  </button>
+
+      
+  </div>
+</details>
 
   </div>
 
@@ -626,17 +798,18 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 
   <h3 class="timeline-comment-header-text f5 text-normal">
 
+
     <strong class="css-truncate">
       
 
-  <a class="author text-inherit css-truncate-target" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
+  <a class="author text-inherit css-truncate-target" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
   
 
     </strong>
 
     commented
 
-    <a href="#issue-185246647" class="timestamp"><relative-time datetime="2016-10-25T22:05:33Z">Oct 25, 2016</relative-time></a>
+    <a href="#issue-185246647" id="issue-185246647-permalink" class="timestamp js-timestamp"><relative-time datetime="2016-10-25T22:05:33Z">Oct 25, 2016</relative-time></a>
 
 
     <span class="js-comment-fragment">
@@ -644,8 +817,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
             
   <span class="d-inline-block text-gray-light">&#8226;</span>
 
-
-  <details class="details-overlay details-reset d-inline-block dropdown">
+  <details class="details-overlay details-reset d-inline-block dropdown js-load-contents" data-deferred-details-content-url="/_render_node/MDU6SXNzdWUxODUyNDY2NDc=/comments/comment_edit_history_log">
     <summary class="btn-link no-underline text-gray js-notice">
       <div class="position-relative">
         <span>
@@ -655,27 +827,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
       </div>
     </summary>
     <details-menu class="anim-scale-in dropdown-menu dropdown-menu-se py-0" style="width:352px">
-      <div class="dropdown-header px-3 py-2 border-bottom">Edited 3 times</div>
-      <ul class="bg-gray-light" style="overflow-y:auto; max-height:250px">
-          <li class="border-bottom css-truncate">
-              <div class="p-2 text-gray">                <img src="https://avatars1.githubusercontent.com/u/1393946?v=4" width="20" height="20" class="avatar avatar-small v-align-middle" alt="@stefanbuck">
-                <span class="css-truncate-target v-align-middle text-bold text-small">stefanbuck </span>
-              <span class="v-align-middle text-small">edited <relative-time datetime="2017-11-26T21:38:01Z">Nov 26, 2017</relative-time> (most recent)</span>
-</div>
-          </li>
-          <li class="border-bottom css-truncate">
-              <div class="p-2 text-gray">                <img src="https://avatars1.githubusercontent.com/u/1393946?v=4" width="20" height="20" class="avatar avatar-small v-align-middle" alt="@stefanbuck">
-                <span class="css-truncate-target v-align-middle text-bold text-small">stefanbuck </span>
-              <span class="v-align-middle text-small">edited <relative-time datetime="2017-11-26T21:37:45Z">Nov 26, 2017</relative-time></span>
-</div>
-          </li>
-          <li class="border-bottom css-truncate">
-              <div class="p-2 text-gray">                <img src="https://avatars1.githubusercontent.com/u/1393946?v=4" width="20" height="20" class="avatar avatar-small v-align-middle" alt="@stefanbuck">
-                <span class="css-truncate-target v-align-middle text-bold text-small">stefanbuck </span>
-              <span class="v-align-middle text-small">edited <relative-time datetime="2017-08-26T21:19:59Z">Aug 26, 2017</relative-time></span>
-</div>
-          </li>
-      </ul>
+      <include-fragment class="octocat-spinner my-3" aria-label="Loading..."></include-fragment>
     </details-menu>
   </details>
 
@@ -751,11 +903,12 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
   </div>
 </div>
 
-          </div>
+</div>
+
 
           
 
-  <div id="js-timeline-progressive-loader" data-timeline-item-src="OctoLinker/testrepo/timeline?id=MDU6SXNzdWUxODUyNDY2NDc%3D&amp;variables%5Bfirst%5D=80" ></div>
+  <div id="js-timeline-progressive-loader" data-timeline-item-src="OctoLinker/testrepo/timeline?id=MDU6SXNzdWUxODUyNDY2NDc%3D&amp;variables%5Bfirst%5D=60" ></div>
 
 
 
@@ -767,9 +920,10 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
 <div class="js-timeline-marker js-socket-channel js-updatable-content"
       id="partial-timeline"
       data-channel="issue:185246647"
-      data-url="/_render_node/MDU6SXNzdWUxODUyNDY2NDc=/issues/timeline?variables%5BhasFocusedReviewComment%5D=false&amp;variables%5BhasFocusedReviewThread%5D=false&amp;variables%5BsyntaxHighlightingEnabled%5D=true&amp;variables%5BtimelinePageSize%5D=40&amp;variables%5BtimelineSince%5D=2017-11-26T21%3A38%3A01Z"
-      data-last-modified="Sun, 26 Nov 2017 21:38:01 GMT">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="d-none js-timeline-marker-form" action="/_graphql/MarkNotificationSubjectAsRead" accept-charset="UTF-8" data-remote="true" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="/lIMRln3XsG/X7WOPEiCWedG2ZwBuzFbmISFQ3tprpqGNNugxlMDBVTz5BCKJeI4sqf1a+189qC6sPyvhimtRQ==" />
+      data-url="/_render_node/MDU6SXNzdWUxODUyNDY2NDc=/issues/unread_timeline?variables%5BhasFocusedReviewComment%5D=false&amp;variables%5BhasFocusedReviewThread%5D=false&amp;variables%5BsyntaxHighlightingEnabled%5D=true&amp;variables%5BtimelinePageSize%5D=30&amp;variables%5BtimelineSince%5D=2017-11-26T21%3A38%3A01Z"
+      data-last-modified="Sun, 26 Nov 2017 21:38:01 GMT"
+      data-gid="MDU6SXNzdWUxODUyNDY2NDc=">
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="d-none js-timeline-marker-form" action="/_graphql/MarkNotificationSubjectAsRead" accept-charset="UTF-8" data-remote="true" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="GBTH82EWg0R31JmvKIwbeZ/RmQIlSzU2wqzUtnUOCAYeAhjAszMiomBJbynHJe4TZ/gqFGwJQzO84jgOdVqzYg==" />
     <input type="hidden" name="variables[subjectId]" value="MDU6SXNzdWUxODUyNDY2NDc=">
 </form></div>
 
@@ -808,22 +962,22 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
 <div class="footer container-lg px-3" role="contentinfo">
   <div class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light ">
     <ul class="list-style-none d-flex flex-wrap ">
-      <li class="mr-3">&copy; 2018 <span title="0.42523s from unicorn-b66bb5cf9-jr47d">GitHub</span>, Inc.</li>
+      <li class="mr-3">&copy; 2018 <span title="0.28350s from unicorn-7494ccfb9c-fhxwj">GitHub</span>, Inc.</li>
         <li class="mr-3"><a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms">Terms</a></li>
         <li class="mr-3"><a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy">Privacy</a></li>
-        <li class="mr-3"><a href="https://help.github.com/articles/github-security/" data-ga-click="Footer, go to security, text:security">Security</a></li>
+        <li class="mr-3"><a href="/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
         <li class="mr-3"><a href="https://status.github.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
         <li><a data-ga-click="Footer, go to help, text:help" href="https://help.github.com">Help</a></li>
     </ul>
 
-    <a aria-label="Homepage" title="GitHub" class="footer-octicon" href="https://github.com">
+    <a aria-label="Homepage" title="GitHub" class="footer-octicon mr-lg-4" href="https://github.com">
       <svg height="24" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
 </a>
    <ul class="list-style-none d-flex flex-wrap ">
         <li class="mr-3"><a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact">Contact GitHub</a></li>
+        <li class="mr-3"><a href="https://github.com/pricing" data-ga-click="Footer, go to Pricing, text:Pricing">Pricing</a></li>
       <li class="mr-3"><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
       <li class="mr-3"><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
-      <li class="mr-3"><a href="https://shop.github.com" data-ga-click="Footer, go to shop, text:shop">Shop</a></li>
         <li class="mr-3"><a href="https://blog.github.com" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
         <li><a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a></li>
 
@@ -845,10 +999,10 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
   </div>
 
 
-    <script crossorigin="anonymous" integrity="sha512-wIuAKDhvxe9wCaNR1tzCk3rtl+wXEWC28rmRpzmx0h98VEeWC6Y3xCWV1xAW6NP6eQQX+x8ZGhW6Sdut+mLRuw==" type="application/javascript" src="https://assets-cdn.github.com/assets/compat-a48960bafc17c30572990bbab3664e9c.js"></script>
-    <script crossorigin="anonymous" integrity="sha512-T5YBL6byTrSWXd5XhwPeN91OHxxm7jO3OKRwlJpSbnzS8StPr/8h7OJKbLnVFO11CIbQGfv4rsGdsyRP2hyPDw==" type="application/javascript" src="https://assets-cdn.github.com/assets/frameworks-1a53a87937bf67db3a8755ade0d1aa93.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-WnyO4VoIUwWWQOmFLjYf4UGg/c1z9VlaLN8IMuiI3uMhhl6rejyThRdLPDyePeUPW6N+38OoBMs6AkqcvWALtA==" type="application/javascript" src="https://assets-cdn.github.com/assets/compat-b66b5d97b4442a01f057c74b091c4368.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-glXpCrOqxNGPFRZ0xGRWMgpYC4Xn/c/CL82vk2eeRostCZHF7Px1wBjxv6Wohcq9+xhM1Lt7DvrkWcSvF3j28w==" type="application/javascript" src="https://assets-cdn.github.com/assets/frameworks-7fcedd2a70cd3dde438cbad4c2d08128.js"></script>
     
-    <script crossorigin="anonymous" async="async" integrity="sha512-ZrDYjGIqlGGaG1GSHOH63EE/l7t50rQzDVzGjouPFMRY7kaFss37h4UiSGfJj0BjL2gX4Yeo7xNEUVE5GHcWaQ==" type="application/javascript" src="https://assets-cdn.github.com/assets/github-a81c60bf5144275576e157b9f381c39c.js"></script>
+    <script crossorigin="anonymous" async="async" integrity="sha512-NnkR3Qo+4D5ma5koFlDfAf9bKKHnuAC5BlrEUdKfDKZo46qS4hjt+C4Uw5KtLsTBASZoMneayDVNRxQRucQXqw==" type="application/javascript" src="https://assets-cdn.github.com/assets/github-927061254931b1e409112c1baeed3a26.js"></script>
     
     
     
@@ -866,6 +1020,18 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
     </button>
   </div>
 </div>
+
+  <template id="site-details-dialog">
+  <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark" open>
+    <summary aria-haspopup="dialog" aria-label="Close dialog"></summary>
+    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast">
+      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
+        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+      </button>
+      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
+    </details-dialog>
+  </details>
+</template>
 
   <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
   <div class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large" style="width:360px;">

--- a/packages/blob-reader/fixtures/github.com/pull/comments.html
+++ b/packages/blob-reader/fixtures/github.com/pull/comments.html
@@ -18,11 +18,12 @@
 
 
 
-  <link crossorigin="anonymous" media="all" integrity="sha512-qQ+v+W1uJYfDMrQ/cwCVI+AGTsn1yi4rCU6KX45obe52BoF+WiHNeQ11u63iJA05vyivY57xNbhAsyK4/j1ZIQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/frameworks-01356238c65ce56a395237b592b58668.css" />
-  <link crossorigin="anonymous" media="all" integrity="sha512-I/jquBVUOVtEQ8ehveYgKO7ocZSEM5uc5vLFYM12R0EPDDFGfJOUf2gKgR3JBad6KH8L69CxKe0xyYLhMYLOsw==" rel="stylesheet" href="https://assets-cdn.github.com/assets/github-914619a4164d34dd9bc73702931c9f3b.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-lLo2nlsdl+bHLu6PGvC2j3wfP45RnK4wKQLiPnCDcuXfU38AiD+JCdMywnF3WbJC1jaxe3lAI6AM4uJuMFBLEw==" rel="stylesheet" href="https://assets-cdn.github.com/assets/frameworks-08fc49d3bd2694c870ea23d0906f3610.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-4kfWSrzu4OShEnC5m0lqUCfKkZfG7JH0ff4wnEtubTUTZqV5pS5oUMTOvWE2DDL7ttjZ9FpnZInl/0TLO3EIiA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/github-6c1d4c04bb55a87b9cb81ffdbd683662.css" />
   
   
-  <link crossorigin="anonymous" media="all" integrity="sha512-2jE+5s+6LV2ckEshC+YTwb0A/IhES9iLMcwfkkybRMMGemXcEjAx8wdd2ZbbVr1dYBJt+fkCaR+UvXiybFr/sA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/site-99075769314a73391cea9aa2907a29f9.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-PcJMPDRp7jbbEAmTk9kaL2kRQqg69QZ26WsZf07xsPyaipKsi3wVG0805PZNYXxotPDAliKKFvNSQPhD8fp1FQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/site-50c740d9290419d070dd6213a7cd03b5.css" />
+  
   
 
   <meta name="viewport" content="width=device-width">
@@ -40,7 +41,7 @@
   
   <meta name="pjax-timeout" content="1000">
   
-  <meta name="request-id" content="F365:1E01:7718CCC:DE54CD7:5B60705C" data-pjax-transient>
+  <meta name="request-id" content="3C71:5677:45518F:877EF1:5C02824B" data-pjax-transient>
 
     <meta name="hovercard-subject-tag" content="pull_request:90889453" data-pjax-transient>
 
@@ -48,18 +49,20 @@
 
   <meta name="selected-link" value="repo_pulls" data-pjax-transient>
 
-    <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
-  <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
-  <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
-    <meta name="google-analytics" content="UA-3769691-2">
+      <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+    <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+    <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
 
-<meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="F365:1E01:7718CCC:DE54CD7:5B60705C" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
+  <meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="3C71:5677:45518F:877EF1:5C02824B" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
 <meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/pull_requests/show" data-pjax-transient="true" />
 
 
 
+    <meta name="google-analytics" content="UA-3769691-2">
+
 
 <meta class="js-ga-set" name="dimension1" content="Logged Out">
+
 
 
   
@@ -68,32 +71,16 @@
     <meta name="user-login" content="">
 
       <meta name="expected-hostname" content="github.com">
-    <meta name="js-proxy-site-detection-payload" content="MjEwNGM2OTY0NGUzNTRjYmQzMTkxMmY2NzVjMDI0NzE2ZmVlYWVkMTI4YWY2NjFjNjc1OTNkNzI2NjVhN2VkOXx7InJlbW90ZV9hZGRyZXNzIjoiNzguNDMuMjUuMjEyIiwicmVxdWVzdF9pZCI6IkYzNjU6MUUwMTo3NzE4Q0NDOkRFNTRDRDc6NUI2MDcwNUMiLCJ0aW1lc3RhbXAiOjE1MzMwNDY4NzcsImhvc3QiOiJnaXRodWIuY29tIn0=">
+    <meta name="js-proxy-site-detection-payload" content="Y2ZlZDRkMjRhMThlYjFlZjA5OGRkNjQwZmI3NzMyNTNhMmU4MGI2MjE3MGQzODBjZWY1OTljNzU2M2FhMmQ1OHx7InJlbW90ZV9hZGRyZXNzIjoiNDYuMjIzLjE5My4xODEiLCJyZXF1ZXN0X2lkIjoiM0M3MTo1Njc3OjQ1NTE4Rjo4NzdFRjE6NUMwMjgyNEIiLCJ0aW1lc3RhbXAiOjE1NDM2NjgzMDAsImhvc3QiOiJnaXRodWIuY29tIn0=">
 
-    <meta name="enabled-features" content="DASHBOARD_V2_LAYOUT_OPT_IN,EXPLORE_DISCOVER_REPOSITORIES,UNIVERSE_BANNER,FREE_TRIALS,MARKETPLACE_INSIGHTS,MARKETPLACE_PLAN_RESTRICTION_EDITOR,MARKETPLACE_SEARCH,MARKETPLACE_INSIGHTS_CONVERSION_PERCENTAGES">
+    <meta name="enabled-features" content="DASHBOARD_V2_LAYOUT_OPT_IN,EXPLORE_DISCOVER_REPOSITORIES,UNIVERSE_BANNER,MARKETPLACE_PLAN_RESTRICTION_EDITOR">
 
-  <meta name="html-safe-nonce" content="8b62e77ca4daadeaa0ae001201b4280a6143ed79">
+  <meta name="html-safe-nonce" content="02a42986cfcb8d3224b7319c20eee0e626382c6b">
 
-  <meta http-equiv="x-pjax-version" content="667434520185c1ed6aaeb4d9a450ac61">
+  <meta http-equiv="x-pjax-version" content="cdc9a5bb30661c6c1c8e99ce4d3646f2">
   
 
-    <style type="text/css" media="screen" id="issue-labels-style">
-  span.labelstyle-fc2929, .linked-labelstyle-fc2929 {  background-color: #fc2929 !important;  color: #000000 !important;}.labelstyle-fc2929.selected {  background-color: #fc2929 !important;  color: #000000 !important;}.label-select-menu .labelstyle-fc2929.selected {  background: rgba(252, 41, 41, 0.12) !important;  color: #991818 !important;}
-
-span.labelstyle-cccccc, .linked-labelstyle-cccccc {  background-color: #cccccc !important;  color: #000000 !important;}.labelstyle-cccccc.selected {  background-color: #cccccc !important;  color: #000000 !important;}.label-select-menu .labelstyle-cccccc.selected {  background: rgba(204, 204, 204, 0.12) !important;  color: #999999 !important;}
-
-span.labelstyle-84b6eb, .linked-labelstyle-84b6eb {  background-color: #84b6eb !important;  color: #000000 !important;}.labelstyle-84b6eb.selected {  background-color: #84b6eb !important;  color: #000000 !important;}.label-select-menu .labelstyle-84b6eb.selected {  background: rgba(132, 182, 235, 0.12) !important;  color: #557699 !important;}
-
-span.labelstyle-159818, .linked-labelstyle-159818 {  background-color: #159818 !important;  color: #000000 !important;}.labelstyle-159818.selected {  background-color: #159818 !important;  color: #000000 !important;}.label-select-menu .labelstyle-159818.selected {  background: rgba(21, 152, 24, 0.12) !important;  color: #159918 !important;}
-
-span.labelstyle-e6e6e6, .linked-labelstyle-e6e6e6 {  background-color: #e6e6e6 !important;  color: #000000 !important;}.labelstyle-e6e6e6.selected {  background-color: #e6e6e6 !important;  color: #000000 !important;}.label-select-menu .labelstyle-e6e6e6.selected {  background: rgba(230, 230, 230, 0.12) !important;  color: #999999 !important;}
-
-span.labelstyle-cc317c, .linked-labelstyle-cc317c {  background-color: #cc317c !important;  color: #ffffff !important;}.labelstyle-cc317c.selected {  background-color: #cc317c !important;  color: #ffffff !important;}.label-select-menu .labelstyle-cc317c.selected {  background: rgba(204, 49, 124, 0.12) !important;  color: #99245c !important;}
-
-span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !important;  color: #000000 !important;}.labelstyle-ffffff.selected {  background-color: #ffffff !important;  color: #000000 !important;}.label-select-menu .labelstyle-ffffff.selected {  background: rgba(255, 255, 255, 0.12) !important;  color: #999999 !important;}
-</style>
-
-  <link href="https://github.com/OctoLinker/testrepo/commits/stefanbuck-patch-1.atom" rel="alternate" title="Recent Commits to testrepo:stefanbuck-patch-1" type="application/atom+xml">
+      <link href="https://github.com/OctoLinker/testrepo/commits/stefanbuck-patch-1.atom" rel="alternate" title="Recent Commits to testrepo:stefanbuck-patch-1" type="application/atom+xml">
 
   <meta name="go-import" content="github.com/OctoLinker/testrepo git https://github.com/OctoLinker/testrepo.git">
 
@@ -113,7 +100,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 
 
 
-<link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
+  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
 
   </head>
 
@@ -129,55 +116,129 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
     
 
 
-
         
-
-
-  <header class="Header header-logged-out  position-relative f4 py-3" role="banner" >
-    <div class="container-lg d-flex px-3">
-      <div class="d-flex flex-justify-between flex-items-center">
-        <a class="header-logo-invertocat my-0" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark; experiment:site_header_dropdowns; group:control">
-          <svg height="32" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+<header class="Header header-logged-out  position-relative f4 py-3" role="banner">
+  <div class="container-lg d-flex px-3">
+    <div class="d-flex flex-justify-between flex-items-center">
+        <a class="mr-4" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark; experiment:site_header_dropdowns; group:dropdowns">
+          <svg height="32" class="octicon octicon-mark-github text-white" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
         </a>
+    </div>
 
+    <div class="HeaderMenu HeaderMenu--logged-out d-flex flex-justify-between flex-items-center flex-auto">
+      <div class="d-none">
+        <button class="btn-link js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
+          <svg height="24" class="octicon octicon-x text-gray" viewBox="0 0 12 16" version="1.1" width="18" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+        </button>
       </div>
 
-      <div class="HeaderMenu d-flex flex-justify-between flex-auto">
-          <nav class="mt-0">
-            <ul class="d-flex list-style-none">
-                <li class="ml-2">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:features; experiment:site_header_dropdowns; group:control" data-selected-links="/features /features/project-management /features/code-review /features/project-management /features/integrations /features" href="/features">
-                    Features
-</a>                </li>
-                <li class="ml-4">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:business; experiment:site_header_dropdowns; group:control" data-selected-links="/business /business/security /business/customers /business" href="/business">
-                    Business
-</a>                </li>
+        <nav class="mt-0" aria-label="Global">
+          <ul class="d-flex list-style-none">
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
+                    Why GitHub?
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 mt-0  p-4 left-n4 position-absolute">
+                    <a href="/features" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Features <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+                    <ul class="list-style-none f5 pb-3">
+                      <li class="edge-item-fix"><a href="/features/code-review/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code review">Code review</a></li>
+                      <li class="edge-item-fix"><a href="/features/project-management/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Project management">Project management</a></li>
+                      <li class="edge-item-fix"><a href="/features/integrations" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Integrations">Integrations</a></li>
+                      <li class="edge-item-fix"><a href="/features#team-management" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team management">Team management</a></li>
+                      <li class="edge-item-fix"><a href="/features#social-coding" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Social coding">Social coding</a></li>
+                      <li class="edge-item-fix"><a href="/features#documentation" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Documentation">Documentation</a></li>
+                      <li class="edge-item-fix"><a href="/features#code-hosting" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code hosting">Code hosting</a></li>
+                    </ul>
 
-                <li class="ml-4">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:explore; experiment:site_header_dropdowns; group:control" data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship showcases showcases_search showcases_landing /explore" href="/explore">
+                    <ul class="list-style-none mb-0 border-lg-top pt-lg-3">
+                      <li class="edge-item-fix"><a href="/case-studies" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Case studies">Case Studies <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="/security" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Security">Security <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+              <li class=" mr-3 mr-lg-3">
+                <a href="/business" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Business">Business</a>
+              </li>
+
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
                     Explore
-</a>                </li>
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
 
-                <li class="ml-4">
-                      <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:marketplace; experiment:site_header_dropdowns; group:control" data-selected-links=" /marketplace" href="/marketplace">
-                        Marketplace
-</a>                </li>
-                <li class="ml-4">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:pricing; experiment:site_header_dropdowns; group:control" data-selected-links="/pricing /pricing/developer /pricing/team /pricing/business-hosted /pricing/business-enterprise /pricing" href="/pricing">
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-0 mt-0  p-4 left-n4 position-absolute">
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/explore" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Explore GitHub <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Learn &amp; contribute</h4>
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/topics" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Topics">Topics</a></li>
+                      <li class="edge-item-fix"><a href="/collections" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Collections">Collections</a></li>
+                      <li class="edge-item-fix"><a href="/trending" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Trending">Trending</a></li>
+                      <li class="edge-item-fix"><a href="https://lab.github.com/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Learning lab">Learning Lab</a></li>
+                      <li class="edge-item-fix"><a href="https://opensource.guide" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Open source guides">Open source guides</a></li>
+                    </ul>
+
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Connect with others</h4>
+                    <ul class="list-style-none mb-0">
+                      <li class="edge-item-fix"><a href="/events" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Events">Events</a></li>
+                      <li class="edge-item-fix"><a href="https://github.community" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Community forum">Community forum</a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com" class="py-2 pb-0 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to GitHub Education">GitHub Education</a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+
+              <li class=" mr-3 mr-lg-3">
+                <a href="/marketplace" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Marketplace">Marketplace</a>
+              </li>
+
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
                     Pricing
-</a>                </li>
-            </ul>
-          </nav>
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                       <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
 
-        <div class="d-flex">
-            <div class="d-lg-flex flex-items-center mr-3">
-              <div class="header-search scoped-search site-scoped-search js-site-search position-relative js-jump-to"
-  role="search combobox"
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-4 mt-0  p-4 left-n4 position-absolute">
+                    <a href="/pricing" class="pb-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Pricing">Plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/pricing/developer" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Developers">Developer</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/team" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team">Team</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/business-cloud" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Business Cloud">Business Cloud</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/enterprise" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Enterprise">Enterprise</a></li>
+                    </ul>
+
+                    <ul class="list-style-none mb-0  border-top pt-3">
+                      <li class="edge-item-fix"><a href="/pricing#feature-comparison" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Compare features">Compare plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="/nonprofit" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Nonprofits">Nonprofit <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com/discount_requests/new" class="py-2 pb-0 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover"  data-ga-click="(Logged out) Header, go to Education">Education <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+          </ul>
+        </nav>
+
+      <div class="d-flex flex-items-center px-0 text-center text-left">
+          <div class="d-lg-flex mr-3">
+            <div class="header-search scoped-search site-scoped-search js-site-search position-relative js-jump-to"
+  role="combobox"
   aria-owns="jump-to-results"
   aria-label="Search or jump to"
   aria-haspopup="listbox"
-  aria-expanded="true"
+  aria-expanded="false"
 >
   <div class="position-relative">
     <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-site-search-form" data-scope-type="Repository" data-scope-id="45358638" data-scoped-search-url="/OctoLinker/testrepo/search" data-unscoped-search-url="/search" action="/OctoLinker/testrepo/search" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
@@ -193,72 +254,138 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
           autocapitalize="off"
           aria-autocomplete="list"
           aria-controls="jump-to-results"
-          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=2NUHnU+2t6pXeyqJ1FDTz1mzU1oKDvTl3M14XT5eLbJB/wT6+spdhmrif6WB8uHoFGP6ozzQLbNO9fqMbtOOcA=="
+          aria-label="Search"
+          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=fAEebNmeVqFDFh+pBYyxZctJlrIUDSSlTWncG79a5Liz37BXPNMNU6vgj1304OpQD94foAGLGBt1Mix6KR2mzA=="
           spellcheck="false"
           autocomplete="off"
           >
           <input type="hidden" class="js-site-search-type-field" name="type" >
-            <img src="https://assets-cdn.github.com/images/search-shortcut-hint.svg" alt="" class="mr-2 header-search-key-slash">
+            <img src="https://assets-cdn.github.com/images/search-key-slash.svg" alt="" class="mr-2 header-search-key-slash">
 
             <div class="Box position-absolute overflow-hidden d-none jump-to-suggestions js-jump-to-suggestions-container">
-              <ul class="d-none js-jump-to-suggestions-template-container">
-                <li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item">
-                  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center p-2 jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open" href="">
-                    <div class="jump-to-octicon js-jump-to-octicon mr-2 text-center d-none"></div>
-                    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar" alt="" aria-label="Team" src="" width="28" height="28">
+              
+<ul class="d-none js-jump-to-suggestions-template-container">
+  
 
-                    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
-                    </div>
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-suggestion" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
 
-                    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
-                      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
-                        In this repository
-                      </span>
-                      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
-                        All GitHub
-                      </span>
-                      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
-                    </div>
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
 
-                    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
-                      Jump to
-                      <span class="d-inline-block ml-1 v-align-middle">↵</span>
-                    </div>
-                  </a>
-                </li>
-                <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-repo-octicon-template" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-                <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-project-octicon-template" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-                <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-search-octicon-template" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
-              </ul>
-              <ul class="d-none js-jump-to-no-results-template-container">
-                <li class="d-flex flex-justify-center flex-items-center p-3 f5 d-none">
-                  <span class="text-gray">No suggested jump to results</span>
-                </li>
-              </ul>
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
 
-              <ul id="jump-to-results" class="js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container" >
-                <li class="d-flex flex-justify-center flex-items-center p-0 f5">
-                  <img src="https://assets-cdn.github.com/images/spinners/octocat-spinner-128.gif" alt="Octocat Spinner Icon" class="m-2" width="28">
-                </li>
-              </ul>
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+</ul>
+
+<ul class="d-none js-jump-to-no-results-template-container">
+  <li class="d-flex flex-justify-center flex-items-center f5 d-none js-jump-to-suggestion p-2">
+    <span class="text-gray">No suggested jump to results</span>
+  </li>
+</ul>
+
+<ul id="jump-to-results" role="listbox" class="p-0 m-0 js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container">
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-scoped-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-global-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+
+</ul>
+
             </div>
       </label>
 </form>  </div>
 </div>
 
-            </div>
+          </div>
 
-          <span class="d-inline-block">
-              <div class="HeaderNavlink px-0 py-2 m-0">
-                <a class="text-bold text-white no-underline" href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fpull%2F1" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in; experiment:site_header_dropdowns; group:control">Sign in</a>
-                  <span class="text-gray">or</span>
-                  <a class="text-bold text-white no-underline" href="/join?source=header-repo" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up; experiment:site_header_dropdowns; group:control">Sign up</a>
-              </div>
-          </span>
-        </div>
+        <a class="HeaderMenu-link no-underline mr-3" href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fpull%2F1" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign&nbsp;in</a>
+          <a class="HeaderMenu-link d-inline-block no-underline border border-gray-dark rounded-1 px-2 py-1" href="/join" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">Sign&nbsp;up</a>
       </div>
     </div>
-  </header>
+  </div>
+</header>
 
   </div>
 
@@ -271,11 +398,10 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 
 
 
-  <div role="main" class="application-main ">
+  <div role="main" class="application-main " >
         <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
     <div id="js-repo-pjax-container" data-pjax-container >
       
-
 <!-- base sha1: &quot;8c802922609af8721bae6f954a58f1b804e7d765&quot; -->
 <!-- head sha1: &quot;9981d1a99ef8fff1f569c2ae24b136d5a0275132&quot; -->
 
@@ -292,9 +418,9 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
       <ul class="pagehead-actions">
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-s"
     aria-label="You must be signed in to watch a repository" rel="nofollow">
-    <svg class="octicon octicon-eye" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
+    <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
     Watch
   </a>
   <a class="social-count" href="/OctoLinker/testrepo/watchers"
@@ -306,9 +432,9 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-s"
     aria-label="You must be signed in to star a repository" rel="nofollow">
-    <svg class="octicon octicon-star" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
+    <svg class="octicon octicon-star v-align-text-bottom" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
     Star
   </a>
 
@@ -321,9 +447,9 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-        class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+        class="btn btn-sm btn-with-count tooltipped tooltipped-s"
         aria-label="You must be signed in to fork a repository" rel="nofollow">
-        <svg class="octicon octicon-repo-forked" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
+        <svg class="octicon octicon-repo-forked v-align-text-bottom" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
         Fork
       </a>
 
@@ -336,7 +462,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 
       <h1 class="public ">
   <svg class="octicon octicon-repo" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-  <span class="author" itemprop="author"><a class="url fn" rel="author" href="/OctoLinker">OctoLinker</a></span><!--
+  <span class="author" itemprop="author"><a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/OctoLinker/hovercard" href="/OctoLinker">OctoLinker</a></span><!--
 --><span class="path-divider">/</span><!--
 --><strong itemprop="name"><a data-pjax="#js-repo-pjax-container" href="/OctoLinker/testrepo">testrepo</a></strong>
 
@@ -347,7 +473,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 <nav class="reponav js-repo-nav js-sidenav-container-pjax container"
      itemscope
      itemtype="http://schema.org/BreadcrumbList"
-     role="navigation"
+    aria-label="Repository"
      data-pjax="#js-repo-pjax-container">
 
   <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
@@ -366,12 +492,13 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 </a>    </span>
 
   <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-    <a data-hotkey="g p" itemprop="url" class="js-selected-navigation-item selected reponav-item" data-selected-links="repo_pulls checks /OctoLinker/testrepo/pulls" href="/OctoLinker/testrepo/pulls">
+    <a data-hotkey="g p" itemprop="url" class="js-selected-navigation-item selected reponav-item" aria-current="page" data-selected-links="repo_pulls checks /OctoLinker/testrepo/pulls" href="/OctoLinker/testrepo/pulls">
       <svg class="octicon octicon-git-pull-request" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
       <span itemprop="name">Pull requests</span>
       <span class="Counter">1</span>
       <meta itemprop="position" content="3">
 </a>  </span>
+
 
     <a data-hotkey="g b" class="js-selected-navigation-item reponav-item" data-selected-links="repo_projects new_repo_project repo_project /OctoLinker/testrepo/projects" href="/OctoLinker/testrepo/projects">
       <svg class="octicon octicon-project" viewBox="0 0 15 16" version="1.1" width="15" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
@@ -380,7 +507,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 </a>
 
 
-  <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse /OctoLinker/testrepo/pulse" href="/OctoLinker/testrepo/pulse">
+  <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse alerts security /OctoLinker/testrepo/pulse" href="/OctoLinker/testrepo/pulse">
     <svg class="octicon octicon-graph" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"/></svg>
     Insights
 </a>
@@ -394,12 +521,12 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
   <div class="repository-content ">
 
     
-  <div class="issues-listing" data-pjax>
+  <div class="issues-listing js-check-all-container" data-pjax>
     
       <div class="signup-prompt-bg rounded-1">
       <div class="signup-prompt p-4 text-center mb-4 rounded-1">
         <div class="position-relative">
-          <!-- '"` --><!-- </textarea></xmp> --></option></form><form action="/site/dismiss_signup_prompt" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="mDBV7Z6dO22wU+XMNiCY7I6aMS0u2U1jYqKnWs78HEhfhWGp+aZyW+ofV94QB+vMME9a1lYiQUGO4eWMvcEWog==" />
+          <!-- '"` --><!-- </textarea></xmp> --></option></form><form action="/site/dismiss_signup_prompt" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="wzzueqwE+jJLmeCd2ihCeJQyyJykDe+9+yIZowM+cAGVd/VbAqcMHivag52LMc+eGBJSCEJDKyr9UZT8krs7mg==" />
             <button type="submit" class="position-absolute top-0 right-0 btn-link link-gray" data-ga-click="(Logged out) Sign up prompt, clicked Dismiss, text:dismiss">
               Dismiss
             </button>
@@ -416,9 +543,11 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
     
   <div
     id="partial-discussion-header"
-    class="gh-header js-details-container Details js-socket-channel js-updatable-content pull request"
+    class="gh-header js-details-container Details js-socket-channel js-updatable-content js-pull-header-details pull request"
     data-channel="pull_request:90889453"
-    data-url="/OctoLinker/testrepo/pull/1/show_partial?partial=pull_requests%2Ftitle">
+    data-url="/OctoLinker/testrepo/pull/1/show_partial?partial=pull_requests%2Ftitle"
+    data-pull-is-open="true"
+    data-gid="MDExOlB1bGxSZXF1ZXN0OTA4ODk0NTM=">
 
   <div class="gh-header-show ">
       <div class="gh-header-actions">
@@ -443,20 +572,20 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
   <strong>Have a question about this project?</strong> Sign up for a free GitHub account to open an issue and contact its maintainers and the community.
   </p>
 
-  <form class="js-signup-form" autocomplete="off" action="/join?return_to=%2FOctoLinker%2Ftestrepo%2Fissues%2Fnew" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="lajBBrdXqxcieREklXu0Jo2qEQn7tLMp25949lS8IGbXI/LULsbMC+wibiEoyx0W8YMlItd6FY1w2PhiPPEnNQ==" />    <auto-check src="/signup_check/username" csrf="9lOiBu4d4dQLIZdiJRekVB4TFLjzRawytar5cSPCAuLkGXOA0SpHTQQfoE/BdzIACKJkC8UhUhbGMAwU10LqFw==">
-      <dl class="form-group"><dt class="input-label"><label name="user[login]" data-facebox-id="user-login-issues" autocapitalize="off" autofocus="autofocus" for="user_login_issues">Pick a username</label></dt><dd><input name="user[login]" data-facebox-id="user-login-issues" autocapitalize="off" autofocus="autofocus" class="form-control" type="text" id="user_login_issues" /></dd></dl>
+  <form class="js-signup-form" autocomplete="off" action="/join?return_to=%2FOctoLinker%2Ftestrepo%2Fissues%2Fnew" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="nwwjRWB4Iwv55UjAbOuWK+pf2EE00Ujmw/T+HAOEhSfahbG87XUE5CH2O4aYAG3U9hqR3GpGehKzXjpAZ/RNrA==" />    <auto-check src="/signup_check/username" csrf="g/L42kFCKJVwOXW5ctGrZ0bIKINDVzkZz3IY1ymPuRaWLQFX71tlQTvsE7Nl2nKk4VpSoedp4jLHO7CWFTEKVA==">
+      <dl class="form-group"><dt class="input-label"><label name="user[login]" autocapitalize="off" autofocus="autofocus" for="user_login_issues">Pick a username</label></dt><dd><input name="user[login]" autocapitalize="off" autofocus="autofocus" class="form-control" type="text" id="user_login_issues" /></dd></dl>
     </auto-check>
 
-    <auto-check src="/signup_check/email" csrf="7oCv3IqjsJf+9rL+XvGP9irC9KoMWzoJjaZaeGpaEPgEWkiNMRJI1sWj9yZdlrV/vWxpMmopIttGjAL1lhb6PQ==">
-      <dl class="form-group"><dt class="input-label"><label name="user[email]" data-facebox-id="user-email-issues" autocapitalize="off" for="user_email_issues">Email Address</label></dt><dd><input name="user[email]" data-facebox-id="user-email-issues" autocapitalize="off" class="form-control" type="text" id="user_email_issues" /></dd></dl>
+    <auto-check src="/signup_check/email" csrf="UyvmRy3nyXrK8y8VVbOFYVxl6dvLRlMz3vH6YIxyTC/DL3UrmsbLuSHsnlLpWwYEkj6rgYo8zM+YZ4dky5v9Ww==">
+      <dl class="form-group"><dt class="input-label"><label name="user[email]" autocapitalize="off" for="user_email_issues">Email Address</label></dt><dd><input name="user[email]" autocapitalize="off" class="form-control" type="text" id="user_email_issues" /></dd></dl>
     </auto-check>
 
-    <dl class="form-group"><dt class="input-label"><label name="user[password]" data-facebox-id="user-password-issues" for="user_password_issues">Password</label></dt><dd><input name="user[password]" data-facebox-id="user-password-issues" class="form-control" type="password" id="user_password_issues" /></dd></dl>
+    <dl class="form-group"><dt class="input-label"><label name="user[password]" for="user_password_issues">Password</label></dt><dd><input name="user[password]" class="form-control" type="password" id="user_password_issues" /></dd></dl>
 
     <input type="hidden" name="source" class="js-signup-source" value="modal-issues">
-    <input type="text" name="required_field_6e56" id="required_field_6e56" hidden="hidden" class="form-control" />
-<input type="hidden" name="timestamp" value="1533046877721" class="form-control" />
-<input type="hidden" name="timestamp_secret" value="75327ab5a7fdd0e294e8986f2b0b9a84f4b93a99fdeb8da103520da0381af831" class="form-control" />
+    <input type="text" name="required_field_b9c9" id="required_field_b9c9" hidden="hidden" class="form-control" />
+<input type="hidden" name="timestamp" value="1543668300439" class="form-control" />
+<input type="hidden" name="timestamp_secret" value="3bd1fcebf41b89a1bebdc04344358a691fdbc3bd3c79dfa2bfbcabfe49daa890" class="form-control" />
 
 
     <button class="btn btn-primary mt-2 btn-block" type="submit" data-ga-click="(Logged out) New issue modal, clicked Sign up, text:sign-up">Sign up for GitHub</button>
@@ -488,7 +617,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
         </div>
     </div>
     <div class="TableObject-item TableObject-item--primary">
-          <a class="author pull-header-username css-truncate css-truncate-target expandable" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
+          <a class="author pull-header-username css-truncate css-truncate-target expandable" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
    wants to merge 1 commit into
 
 
@@ -496,20 +625,18 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
   <span title="OctoLinker/testrepo:master" class="commit-ref css-truncate user-select-contain expandable base-ref"><span class="css-truncate-target">master</span></span>
 
   <div class="commit-ref-dropdown">
-    <div class="select-menu js-menu-container js-select-menu commitish-suggester js-load-contents" data-contents-url="/OctoLinker/testrepo/pull/1/show_partial?partial=pull_requests%2Fdescription_branches_dropdown">
-      <button class="btn btn-sm select-menu-button js-menu-target branch" type="button" aria-label="Choose a base branch" aria-haspopup="true" aria-expanded="false">
+    <details class="details-reset details-overlay select-menu js-select-menu commitish-suggester js-load-contents" data-contents-url="/OctoLinker/testrepo/pull/1/show_partial?partial=pull_requests%2Fdescription_branches_dropdown">
+      <summary class="btn btn-sm select-menu-button branch" title="Choose a base branch" aria-haspopup="true">
         <i>base:</i>
-        <span class="js-select-button css-truncate css-truncate-target" title="base: master">master</span>
-      </button>
-      <div class="select-menu-modal-holder js-menu-content js-navigation-container">
-        <div class="select-menu-modal">
-          <div class="js-select-menu-deferred-content"></div>
-          <div class="select-menu-loading-overlay anim-pulse">
-            <svg height="32" class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"/></svg>
-          </div>
+        <span class="js-select-button css-truncate css-truncate-target" title="master">master</span>
+      </summary>
+      <details-menu class="select-menu-modal position-absolute" style="z-index: 90;">
+        <div class="js-select-menu-deferred-content"></div>
+        <div class="select-menu-loading-overlay anim-pulse">
+          <svg height="32" class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"/></svg>
         </div>
-      </div>
-    </div>
+      </details-menu>
+    </details>
   </div>
 
 from
@@ -523,19 +650,32 @@ from
 </div>
 
 
-      <include-fragment src="/OctoLinker/testrepo/pull/1/show_partial?partial=pull_requests%2Ftabs">
-    
+      
 <div class="tabnav tabnav-pr">
+    <div class="tabnav-extra float-right">
+      <span class="diffstat" id="diffstat">
+        <span class="text-green">
+          +1
+        </span>
+        <span class="text-red">
+          −1
+        </span>
+        <span class="tooltipped tooltipped-s" aria-label="2 lines changed">
+          <span class="block-diff-added"></span><span class="block-diff-deleted"></span><span class="block-diff-neutral"></span><span class="block-diff-neutral"></span><span class="block-diff-neutral"></span>
+        </span>
+      </span>
+    </div>
 
   <nav class="tabnav-tabs">
-    <a href="/OctoLinker/testrepo/pull/1" class="tabnav-tab selected js-pjax-history-navigate">
-      <svg class="octicon octicon-comment-discussion" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15 1H6c-.55 0-1 .45-1 1v2H1c-.55 0-1 .45-1 1v6c0 .55.45 1 1 1h1v3l3-3h4c.55 0 1-.45 1-1V9h1l3 3V9h1c.55 0 1-.45 1-1V2c0-.55-.45-1-1-1zM9 11H4.5L3 12.5V11H1V5h4v3c0 .55.45 1 1 1h3v2zm6-3h-2v1.5L11.5 8H6V2h9v6z"/></svg>
-      Conversation
 
-      <span id="conversation_tab_counter" class="Counter">
-        2
-      </span>
-    </a>
+      <a href="/OctoLinker/testrepo/pull/1" class="tabnav-tab selected js-pjax-history-navigate">
+        <svg class="octicon octicon-comment-discussion" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15 1H6c-.55 0-1 .45-1 1v2H1c-.55 0-1 .45-1 1v6c0 .55.45 1 1 1h1v3l3-3h4c.55 0 1-.45 1-1V9h1l3 3V9h1c.55 0 1-.45 1-1V2c0-.55-.45-1-1-1zM9 11H4.5L3 12.5V11H1V5h4v3c0 .55.45 1 1 1h3v2zm6-3h-2v1.5L11.5 8H6V2h9v6z"/></svg>
+        Conversation
+
+        <span id="conversation_tab_counter" class="Counter">
+          2
+        </span>
+      </a>
 
     <a href="/OctoLinker/testrepo/pull/1/commits" class="tabnav-tab  js-pjax-history-navigate">
       <svg class="octicon octicon-git-commit" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10.86 7c-.45-1.72-2-3-3.86-3-1.86 0-3.41 1.28-3.86 3H0v2h3.14c.45 1.72 2 3 3.86 3 1.86 0 3.41-1.28 3.86-3H14V7h-3.14zM7 10.2c-1.22 0-2.2-.98-2.2-2.2 0-1.22.98-2.2 2.2-2.2 1.22 0 2.2.98 2.2 2.2 0 1.22-.98 2.2-2.2 2.2z"/></svg>
@@ -560,24 +700,29 @@ from
       <svg class="octicon octicon-diff" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6 7h2v1H6v2H5V8H3V7h2V5h1v2zm-3 6h5v-1H3v1zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6.5zM10 6L7 3H1v12h9V6zM8.5 0H3v1h5l4 4v8h1V4.5L8.5 0z"/></svg>
       Files changed
 
+        <span id="files_tab_counter" class="Counter">
+            1
+        </span>
     </a>
   </nav>
 </div>
 
-  </include-fragment>
 
 
     <h2 class="sr-only">Conversation</h2>
-      <div id="discussion_bucket" class="clearfix pull-request-tab-content is-visible">
+      <div id="discussion_bucket"
+           class="clearfix pull-request-tab-content is-visible js-socket-channel js-updatable-content"
+           data-channel="pull_request:90889453:timeline">
       
 <div class="discussion-sidebar">
   <div id="partial-discussion-sidebar"
   class="js-socket-channel js-updatable-content"
   data-channel="pull_request:90889453"
+  data-gid="MDExOlB1bGxSZXF1ZXN0OTA4ODk0NTM="
   data-url="/OctoLinker/testrepo/issues/1/show_partial?partial=issues%2Fsidebar">
 
-    <div class="discussion-sidebar-item sidebar-assignee js-discussion-sidebar-item position-relative">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/pull/1/review-requests?pr_global_id=MDExOlB1bGxSZXF1ZXN0OTA4ODk0NTM%3D" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="7gPvOBE50ZsNtogiqP72QBsq2+UVoH6ewYFs34C4wsRJRFNayaOxhaDvbEMxfYZBFdpde6xYzNq8eh8C9Dsiqw==" />
+    <div class="discussion-sidebar-item sidebar-assignee js-discussion-sidebar-item position-relative" >
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/pull/1/review-requests?pr_global_id=MDExOlB1bGxSZXF1ZXN0OTA4ODk0NTM%3D" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="1xwYoKiHfJ+BpSpSFHgbD10aCeS0zRhzF4a+aVV3lqCLzMYM6m/lzmdrIW1XnFDRG9kmKSAWN/JuuDXXwW8LSQ==" />
     
 
   <div class="discussion-sidebar-heading text-bold">
@@ -592,40 +737,38 @@ from
 
 
   <div class="discussion-sidebar-item sidebar-assignee js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/issues/1?partial=issues%2Fsidebar%2Fshow%2Fassignees" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="MQobFLeDik8yLj2vAZGyTVNOUl8Mcu3ZcFo1n1TJe7ugxT5t9K0dXa41b4okKr+4xzTwseNJ+IVsQh/1rg1aKQ==" />
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/issues/1?partial=issues%2Fsidebar%2Fshow%2Fassignees" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="BGvyNPGceKhs3rrM+LkFoeJhGLL6CDgtfZvBcqk//qVaxGM0SXaLLftXaEHTGR9fnMdmtSZu6w+Gs2v4XCaDiw==" />
     
 
   <div class="discussion-sidebar-heading text-bold">
     Assignees
   </div>
 
-    <span class="css-truncate">
+    <span class="css-truncate js-issue-assignees">
     No one assigned
 </span>
 
 </form></div>
 
   <div class="discussion-sidebar-item sidebar-labels js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/issues/1?partial=issues%2Fsidebar%2Fshow%2Flabels" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="ekuXO1rlu579C3ntmnvKSRoVlt0kzTHM0EmJmqwZtmnrhLJCGcssjGEQK8i/wMe8jm80M8v2JJDMUaPwVt2X+w==" />
-    <div class="js-issue-labels-container">
-      
+  
+
+
 
   <div class="discussion-sidebar-heading text-bold">
     Labels
   </div>
 
-
-    </div>
-    <div aria-live="polite" aria-label="Labels">
-      <div class="labels css-truncate">
+  <div aria-live="polite" aria-label="Labels">
+    <div class="labels css-truncate js-issue-labels">
     None yet
 </div>
 
-    </div>
-</form></div>
+  </div>
+</div>
 
     <div class="discussion-sidebar-item js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/projects/issues/1" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="G+3iX8+3TJInWWHldEKEtzzMtWdpoKKq84UKK0Vw6LUTf03k7Wi31ZECVsVjFWSCOS3ZI2jV1xICeNsODJzceQ==" />
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/projects/issues/1" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="Q/5lF7n7SzKaHOV41Sq0ZH9588S+wIz/gysaprxIJ4nWcLADdpAs42+RfvXlLQO8Knj3P8ymHMiNiV2a3Ea/8w==" />
     
 
   <div class="discussion-sidebar-heading text-bold">
@@ -640,7 +783,7 @@ from
 </form></div>
 
   <div class="discussion-sidebar-item sidebar-milestone js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/issues/1/set_milestone?partial=issues%2Fsidebar%2Fshow%2Fmilestone" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="2wNfkdirZvW0pnUwtTqzsgabggMw9cgCnoGs7doWv9LqZD5uwnekTRgQZ6Xa4dK70676f8qImOmyFjAS5gvRBA==" />
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" action="/OctoLinker/testrepo/issues/1/set_milestone?partial=issues%2Fsidebar%2Fshow%2Fmilestone" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="apS5Yr2yca8+7EXM4YT8O4+H3HgvVAEaWyGD91TfS4ZEt3RgicceiPcZkHl+pfvy6X5ubyiTiM7e2pwcVNDZyw==" />
     
 
   <div class="discussion-sidebar-heading text-bold">
@@ -659,7 +802,7 @@ from
       1 participant
     </div>
     <div class="participation-avatars d-flex flex-wrap">
-        <a class="participant-avatar" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">
+        <a class="participant-avatar" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">
           <img class="avatar" src="https://avatars3.githubusercontent.com/u/1393946?s=52&amp;v=4" width="26" height="26" alt="@stefanbuck" /> 
 </a>    </div>
   </div>
@@ -668,28 +811,42 @@ from
 
   
 
+
+
+    
+
+</div>
+
+
+<div class="border-top mt-3 py-3 text-gray text-small">
 </div>
 
 
 </div>
 
-<div class="discussion-timeline pull-discussion-timeline js-pull-discussion-timeline js-quote-selection-container js-review-state-classes " >
-  <div class="js-discussion js-socket-channel" data-channel="marked-as-read:pull-request:90889453">
+<div class="discussion-timeline pull-discussion-timeline js-pull-discussion-timeline js-quote-selection-container js-review-state-classes "
+    data-quote-markdown=".js-comment-body" data-issue-and-pr-hovercards-enabled >
+    <div class="js-discussion js-socket-channel" data-channel="marked-as-read:pull-request:90889453">
 
-    <div class="timeline-comment-wrapper js-comment-container mt-0">
-      
+    
+<div class="timeline-comment-wrapper js-comment-container mt-0 js-socket-channel"
+  data-gid="MDExOlB1bGxSZXF1ZXN0OTA4ODk0NTM="
+  data-url="/_render_node/MDExOlB1bGxSZXF1ZXN0OTA4ODk0NTM=/pull_requests/body"
+  data-channel="pull_request:90889453">
+
+  
 
 <div class="avatar-parent-child timeline-comment-avatar">
-    <a class="d-inline-block" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar rounded-1" height="44" width="44" alt="@stefanbuck" src="https://avatars0.githubusercontent.com/u/1393946?s=88&amp;v=4" /></a>
+    <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar rounded-1" height="44" width="44" alt="@stefanbuck" src="https://avatars0.githubusercontent.com/u/1393946?s=88&amp;v=4" /></a>
 
 </div>
 
 
-      
-<div class="timeline-comment-group js-minimizable-comment-group" id="issue-90889453">
+  
+<div class="timeline-comment-group js-minimizable-comment-group js-targetable-comment" id="issue-90889453">
   <div class="unminimized-comment comment previewable-edit js-comment js-task-list-container timeline-comment  "
        data-body-version="d41d8cd98f00b204e9800998ecf8427e"
-       data-unfurl-authenticity-token="74d6yPcC/kniRRchJkkZ7lpv+YZUXrBTBgN9OWIt0zRbxhBsKaDS9rT5bv/3c5PbS+30Zmd+ed7MlC3A9wBdrA==">
+       data-unfurl-authenticity-token="+wt+d4kn7Ufx3c1AUdu97UjMAYuYJIi2dA5tdKYKeCvRtlGsFPC1y0ZWZQBFuC7S5E2p9lHklPGRyX32Ea2keQ==">
 
     
 <div class="timeline-comment-header clearfix">
@@ -702,7 +859,41 @@ from
 
 
 
-<!-- Closes div if we are showing the kebab menu -->
+
+
+
+
+
+
+
+
+<details class="details-overlay details-reset position-relative d-inline-block js-dropdown-details " id="details-pullrequest-90889453">
+  <summary
+    class="btn-link timeline-comment-action"
+    aria-haspopup="true"
+    aria-label="Show options">
+    <svg aria-label="Show options" class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/></svg>
+  </summary>
+  <div class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" role="menu">
+        <clipboard-copy
+    class="dropdown-item btn-link"
+    for="pullrequest-90889453-permalink"
+    aria-label="Copy link"
+    data-toggle-for="details-pullrequest-90889453"
+    role="menuitem">
+    Copy link
+  </clipboard-copy>
+
+        <button
+    type="button"
+    class="dropdown-item btn-link d-none js-comment-quote-reply"
+    data-toggle-for="details-pullrequest-90889453">
+    Quote reply
+  </button>
+
+      
+  </div>
+</details>
 
   </div>
 
@@ -715,17 +906,18 @@ from
 
   <h3 class="timeline-comment-header-text f5 text-normal">
 
+
     <strong class="css-truncate">
       
 
-  <a class="author text-inherit css-truncate-target" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
+  <a class="author text-inherit css-truncate-target" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
   
 
     </strong>
 
     commented
 
-    <a href="#issue-90889453" class="timestamp"><relative-time datetime="2016-10-25T20:53:19Z">Oct 25, 2016</relative-time></a>
+    <a href="#issue-90889453" id="pullrequest-90889453-permalink" class="timestamp js-timestamp"><relative-time datetime="2016-10-25T20:53:19Z">Oct 25, 2016</relative-time></a>
 
 
     <span class="js-comment-fragment">
@@ -767,16 +959,19 @@ from
   </div>
 </div>
 
-    </div>
+</div>
+
 
     
 
-  <div id="js-timeline-progressive-loader" data-timeline-item-src="OctoLinker/testrepo/timeline?id=MDExOlB1bGxSZXF1ZXN0OTA4ODk0NTM%3D&amp;variables%5Bafter%5D=Y3Vyc29yOnYyOpPPAAABV%2F2j3IgH2gAxOTA4ODk0NTM6OTk4MWQxYTk5ZWY4ZmZmMWY1NjljMmFlMjRiMTM2ZDVhMDI3NTEzMg%3D%3D&amp;variables%5Bfirst%5D=80" ></div>
+  <div id="js-timeline-progressive-loader" data-timeline-item-src="OctoLinker/testrepo/timeline?id=MDExOlB1bGxSZXF1ZXN0OTA4ODk0NTM%3D&amp;variables%5Bafter%5D=Y3Vyc29yOnYyOpPPAAABV_2j3IgH2gAxOTA4ODk0NTM6OTk4MWQxYTk5ZWY4ZmZmMWY1NjljMmFlMjRiMTM2ZDVhMDI3NTEzMg%3D%3D&amp;variables%5Bfirst%5D=60" ></div>
 
 
   
+  
 <div class="js-timeline-item js-timeline-progressive-focus-container" data-gid="MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTc0MTIxOA==">
-    
+  
+      
 
 <div class="timeline-comment-wrapper discussion-item-review mt-0
             
@@ -785,11 +980,11 @@ from
             is-writer">
     
 
-<div id="pullrequestreview-5741218" class="timeline-comment js-comment">
+<div id="pullrequestreview-5741218" class="timeline-comment js-comment js-updatable-content js-socket-channel js-targetable-comment" data-gid="MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTc0MTIxOA==" data-channel="pull_request_review:5741218" data-url="/_render_node/MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTc0MTIxOA==/pull_request_reviews/body">
     
 
 <div class="avatar-parent-child timeline-comment-avatar">
-    <a class="d-inline-block" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar rounded-1" height="44" width="44" alt="@stefanbuck" src="https://avatars0.githubusercontent.com/u/1393946?s=88&amp;v=4" /></a>
+    <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar rounded-1" height="44" width="44" alt="@stefanbuck" src="https://avatars0.githubusercontent.com/u/1393946?s=88&amp;v=4" /></a>
 
 </div>
 
@@ -803,7 +998,7 @@ from
           <strong>
             
 
-  <a class="author text-inherit css-truncate-target" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
+  <a class="author text-inherit css-truncate-target" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
   
 
           </strong>
@@ -812,7 +1007,7 @@ from
 
 
           <span class="text-gray">
-              <a href="#pullrequestreview-5741218" class="timestamp">
+              <a href="#pullrequestreview-5741218" class="js-timestamp timestamp">
                 <relative-time datetime="2016-10-25T20:53:36Z">Oct 25, 2016</relative-time>
               </a>
 
@@ -838,7 +1033,7 @@ from
   </div>
 
   
-      
+        
 <div class="discussion-item-body">
       
 
@@ -850,15 +1045,18 @@ from
       sourcereader/popular-cat-names.js
     </a>
 
+
   </div>
-    <div class="blob-wrapper border-bottom">
-    <table id="discussion-diff-84998536" class="diff-table">
       
+  
+<div class="blob-wrapper border-bottom">
+  <table id="discussion-diff-84998536" class="diff-table">
+    
 
 
     <tr data-position="0">
-      <td id="discussion-diff-84998536L0" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
-      <td id="discussion-diff-84998536R0" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
+      <td id="discussion-diff-84998536HL0" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
+      <td id="discussion-diff-84998536HR0" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
       <td class="blob-code blob-code-inner blob-code-hunk">@@ -1,4 +1,4 @@</td>
     </tr>
     <tr>
@@ -912,21 +1110,23 @@ from
       </td>
     </tr>
 
-    </table>
-  </div>
+  </table>
+</div>
 
-  <div class="js-inline-comments-container">
-    
-  <div class="js-line-comments js-quote-selection-container">
+<div class="js-inline-comments-container">
+  <div class="js-line-comments js-quote-selection-container" data-quote-markdown=".js-comment-body">
     <div class="js-comments-holder">
         
 
-  <div class="review-comment js-minimizable-comment-group" id="discussion_r84998536">
+  <div class="review-comment js-minimizable-comment-group js-targetable-comment"
+       id="discussion_r84998536"
+       data-gid="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDg0OTk4NTM2"
+       data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDg0OTk4NTM2/comments/review_comment">
 
     <div class="minimized-comment d-none">
-      
+        
 
-  <details class="Details-element details-reset "
+<details class="Details-element details-reset "
        data-body-version="3695f1fe03728aeb31d9d82dafac5d8d">
     <summary class="text-gray f6">
       <div class="d-flex flex-justify-between flex-items-center">
@@ -939,86 +1139,68 @@ from
 
           </div>
         </h3>
-        <div class="Details-content--closed btn-link text-gray"><svg class="octicon octicon-unfold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z"/></svg>Show comment</div>
-        <div class="Details-content--open btn-link text-gray"><svg class="octicon octicon-fold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"/></svg>Hide comment</div>
-      </div>
-    </summary>
-    <div class="py-2 pl-6 pr-0">
-      <div class="previewable-edit  js-task-list-container ">
-        <div class="edit-comment-hide">
-          <div class="timeline-comment-actions">
-            
-
-
-
-
-
-
-
-<!-- Closes div if we are showing the kebab menu -->
-
-          </div>
-            <a class="float-left mt-1" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar" height="28" width="28" alt="@stefanbuck" src="https://avatars1.githubusercontent.com/u/1393946?s=60&amp;v=4" /></a>
-          <div class="review-comment-contents">
-            <h4 class="f5 text-normal d-inline text-gray-dark">
-              <strong class="text-gray">
-                
-
-  <a class="author text-inherit css-truncate-target" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
-  
-
-              </strong>
-              <span class="text-gray">
-                  <a href="#discussion_r84998536" class="timestamp"><relative-time datetime="2016-10-25T20:53:36Z">Oct 25, 2016</relative-time></a>
-              </span>
-            </h4>
-            
-    <span class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is a member of the OctoLinker organization.">
-      Member
-    </span>
-
-            <task-lists disabled sortable>
-              <div class="comment-body markdown-body p-0 pt-1 js-comment-body ">
-                  <p><g-emoji class="g-emoji" alias="+1" fallback-src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f44d.png">👍</g-emoji></p>
-              </div>
-            </task-lists>
-          </div>
-        </div>
-
+      <div class="text-gray text-small">
+        <a rel="nofollow" class="link-gray" href="/login?return_to=https%3A%2F%2Fgithub.com%2FOctoLinker%2Ftestrepo%2Fpull%2F1">Sign in to view</a>
       </div>
     </div>
-  </details>
+  </summary>
+</details>
+
 
     </div>
 
-  <div class="previewable-edit js-comment js-task-list-container unminimized-comment
-             
-             
-              "
-      data-body-version="3695f1fe03728aeb31d9d82dafac5d8d">
+  <div class="previewable-edit js-suggested-changes-container js-task-list-container unminimized-comment js-comment "
+       data-body-version="3695f1fe03728aeb31d9d82dafac5d8d"
+       data-thread-side="right">
     <div class="edit-comment-hide">
       <div class="timeline-comment-actions">
+        <details class="details-overlay details-reset position-relative d-inline-block js-dropdown-details" id="details-discussion_r84998536">
+          <summary
+              class="btn-link timeline-comment-action"
+              aria-haspopup="true"
+              aria-label="Show more options">
+            <svg aria-label="Show more options" class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/></svg>
+          </summary>
+
+          <div class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in">
+
+            <clipboard-copy
+              class="dropdown-item btn-link tooltipped tooltipped-nw"
+              for="discussion_r84998536-permalink"
+              aria-label="Copy link"
+              data-toggle-for="details-discussion_r84998536"
+              role="menuitem">
+              Copy link
+            </clipboard-copy>
+
+            <button type="button"
+                class="dropdown-item btn-link d-none js-comment-quote-reply"
+                data-toggle-for="details-discussion_r84998536">
+              Quote reply
+            </button>
 
 
 
 
 
-      <!-- Closes div if we are showing the kebab menu -->
+
+
+          </div>
+        </details>
       </div>
 
-
       <span class="float-left mt-1">
-        <a class="d-inline-block" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar" height="28" width="28" alt="@stefanbuck" src="https://avatars1.githubusercontent.com/u/1393946?s=60&amp;v=4" /></a>
+        <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar" height="28" width="28" alt="@stefanbuck" src="https://avatars1.githubusercontent.com/u/1393946?s=60&amp;v=4" /></a>
       </span>
 
-      <div class="review-comment-contents">
+      <div class="review-comment-contents js-suggested-changes-contents" data-thread-side="right">
         <h4 class="f5 text-normal d-inline">
           <strong>
-              <a class="author link-gray-dark" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a> 
+              <a class="author link-gray-dark" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a> 
           </strong>
           <span class="text-gray">
 
-              <a href="#discussion_r84998536" class="timestamp d-inline-block">
+              <a href="#discussion_r84998536" id="discussion_r84998536-permalink" class="js-timestamp timestamp d-inline-block">
                 <relative-time datetime="2016-10-25T20:53:36Z">Oct 25, 2016</relative-time>
               </a>
 
@@ -1037,9 +1219,9 @@ from
         <task-lists disabled sortable>
           <div class="comment-body markdown-body  js-comment-body">
             <p><g-emoji class="g-emoji" alias="+1" fallback-src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f44d.png">👍</g-emoji></p>
-
           </div>
         </task-lists>
+
 
           
 
@@ -1061,8 +1243,6 @@ from
   </div>
 
 
-  </div>
-
 </div>
 
 
@@ -1071,12 +1251,63 @@ from
 </div>
 
 
+
+
 </div>
+
+
+</div>
+
 </div>
 
   
-<div class="js-timeline-item js-timeline-progressive-focus-container" data-gid="MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTc0MjE5OA==">
+  
+<div class="js-timeline-item js-timeline-progressive-focus-container" data-gid="MDIzOkhlYWRSZWZGb3JjZVB1c2hlZEV2ZW50ODM2MTM0MzUy">
+  
+        <div class="discussion-item discussion-item-head_ref_force_pushed" >
+  <h3 class="discussion-item-header f5 text-normal" id="event-836134352">
+
+    <span class="discussion-item-icon">
+      <svg class="octicon octicon-repo-force-push" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 9H8v7H6V9H4l2.25-3H4l3-4 3 4H7.75L10 9zm1-9H1C.45 0 0 .45 0 1v12c0 .55.45 1 1 1h4v-1H1v-2h4v-1H2V1h9v9H9v1h2v2H9v1h2c.55 0 1-.45 1-1V1c0-.55-.45-1-1-1z"/></svg>
+    </span>
+
     
+
+        <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar" height="16" width="16" alt="@stefanbuck" src="https://avatars1.githubusercontent.com/u/1393946?s=60&amp;v=4" /></a>
+  <a class="author text-inherit" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
+  
+
+
+      
+<a data-hydro-click="{&quot;event_type&quot;:&quot;force_push_timeline_diff.click&quot;,&quot;payload&quot;:{&quot;pull_request_id&quot;:90889453,&quot;repository_id&quot;:45358638,&quot;event_id&quot;:836134352,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;3C71:5677:45518F:877EF1:5C02824B&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/pull/1&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="cdc9c6ca558c46fc3904814f7bbebd0ec48328f32d216500ef562bca9626a6e0" href="/OctoLinker/testrepo/compare/64dc9c25b3e09d1d9af437e09d968d08ad5ec903..cc14b0ce8b94b7044f8c5d2d7af656270330bca2">force-pushed</a> the
+<span class="commit-ref user-select-contain">
+  <span class="css-truncate-target">
+    stefanbuck-patch-1
+
+  </span>
+</span>
+branch
+  from
+  <a href="/OctoLinker/testrepo/commit/64dc9c25b3e09d1d9af437e09d968d08ad5ec903"><code class="discussion-item-entity">64dc9c2</code></a>
+  to
+  <a href="/OctoLinker/testrepo/commit/cc14b0ce8b94b7044f8c5d2d7af656270330bca2"><code class="discussion-item-entity">cc14b0c</code></a>
+
+
+    <a href="#event-836134352" class="timestamp"><relative-time datetime="2016-10-25T20:57:24Z">Oct 25, 2016</relative-time></a>
+
+  </h3>
+</div>
+
+
+
+
+</div>
+
+  
+  
+<div class="js-timeline-item js-timeline-progressive-focus-container" data-gid="MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTc0MjE5OA==">
+  
+      
 
 <div class="timeline-comment-wrapper discussion-item-review mt-0
             
@@ -1085,11 +1316,11 @@ from
             is-writer">
     
 
-<div id="pullrequestreview-5742198" class="timeline-comment js-comment">
+<div id="pullrequestreview-5742198" class="timeline-comment js-comment js-updatable-content js-socket-channel js-targetable-comment" data-gid="MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTc0MjE5OA==" data-channel="pull_request_review:5742198" data-url="/_render_node/MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NTc0MjE5OA==/pull_request_reviews/body">
     
 
 <div class="avatar-parent-child timeline-comment-avatar">
-    <a class="d-inline-block" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar rounded-1" height="44" width="44" alt="@stefanbuck" src="https://avatars0.githubusercontent.com/u/1393946?s=88&amp;v=4" /></a>
+    <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar rounded-1" height="44" width="44" alt="@stefanbuck" src="https://avatars0.githubusercontent.com/u/1393946?s=88&amp;v=4" /></a>
 
 </div>
 
@@ -1103,7 +1334,7 @@ from
           <strong>
             
 
-  <a class="author text-inherit css-truncate-target" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
+  <a class="author text-inherit css-truncate-target" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
   
 
           </strong>
@@ -1112,7 +1343,7 @@ from
 
 
           <span class="text-gray">
-              <a href="#pullrequestreview-5742198" class="timestamp">
+              <a href="#pullrequestreview-5742198" class="js-timestamp timestamp">
                 <relative-time datetime="2016-10-25T20:58:52Z">Oct 25, 2016</relative-time>
               </a>
 
@@ -1138,29 +1369,31 @@ from
   </div>
 
   
-      
+        
 <div class="discussion-item-body">
       
 
 
 
-<details class="file outdated-comment details-reset js-comment-container js-resolvable-timeline-thread-container">
-  <summary class="file-header js-toggle-outdated-comments">
-    <span class="btn-link text-gray float-right f6 outdated-comment-label show-outdated-button"><svg class="octicon octicon-unfold position-relative mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z"/></svg>Show outdated</span>
-    <span class="btn-link text-gray float-right f6 outdated-comment-label hide-outdated-button"><svg class="octicon octicon-fold position-relative mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"/></svg>Hide outdated</span>
+<div class="file js-comment-container js-resolvable-timeline-thread-container">
+  <div class="file-header">
         <a href="/OctoLinker/testrepo/pull/1/files/cc14b0ce8b94b7044f8c5d2d7af656270330bca2#diff-ab228c9a0a59a4b87f2c9b2e700f1de6" class="file-info link-gray-dark" title="sourcereader/popular-rabbit-names.js">
       sourcereader/popular-rabbit-names.js
     </a>
 
-  </summary>
-    <div class="blob-wrapper border-bottom">
-    <table id="discussion-diff-84999530" class="diff-table">
+    <span title="Label: Outdated" class="Label Label--outline bg-yellow-light">Outdated</span>
+
+  </div>
       
+  
+<div class="blob-wrapper border-bottom">
+  <table id="discussion-diff-84999530" class="diff-table">
+    
 
 
     <tr data-position="0">
-      <td id="discussion-diff-84999530L1" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
-      <td id="discussion-diff-84999530R1" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
+      <td id="discussion-diff-84999530HL1" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
+      <td id="discussion-diff-84999530HR1" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
       <td class="blob-code blob-code-inner blob-code-hunk">@@ -2,5 +2,4 @@</td>
     </tr>
     <tr>
@@ -1215,21 +1448,23 @@ from
       </td>
     </tr>
 
-    </table>
-  </div>
+  </table>
+</div>
 
-  <div class="js-inline-comments-container">
-    
-  <div class="js-line-comments js-quote-selection-container">
+<div class="js-inline-comments-container">
+  <div class="js-line-comments js-quote-selection-container" data-quote-markdown=".js-comment-body">
     <div class="js-comments-holder">
         
 
-  <div class="review-comment js-minimizable-comment-group" id="discussion_r84999530">
+  <div class="review-comment js-minimizable-comment-group js-targetable-comment"
+       id="discussion_r84999530"
+       data-gid="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDg0OTk5NTMw"
+       data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDg0OTk5NTMw/comments/review_comment">
 
     <div class="minimized-comment d-none">
-      
+        
 
-  <details class="Details-element details-reset "
+<details class="Details-element details-reset "
        data-body-version="47482690f1eb9e38cd7c1373fc7f8204">
     <summary class="text-gray f6">
       <div class="d-flex flex-justify-between flex-items-center">
@@ -1242,86 +1477,68 @@ from
 
           </div>
         </h3>
-        <div class="Details-content--closed btn-link text-gray"><svg class="octicon octicon-unfold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z"/></svg>Show comment</div>
-        <div class="Details-content--open btn-link text-gray"><svg class="octicon octicon-fold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"/></svg>Hide comment</div>
-      </div>
-    </summary>
-    <div class="py-2 pl-6 pr-0">
-      <div class="previewable-edit  js-task-list-container ">
-        <div class="edit-comment-hide">
-          <div class="timeline-comment-actions">
-            
-
-
-
-
-
-
-
-<!-- Closes div if we are showing the kebab menu -->
-
-          </div>
-            <a class="float-left mt-1" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar" height="28" width="28" alt="@stefanbuck" src="https://avatars1.githubusercontent.com/u/1393946?s=60&amp;v=4" /></a>
-          <div class="review-comment-contents">
-            <h4 class="f5 text-normal d-inline text-gray-dark">
-              <strong class="text-gray">
-                
-
-  <a class="author text-inherit css-truncate-target" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
-  
-
-              </strong>
-              <span class="text-gray">
-                  <a href="#discussion_r84999530" class="timestamp"><relative-time datetime="2016-10-25T20:58:52Z">Oct 25, 2016</relative-time></a>
-              </span>
-            </h4>
-            
-    <span class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is a member of the OctoLinker organization.">
-      Member
-    </span>
-
-            <task-lists disabled sortable>
-              <div class="comment-body markdown-body p-0 pt-1 js-comment-body ">
-                  <p><g-emoji class="g-emoji" alias="ok_hand" fallback-src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f44c.png">👌</g-emoji></p>
-              </div>
-            </task-lists>
-          </div>
-        </div>
-
+      <div class="text-gray text-small">
+        <a rel="nofollow" class="link-gray" href="/login?return_to=https%3A%2F%2Fgithub.com%2FOctoLinker%2Ftestrepo%2Fpull%2F1">Sign in to view</a>
       </div>
     </div>
-  </details>
+  </summary>
+</details>
+
 
     </div>
 
-  <div class="previewable-edit js-comment js-task-list-container unminimized-comment
-             
-             
-              "
-      data-body-version="47482690f1eb9e38cd7c1373fc7f8204">
+  <div class="previewable-edit js-suggested-changes-container js-task-list-container unminimized-comment js-comment "
+       data-body-version="47482690f1eb9e38cd7c1373fc7f8204"
+       data-thread-side="left">
     <div class="edit-comment-hide">
       <div class="timeline-comment-actions">
+        <details class="details-overlay details-reset position-relative d-inline-block js-dropdown-details" id="details-discussion_r84999530">
+          <summary
+              class="btn-link timeline-comment-action"
+              aria-haspopup="true"
+              aria-label="Show more options">
+            <svg aria-label="Show more options" class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/></svg>
+          </summary>
+
+          <div class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in">
+
+            <clipboard-copy
+              class="dropdown-item btn-link tooltipped tooltipped-nw"
+              for="discussion_r84999530-permalink"
+              aria-label="Copy link"
+              data-toggle-for="details-discussion_r84999530"
+              role="menuitem">
+              Copy link
+            </clipboard-copy>
+
+            <button type="button"
+                class="dropdown-item btn-link d-none js-comment-quote-reply"
+                data-toggle-for="details-discussion_r84999530">
+              Quote reply
+            </button>
 
 
 
 
 
-      <!-- Closes div if we are showing the kebab menu -->
+
+
+          </div>
+        </details>
       </div>
 
-
       <span class="float-left mt-1">
-        <a class="d-inline-block" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar" height="28" width="28" alt="@stefanbuck" src="https://avatars1.githubusercontent.com/u/1393946?s=60&amp;v=4" /></a>
+        <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar" height="28" width="28" alt="@stefanbuck" src="https://avatars1.githubusercontent.com/u/1393946?s=60&amp;v=4" /></a>
       </span>
 
-      <div class="review-comment-contents">
+      <div class="review-comment-contents js-suggested-changes-contents" data-thread-side="left">
         <h4 class="f5 text-normal d-inline">
           <strong>
-              <a class="author link-gray-dark" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a> 
+              <a class="author link-gray-dark" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a> 
           </strong>
           <span class="text-gray">
 
-              <a href="#discussion_r84999530" class="timestamp d-inline-block">
+              <a href="#discussion_r84999530" id="discussion_r84999530-permalink" class="js-timestamp timestamp d-inline-block">
                 <relative-time datetime="2016-10-25T20:58:52Z">Oct 25, 2016</relative-time>
               </a>
 
@@ -1340,9 +1557,9 @@ from
         <task-lists disabled sortable>
           <div class="comment-body markdown-body  js-comment-body">
             <p><g-emoji class="g-emoji" alias="ok_hand" fallback-src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f44c.png">👌</g-emoji></p>
-
           </div>
         </task-lists>
+
 
           
 
@@ -1364,9 +1581,12 @@ from
   </div>
 
 
-  </div>
+</div>
 
-</details>
+
+
+
+</div>
 
 
 
@@ -1375,11 +1595,57 @@ from
 
 
 </div>
+
 </div>
 
   
-<div class="js-timeline-item js-timeline-progressive-focus-container" data-gid="MDE3OlB1bGxSZXF1ZXN0Q29tbWl0OTA4ODk0NTM6OTk4MWQxYTk5ZWY4ZmZmMWY1NjljMmFlMjRiMTM2ZDVhMDI3NTEzMg==">
+  
+<div class="js-timeline-item js-timeline-progressive-focus-container" data-gid="MDIzOkhlYWRSZWZGb3JjZVB1c2hlZEV2ZW50ODM2MTM2NTk4">
+  
+        <div class="discussion-item discussion-item-head_ref_force_pushed" >
+  <h3 class="discussion-item-header f5 text-normal" id="event-836136598">
+
+    <span class="discussion-item-icon">
+      <svg class="octicon octicon-repo-force-push" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 9H8v7H6V9H4l2.25-3H4l3-4 3 4H7.75L10 9zm1-9H1C.45 0 0 .45 0 1v12c0 .55.45 1 1 1h4v-1H1v-2h4v-1H2V1h9v9H9v1h2v2H9v1h2c.55 0 1-.45 1-1V1c0-.55-.45-1-1-1z"/></svg>
+    </span>
+
     
+
+        <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar" height="16" width="16" alt="@stefanbuck" src="https://avatars1.githubusercontent.com/u/1393946?s=60&amp;v=4" /></a>
+  <a class="author text-inherit" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
+  
+
+
+      
+<a data-hydro-click="{&quot;event_type&quot;:&quot;force_push_timeline_diff.click&quot;,&quot;payload&quot;:{&quot;pull_request_id&quot;:90889453,&quot;repository_id&quot;:45358638,&quot;event_id&quot;:836136598,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;3C71:5677:45518F:877EF1:5C02824B&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/pull/1&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="5203b641e41e5e0671b0963ee598df3473df06f73945c82b1e14abbeaa89226c" href="/OctoLinker/testrepo/compare/cc14b0ce8b94b7044f8c5d2d7af656270330bca2..9981d1a99ef8fff1f569c2ae24b136d5a0275132">force-pushed</a> the
+<span class="commit-ref user-select-contain">
+  <span class="css-truncate-target">
+    stefanbuck-patch-1
+
+  </span>
+</span>
+branch
+  from
+  <a href="/OctoLinker/testrepo/commit/cc14b0ce8b94b7044f8c5d2d7af656270330bca2"><code class="discussion-item-entity">cc14b0c</code></a>
+  to
+  <a href="/OctoLinker/testrepo/commit/9981d1a99ef8fff1f569c2ae24b136d5a0275132"><code class="discussion-item-entity">9981d1a</code></a>
+
+
+    <a href="#event-836136598" class="timestamp"><relative-time datetime="2016-10-25T20:59:14Z">Oct 25, 2016</relative-time></a>
+
+  </h3>
+</div>
+
+
+
+
+</div>
+
+  
+  
+<div class="js-timeline-item js-timeline-progressive-focus-container" data-gid="MDE3OlB1bGxSZXF1ZXN0Q29tbWl0OTA4ODk0NTM6OTk4MWQxYTk5ZWY4ZmZmMWY1NjljMmFlMjRiMTM2ZDVhMDI3NTEzMg==">
+  
+      
 <div class="discussion-item discussion-commits" id="commits-pushed-9981d1a">
   <div class="discussion-item-body">
     <div class="timeline-commits ">
@@ -1397,7 +1663,7 @@ from
 <div class="AvatarStack flex-self-start ">
   <div class="AvatarStack-body" aria-label="stefanbuck">
 
-        <a class="avatar" data-skip-pjax="true" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">
+        <a class="avatar" data-skip-pjax="true" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">
           <img height="20" width="20" alt="@stefanbuck" src="https://avatars1.githubusercontent.com/u/1393946?s=60&amp;v=4" />
 </a>  </div>
 </div>
@@ -1432,6 +1698,7 @@ from
   </div>
 </div>
 
+
 </div>
 
 
@@ -1443,9 +1710,10 @@ from
 <div id="partial-timeline"
       class="js-timeline-marker js-socket-channel js-updatable-content"
       data-channel="pull_request:90889453"
-      data-url="/_render_node/MDExOlB1bGxSZXF1ZXN0OTA4ODk0NTM=/pull_requests/timeline?variables%5BhasFocusedReviewComment%5D=false&amp;variables%5BhasFocusedReviewThread%5D=false&amp;variables%5BsyntaxHighlightingEnabled%5D=true&amp;variables%5BtimelinePageSize%5D=40&amp;variables%5BtimelineSince%5D=2016-10-25T20%3A59%3A17Z"
-      data-last-modified="Tue, 25 Oct 2016 20:59:17 GMT">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="d-none js-timeline-marker-form" action="/_graphql/MarkNotificationSubjectAsRead" accept-charset="UTF-8" data-remote="true" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="6D5Qh3Vu9VVkM8dBvwLEYd9YFCc8Z3pf5WH6DXHU2ut5XR8MNa3hnHxGRKxcQjD16NSj7yOYNtc5fnjeghWeog==" />
+      data-url="/_render_node/MDExOlB1bGxSZXF1ZXN0OTA4ODk0NTM=/pull_requests/unread_timeline?variables%5BhasFocusedReviewComment%5D=false&amp;variables%5BhasFocusedReviewThread%5D=false&amp;variables%5BsyntaxHighlightingEnabled%5D=true&amp;variables%5BtimelinePageSize%5D=30&amp;variables%5BtimelineSince%5D=2016-10-25T20%3A59%3A17Z"
+      data-last-modified="Tue, 25 Oct 2016 20:59:17 GMT"
+      data-gid="MDExOlB1bGxSZXF1ZXN0OTA4ODk0NTM=">
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="d-none js-timeline-marker-form" action="/_graphql/MarkNotificationSubjectAsRead" accept-charset="UTF-8" data-remote="true" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="NlVqXF8t3Aq7iVvjJKfDWh+QOns0CkF/9jSmDs3J+IqW1TA3mCfPmIK4mAXRL9Bxqoox8bkojlY0AzvUoEmAIQ==" />
     <input type="hidden" name="variables[subjectId]" value="MDExOlB1bGxSZXF1ZXN0OTA4ODk0NTM=">
 </form></div>
 
@@ -1466,6 +1734,23 @@ from
 
     </div>
   </div>
+  <div hidden>
+  <span class="js-add-to-batch-enabled">Add this suggestion to a batch that can be applied as a single commit.</span>
+  <span class="js-unchanged-suggestion">This suggestion is invalid because no changes were made to the code.</span>
+  <span class="js-closed-pull">Suggestions cannot be applied while the pull request is closed.</span>
+  <span class="js-viewing-subset-changes">Suggestions cannot be applied while viewing a subset of changes.</span>
+  <span class="js-one-suggestion-per-line">Only one suggestion per line can be applied in a batch.</span>
+  <span class="js-reenable-add-to-batch">Add this suggestion to a batch that can be applied as a single commit.</span>
+  <span class="js-validation-on-left-blob">Applying suggestions on deleted lines is not supported.</span>
+  <span class="js-validation-on-right-blob">You must change the existing code in this line in order to create a valid suggestion.</span>
+  <span class="js-outdated-comment">Outdated suggestions cannot be applied.</span>
+  <span class="js-resolved-thread">This suggestion has been applied or marked resolved.</span>
+  <span class="js-pending-review">Suggestions cannot be applied from pending reviews.</span>
+  <div class="form-group errored m-0 error js-suggested-changes-inline-validation-template d-flex" style="cursor: default;">
+    <span class="js-suggested-changes-inline-error-message position-relative error m-0" style="max-width: inherit;"></span>
+  </div>
+</div>
+
 
   </div>
 
@@ -1482,22 +1767,22 @@ from
 <div class="footer container-lg px-3" role="contentinfo">
   <div class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light ">
     <ul class="list-style-none d-flex flex-wrap ">
-      <li class="mr-3">&copy; 2018 <span title="1.13361s from unicorn-b66bb5cf9-nwdhj">GitHub</span>, Inc.</li>
+      <li class="mr-3">&copy; 2018 <span title="0.56289s from unicorn-8685494797-6b7dq">GitHub</span>, Inc.</li>
         <li class="mr-3"><a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms">Terms</a></li>
         <li class="mr-3"><a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy">Privacy</a></li>
-        <li class="mr-3"><a href="https://help.github.com/articles/github-security/" data-ga-click="Footer, go to security, text:security">Security</a></li>
+        <li class="mr-3"><a href="/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
         <li class="mr-3"><a href="https://status.github.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
         <li><a data-ga-click="Footer, go to help, text:help" href="https://help.github.com">Help</a></li>
     </ul>
 
-    <a aria-label="Homepage" title="GitHub" class="footer-octicon" href="https://github.com">
+    <a aria-label="Homepage" title="GitHub" class="footer-octicon mr-lg-4" href="https://github.com">
       <svg height="24" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
 </a>
    <ul class="list-style-none d-flex flex-wrap ">
         <li class="mr-3"><a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact">Contact GitHub</a></li>
+        <li class="mr-3"><a href="https://github.com/pricing" data-ga-click="Footer, go to Pricing, text:Pricing">Pricing</a></li>
       <li class="mr-3"><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
       <li class="mr-3"><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
-      <li class="mr-3"><a href="https://shop.github.com" data-ga-click="Footer, go to shop, text:shop">Shop</a></li>
         <li class="mr-3"><a href="https://blog.github.com" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
         <li><a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a></li>
 
@@ -1519,10 +1804,10 @@ from
   </div>
 
 
-    <script crossorigin="anonymous" integrity="sha512-wIuAKDhvxe9wCaNR1tzCk3rtl+wXEWC28rmRpzmx0h98VEeWC6Y3xCWV1xAW6NP6eQQX+x8ZGhW6Sdut+mLRuw==" type="application/javascript" src="https://assets-cdn.github.com/assets/compat-a48960bafc17c30572990bbab3664e9c.js"></script>
-    <script crossorigin="anonymous" integrity="sha512-T5YBL6byTrSWXd5XhwPeN91OHxxm7jO3OKRwlJpSbnzS8StPr/8h7OJKbLnVFO11CIbQGfv4rsGdsyRP2hyPDw==" type="application/javascript" src="https://assets-cdn.github.com/assets/frameworks-1a53a87937bf67db3a8755ade0d1aa93.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-WnyO4VoIUwWWQOmFLjYf4UGg/c1z9VlaLN8IMuiI3uMhhl6rejyThRdLPDyePeUPW6N+38OoBMs6AkqcvWALtA==" type="application/javascript" src="https://assets-cdn.github.com/assets/compat-b66b5d97b4442a01f057c74b091c4368.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-glXpCrOqxNGPFRZ0xGRWMgpYC4Xn/c/CL82vk2eeRostCZHF7Px1wBjxv6Wohcq9+xhM1Lt7DvrkWcSvF3j28w==" type="application/javascript" src="https://assets-cdn.github.com/assets/frameworks-7fcedd2a70cd3dde438cbad4c2d08128.js"></script>
     
-    <script crossorigin="anonymous" async="async" integrity="sha512-ZrDYjGIqlGGaG1GSHOH63EE/l7t50rQzDVzGjouPFMRY7kaFss37h4UiSGfJj0BjL2gX4Yeo7xNEUVE5GHcWaQ==" type="application/javascript" src="https://assets-cdn.github.com/assets/github-a81c60bf5144275576e157b9f381c39c.js"></script>
+    <script crossorigin="anonymous" async="async" integrity="sha512-NnkR3Qo+4D5ma5koFlDfAf9bKKHnuAC5BlrEUdKfDKZo46qS4hjt+C4Uw5KtLsTBASZoMneayDVNRxQRucQXqw==" type="application/javascript" src="https://assets-cdn.github.com/assets/github-927061254931b1e409112c1baeed3a26.js"></script>
     
     
     
@@ -1540,6 +1825,18 @@ from
     </button>
   </div>
 </div>
+
+  <template id="site-details-dialog">
+  <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark" open>
+    <summary aria-haspopup="dialog" aria-label="Close dialog"></summary>
+    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast">
+      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
+        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+      </button>
+      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
+    </details-dialog>
+  </details>
+</template>
 
   <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
   <div class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large" style="width:360px;">

--- a/packages/blob-reader/fixtures/github.com/pull/diff.html
+++ b/packages/blob-reader/fixtures/github.com/pull/diff.html
@@ -18,11 +18,12 @@
 
 
 
-  <link crossorigin="anonymous" media="all" integrity="sha512-qQ+v+W1uJYfDMrQ/cwCVI+AGTsn1yi4rCU6KX45obe52BoF+WiHNeQ11u63iJA05vyivY57xNbhAsyK4/j1ZIQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/frameworks-01356238c65ce56a395237b592b58668.css" />
-  <link crossorigin="anonymous" media="all" integrity="sha512-I/jquBVUOVtEQ8ehveYgKO7ocZSEM5uc5vLFYM12R0EPDDFGfJOUf2gKgR3JBad6KH8L69CxKe0xyYLhMYLOsw==" rel="stylesheet" href="https://assets-cdn.github.com/assets/github-914619a4164d34dd9bc73702931c9f3b.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-lLo2nlsdl+bHLu6PGvC2j3wfP45RnK4wKQLiPnCDcuXfU38AiD+JCdMywnF3WbJC1jaxe3lAI6AM4uJuMFBLEw==" rel="stylesheet" href="https://assets-cdn.github.com/assets/frameworks-08fc49d3bd2694c870ea23d0906f3610.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-4kfWSrzu4OShEnC5m0lqUCfKkZfG7JH0ff4wnEtubTUTZqV5pS5oUMTOvWE2DDL7ttjZ9FpnZInl/0TLO3EIiA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/github-6c1d4c04bb55a87b9cb81ffdbd683662.css" />
   
   
-  <link crossorigin="anonymous" media="all" integrity="sha512-2jE+5s+6LV2ckEshC+YTwb0A/IhES9iLMcwfkkybRMMGemXcEjAx8wdd2ZbbVr1dYBJt+fkCaR+UvXiybFr/sA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/site-99075769314a73391cea9aa2907a29f9.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-PcJMPDRp7jbbEAmTk9kaL2kRQqg69QZ26WsZf07xsPyaipKsi3wVG0805PZNYXxotPDAliKKFvNSQPhD8fp1FQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/site-50c740d9290419d070dd6213a7cd03b5.css" />
+  
   
 
   <meta name="viewport" content="width=device-width">
@@ -40,7 +41,7 @@
   
   <meta name="pjax-timeout" content="1000">
   
-  <meta name="request-id" content="F366:1E00:5C65B65:B2285D5:5B60705F" data-pjax-transient>
+  <meta name="request-id" content="3C17:5678:C3F4C3:168BC54:5C02824D" data-pjax-transient>
 
     <meta name="hovercard-subject-tag" content="pull_request:90889453" data-pjax-transient>
 
@@ -48,18 +49,20 @@
 
   <meta name="selected-link" value="repo_pulls" data-pjax-transient>
 
-    <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
-  <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
-  <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
-    <meta name="google-analytics" content="UA-3769691-2">
+      <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+    <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+    <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
 
-<meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="F366:1E00:5C65B65:B2285D5:5B60705F" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
+  <meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="3C17:5678:C3F4C3:168BC54:5C02824D" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
 <meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/pull_requests/show/files" data-pjax-transient="true" />
 
 
 
+    <meta name="google-analytics" content="UA-3769691-2">
+
 
 <meta class="js-ga-set" name="dimension1" content="Logged Out">
+
 
 
   
@@ -68,13 +71,13 @@
     <meta name="user-login" content="">
 
       <meta name="expected-hostname" content="github.com">
-    <meta name="js-proxy-site-detection-payload" content="YTJhY2UyYzU3OWVmMGQwNmNkMTYyMDFiNzBlZDBkYTU5YzRhNDZmOWQzYzcyODZkYmZiMDJlMGU4NDZkYmFkY3x7InJlbW90ZV9hZGRyZXNzIjoiNzguNDMuMjUuMjEyIiwicmVxdWVzdF9pZCI6IkYzNjY6MUUwMDo1QzY1QjY1OkIyMjg1RDU6NUI2MDcwNUYiLCJ0aW1lc3RhbXAiOjE1MzMwNDY4NzksImhvc3QiOiJnaXRodWIuY29tIn0=">
+    <meta name="js-proxy-site-detection-payload" content="N2YzNTkzN2QzNTQ0NWVkYjc3ZDM2OGMzNzFlMjc1OTllMjgxZTc1ZmFhNzVhMTU1M2QzYjkwMTAzOTM1ZGMwMHx7InJlbW90ZV9hZGRyZXNzIjoiNDYuMjIzLjE5My4xODEiLCJyZXF1ZXN0X2lkIjoiM0MxNzo1Njc4OkMzRjRDMzoxNjhCQzU0OjVDMDI4MjREIiwidGltZXN0YW1wIjoxNTQzNjY4MzAyLCJob3N0IjoiZ2l0aHViLmNvbSJ9">
 
-    <meta name="enabled-features" content="DASHBOARD_V2_LAYOUT_OPT_IN,EXPLORE_DISCOVER_REPOSITORIES,UNIVERSE_BANNER,FREE_TRIALS,MARKETPLACE_INSIGHTS,MARKETPLACE_PLAN_RESTRICTION_EDITOR,MARKETPLACE_SEARCH,MARKETPLACE_INSIGHTS_CONVERSION_PERCENTAGES">
+    <meta name="enabled-features" content="DASHBOARD_V2_LAYOUT_OPT_IN,EXPLORE_DISCOVER_REPOSITORIES,UNIVERSE_BANNER,MARKETPLACE_PLAN_RESTRICTION_EDITOR">
 
-  <meta name="html-safe-nonce" content="6a89f5bec6913ed5335da5c9119b939a592b0d7e">
+  <meta name="html-safe-nonce" content="ff8a264933979cbf2ac9b9b4f1e9e73b0697997e">
 
-  <meta http-equiv="x-pjax-version" content="667434520185c1ed6aaeb4d9a450ac61">
+  <meta http-equiv="x-pjax-version" content="cdc9a5bb30661c6c1c8e99ce4d3646f2">
   
 
       <link data-pjax-transient rel="alternate" type="text/x-diff" href="/OctoLinker/testrepo/pull/1.diff">
@@ -101,11 +104,11 @@
 
 
 
-<link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
+  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
 
   </head>
 
-  <body class="logged-out env-production">
+  <body class="logged-out env-production ">
     
 
   <div class="position-relative js-header-wrapper ">
@@ -117,55 +120,129 @@
     
 
 
-
         
-
-
-  <header class="Header header-logged-out  position-relative f4 py-3" role="banner" >
-    <div class="container-lg d-flex px-3">
-      <div class="d-flex flex-justify-between flex-items-center">
-        <a class="header-logo-invertocat my-0" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark; experiment:site_header_dropdowns; group:control">
-          <svg height="32" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+<header class="Header header-logged-out  position-relative f4 py-3" role="banner">
+  <div class="container-lg d-flex px-3">
+    <div class="d-flex flex-justify-between flex-items-center">
+        <a class="mr-4" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark; experiment:site_header_dropdowns; group:dropdowns">
+          <svg height="32" class="octicon octicon-mark-github text-white" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
         </a>
+    </div>
 
+    <div class="HeaderMenu HeaderMenu--logged-out d-flex flex-justify-between flex-items-center flex-auto">
+      <div class="d-none">
+        <button class="btn-link js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
+          <svg height="24" class="octicon octicon-x text-gray" viewBox="0 0 12 16" version="1.1" width="18" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+        </button>
       </div>
 
-      <div class="HeaderMenu d-flex flex-justify-between flex-auto">
-          <nav class="mt-0">
-            <ul class="d-flex list-style-none">
-                <li class="ml-2">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:features; experiment:site_header_dropdowns; group:control" data-selected-links="/features /features/project-management /features/code-review /features/project-management /features/integrations /features" href="/features">
-                    Features
-</a>                </li>
-                <li class="ml-4">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:business; experiment:site_header_dropdowns; group:control" data-selected-links="/business /business/security /business/customers /business" href="/business">
-                    Business
-</a>                </li>
+        <nav class="mt-0" aria-label="Global">
+          <ul class="d-flex list-style-none">
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
+                    Why GitHub?
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 mt-0  p-4 left-n4 position-absolute">
+                    <a href="/features" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Features <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+                    <ul class="list-style-none f5 pb-3">
+                      <li class="edge-item-fix"><a href="/features/code-review/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code review">Code review</a></li>
+                      <li class="edge-item-fix"><a href="/features/project-management/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Project management">Project management</a></li>
+                      <li class="edge-item-fix"><a href="/features/integrations" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Integrations">Integrations</a></li>
+                      <li class="edge-item-fix"><a href="/features#team-management" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team management">Team management</a></li>
+                      <li class="edge-item-fix"><a href="/features#social-coding" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Social coding">Social coding</a></li>
+                      <li class="edge-item-fix"><a href="/features#documentation" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Documentation">Documentation</a></li>
+                      <li class="edge-item-fix"><a href="/features#code-hosting" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code hosting">Code hosting</a></li>
+                    </ul>
 
-                <li class="ml-4">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:explore; experiment:site_header_dropdowns; group:control" data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship showcases showcases_search showcases_landing /explore" href="/explore">
+                    <ul class="list-style-none mb-0 border-lg-top pt-lg-3">
+                      <li class="edge-item-fix"><a href="/case-studies" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Case studies">Case Studies <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="/security" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Security">Security <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+              <li class=" mr-3 mr-lg-3">
+                <a href="/business" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Business">Business</a>
+              </li>
+
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
                     Explore
-</a>                </li>
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
 
-                <li class="ml-4">
-                      <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:marketplace; experiment:site_header_dropdowns; group:control" data-selected-links=" /marketplace" href="/marketplace">
-                        Marketplace
-</a>                </li>
-                <li class="ml-4">
-                  <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:pricing; experiment:site_header_dropdowns; group:control" data-selected-links="/pricing /pricing/developer /pricing/team /pricing/business-hosted /pricing/business-enterprise /pricing" href="/pricing">
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-0 mt-0  p-4 left-n4 position-absolute">
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/explore" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Explore GitHub <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Learn &amp; contribute</h4>
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/topics" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Topics">Topics</a></li>
+                      <li class="edge-item-fix"><a href="/collections" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Collections">Collections</a></li>
+                      <li class="edge-item-fix"><a href="/trending" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Trending">Trending</a></li>
+                      <li class="edge-item-fix"><a href="https://lab.github.com/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Learning lab">Learning Lab</a></li>
+                      <li class="edge-item-fix"><a href="https://opensource.guide" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Open source guides">Open source guides</a></li>
+                    </ul>
+
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Connect with others</h4>
+                    <ul class="list-style-none mb-0">
+                      <li class="edge-item-fix"><a href="/events" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Events">Events</a></li>
+                      <li class="edge-item-fix"><a href="https://github.community" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Community forum">Community forum</a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com" class="py-2 pb-0 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to GitHub Education">GitHub Education</a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+
+              <li class=" mr-3 mr-lg-3">
+                <a href="/marketplace" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Marketplace">Marketplace</a>
+              </li>
+
+              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
                     Pricing
-</a>                </li>
-            </ul>
-          </nav>
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                       <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
 
-        <div class="d-flex">
-            <div class="d-lg-flex flex-items-center mr-3">
-              <div class="header-search scoped-search site-scoped-search js-site-search position-relative js-jump-to"
-  role="search combobox"
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-4 mt-0  p-4 left-n4 position-absolute">
+                    <a href="/pricing" class="pb-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Pricing">Plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/pricing/developer" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Developers">Developer</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/team" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team">Team</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/business-cloud" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Business Cloud">Business Cloud</a></li>
+                      <li class="edge-item-fix"><a href="/pricing/enterprise" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Enterprise">Enterprise</a></li>
+                    </ul>
+
+                    <ul class="list-style-none mb-0  border-top pt-3">
+                      <li class="edge-item-fix"><a href="/pricing#feature-comparison" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Compare features">Compare plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="/nonprofit" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Nonprofits">Nonprofit <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com/discount_requests/new" class="py-2 pb-0 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover"  data-ga-click="(Logged out) Header, go to Education">Education <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+          </ul>
+        </nav>
+
+      <div class="d-flex flex-items-center px-0 text-center text-left">
+          <div class="d-lg-flex mr-3">
+            <div class="header-search scoped-search site-scoped-search js-site-search position-relative js-jump-to"
+  role="combobox"
   aria-owns="jump-to-results"
   aria-label="Search or jump to"
   aria-haspopup="listbox"
-  aria-expanded="true"
+  aria-expanded="false"
 >
   <div class="position-relative">
     <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-site-search-form" data-scope-type="Repository" data-scope-id="45358638" data-scoped-search-url="/OctoLinker/testrepo/search" data-unscoped-search-url="/search" action="/OctoLinker/testrepo/search" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
@@ -181,72 +258,138 @@
           autocapitalize="off"
           aria-autocomplete="list"
           aria-controls="jump-to-results"
-          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=uPSmr4eg3NWCt6Fy4tYq9ietGZCPLD/c9ao3kAcqB8EWpbk6w3FbXB4dl0gLAPgtT3816s/H2LWUetiLP6gYgA=="
+          aria-label="Search"
+          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=zhXG1XFMaDWQ94QmQyutAd0iVyu2RTbusKo/gT/gu5I/pP4xPsXvbE0TG886dHmGtsoUfcskeCELqSLimDVKIA=="
           spellcheck="false"
           autocomplete="off"
           >
           <input type="hidden" class="js-site-search-type-field" name="type" >
-            <img src="https://assets-cdn.github.com/images/search-shortcut-hint.svg" alt="" class="mr-2 header-search-key-slash">
+            <img src="https://assets-cdn.github.com/images/search-key-slash.svg" alt="" class="mr-2 header-search-key-slash">
 
             <div class="Box position-absolute overflow-hidden d-none jump-to-suggestions js-jump-to-suggestions-container">
-              <ul class="d-none js-jump-to-suggestions-template-container">
-                <li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item">
-                  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center p-2 jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open" href="">
-                    <div class="jump-to-octicon js-jump-to-octicon mr-2 text-center d-none"></div>
-                    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar" alt="" aria-label="Team" src="" width="28" height="28">
+              
+<ul class="d-none js-jump-to-suggestions-template-container">
+  
 
-                    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
-                    </div>
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-suggestion" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
 
-                    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
-                      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
-                        In this repository
-                      </span>
-                      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
-                        All GitHub
-                      </span>
-                      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
-                    </div>
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
 
-                    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
-                      Jump to
-                      <span class="d-inline-block ml-1 v-align-middle">↵</span>
-                    </div>
-                  </a>
-                </li>
-                <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-repo-octicon-template" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-                <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-project-octicon-template" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-                <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-search-octicon-template" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
-              </ul>
-              <ul class="d-none js-jump-to-no-results-template-container">
-                <li class="d-flex flex-justify-center flex-items-center p-3 f5 d-none">
-                  <span class="text-gray">No suggested jump to results</span>
-                </li>
-              </ul>
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
 
-              <ul id="jump-to-results" class="js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container" >
-                <li class="d-flex flex-justify-center flex-items-center p-0 f5">
-                  <img src="https://assets-cdn.github.com/images/spinners/octocat-spinner-128.gif" alt="Octocat Spinner Icon" class="m-2" width="28">
-                </li>
-              </ul>
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+</ul>
+
+<ul class="d-none js-jump-to-no-results-template-container">
+  <li class="d-flex flex-justify-center flex-items-center f5 d-none js-jump-to-suggestion p-2">
+    <span class="text-gray">No suggested jump to results</span>
+  </li>
+</ul>
+
+<ul id="jump-to-results" role="listbox" class="p-0 m-0 js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container">
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-scoped-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-global-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+        In this repository
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+
+</ul>
+
             </div>
       </label>
 </form>  </div>
 </div>
 
-            </div>
+          </div>
 
-          <span class="d-inline-block">
-              <div class="HeaderNavlink px-0 py-2 m-0">
-                <a class="text-bold text-white no-underline" href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fpull%2F1%2Ffiles" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in; experiment:site_header_dropdowns; group:control">Sign in</a>
-                  <span class="text-gray">or</span>
-                  <a class="text-bold text-white no-underline" href="/join?source=header-repo" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up; experiment:site_header_dropdowns; group:control">Sign up</a>
-              </div>
-          </span>
-        </div>
+        <a class="HeaderMenu-link no-underline mr-3" href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fpull%2F1%2Ffiles" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign&nbsp;in</a>
+          <a class="HeaderMenu-link d-inline-block no-underline border border-gray-dark rounded-1 px-2 py-1" href="/join" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">Sign&nbsp;up</a>
       </div>
     </div>
-  </header>
+  </div>
+</header>
 
   </div>
 
@@ -259,7 +402,7 @@
 
 
 
-  <div role="main" class="application-main ">
+  <div role="main" class="application-main " >
         <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
     <div id="js-repo-pjax-container" data-pjax-container >
       
@@ -278,9 +421,9 @@
       <ul class="pagehead-actions">
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-s"
     aria-label="You must be signed in to watch a repository" rel="nofollow">
-    <svg class="octicon octicon-eye" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
+    <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
     Watch
   </a>
   <a class="social-count" href="/OctoLinker/testrepo/watchers"
@@ -292,9 +435,9 @@
 
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-s"
     aria-label="You must be signed in to star a repository" rel="nofollow">
-    <svg class="octicon octicon-star" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
+    <svg class="octicon octicon-star v-align-text-bottom" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
     Star
   </a>
 
@@ -307,9 +450,9 @@
 
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
-        class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+        class="btn btn-sm btn-with-count tooltipped tooltipped-s"
         aria-label="You must be signed in to fork a repository" rel="nofollow">
-        <svg class="octicon octicon-repo-forked" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
+        <svg class="octicon octicon-repo-forked v-align-text-bottom" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
         Fork
       </a>
 
@@ -322,7 +465,7 @@
 
       <h1 class="public ">
   <svg class="octicon octicon-repo" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-  <span class="author" itemprop="author"><a class="url fn" rel="author" href="/OctoLinker">OctoLinker</a></span><!--
+  <span class="author" itemprop="author"><a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/OctoLinker/hovercard" href="/OctoLinker">OctoLinker</a></span><!--
 --><span class="path-divider">/</span><!--
 --><strong itemprop="name"><a data-pjax="#js-repo-pjax-container" href="/OctoLinker/testrepo">testrepo</a></strong>
 
@@ -333,7 +476,7 @@
 <nav class="reponav js-repo-nav js-sidenav-container-pjax container"
      itemscope
      itemtype="http://schema.org/BreadcrumbList"
-     role="navigation"
+    aria-label="Repository"
      data-pjax="#js-repo-pjax-container">
 
   <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
@@ -352,12 +495,13 @@
 </a>    </span>
 
   <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-    <a data-hotkey="g p" itemprop="url" class="js-selected-navigation-item selected reponav-item" data-selected-links="repo_pulls checks /OctoLinker/testrepo/pulls" href="/OctoLinker/testrepo/pulls">
+    <a data-hotkey="g p" itemprop="url" class="js-selected-navigation-item selected reponav-item" aria-current="page" data-selected-links="repo_pulls checks /OctoLinker/testrepo/pulls" href="/OctoLinker/testrepo/pulls">
       <svg class="octicon octicon-git-pull-request" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
       <span itemprop="name">Pull requests</span>
       <span class="Counter">1</span>
       <meta itemprop="position" content="3">
 </a>  </span>
+
 
     <a data-hotkey="g b" class="js-selected-navigation-item reponav-item" data-selected-links="repo_projects new_repo_project repo_project /OctoLinker/testrepo/projects" href="/OctoLinker/testrepo/projects">
       <svg class="octicon octicon-project" viewBox="0 0 15 16" version="1.1" width="15" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
@@ -366,7 +510,7 @@
 </a>
 
 
-  <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse /OctoLinker/testrepo/pulse" href="/OctoLinker/testrepo/pulse">
+  <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse alerts security /OctoLinker/testrepo/pulse" href="/OctoLinker/testrepo/pulse">
     <svg class="octicon octicon-graph" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"/></svg>
     Insights
 </a>
@@ -380,7 +524,8 @@
   <div class="repository-content ">
 
     
-  <div class="issues-listing js-review-state-classes " data-pjax>
+  <div class="issues-listing js-review-state-classes  js-suggested-changes-files-tab " data-pjax data-issue-and-pr-hovercards-enabled>
+
     <div id="files_bucket" class="files-bucket files-next-bucket clearfix pull-request-tab-content is-visible">
       
 
@@ -388,9 +533,11 @@
         
   <div
     id="partial-discussion-header"
-    class="gh-header js-details-container Details js-socket-channel js-updatable-content pull request"
+    class="gh-header js-details-container Details js-socket-channel js-updatable-content js-pull-header-details pull request"
     data-channel="pull_request:90889453"
-    data-url="/OctoLinker/testrepo/pull/1/show_partial?partial=pull_requests%2Ftitle">
+    data-url="/OctoLinker/testrepo/pull/1/show_partial?partial=pull_requests%2Ftitle"
+    data-pull-is-open="true"
+    data-gid="MDExOlB1bGxSZXF1ZXN0OTA4ODk0NTM=">
 
   <div class="gh-header-show ">
       <div class="gh-header-actions">
@@ -415,20 +562,20 @@
   <strong>Have a question about this project?</strong> Sign up for a free GitHub account to open an issue and contact its maintainers and the community.
   </p>
 
-  <form class="js-signup-form" autocomplete="off" action="/join?return_to=%2FOctoLinker%2Ftestrepo%2Fissues%2Fnew" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="H2Rk9Y0+RsHZocd0nenkOkspy74jpNQho3r2tDYIb/uUzrrozq5YaCTyVyjvfetGV6GFzYEE/jqj+G04MVPkIw==" />    <auto-check src="/signup_check/username" csrf="FIYaTN5/MU8+uu/SMYdf6EtJtoeoKn6piVss73AD39+ncTHQ1JwCUyPLaPWsoSnTvOVDXwC7nxN+lVux93U77g==">
-      <dl class="form-group"><dt class="input-label"><label name="user[login]" data-facebox-id="user-login-issues" autocapitalize="off" autofocus="autofocus" for="user_login_issues">Pick a username</label></dt><dd><input name="user[login]" data-facebox-id="user-login-issues" autocapitalize="off" autofocus="autofocus" class="form-control" type="text" id="user_login_issues" /></dd></dl>
+  <form class="js-signup-form" autocomplete="off" action="/join?return_to=%2FOctoLinker%2Ftestrepo%2Fissues%2Fnew" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="Nbmuhyx5pmIrKCrUcU4FBO+kji4d/j/NCu/lMWBjOF5g1hFU4eLlyfppxRd5WpP3qK9xHQxabGDyIF9Ct46UZQ==" />    <auto-check src="/signup_check/username" csrf="6hbC/UL4be17vzJzOsdVjj/OdOi7PHMokPLFHVgBw25uqArn+PHevcncMci4UPvM3y3H+l/6/JqYsgHAKHeQpA==">
+      <dl class="form-group"><dt class="input-label"><label name="user[login]" autocapitalize="off" autofocus="autofocus" for="user_login_issues">Pick a username</label></dt><dd><input name="user[login]" autocapitalize="off" autofocus="autofocus" class="form-control" type="text" id="user_login_issues" /></dd></dl>
     </auto-check>
 
-    <auto-check src="/signup_check/email" csrf="CIangMmtB4t66lNSLG8U2yzq3byhgb7yIkW+np3C4Hg2xLA+8rf1rkKLWOaxBL5ojoBbScjYUCizknfEGFEZbw==">
-      <dl class="form-group"><dt class="input-label"><label name="user[email]" data-facebox-id="user-email-issues" autocapitalize="off" for="user_email_issues">Email Address</label></dt><dd><input name="user[email]" data-facebox-id="user-email-issues" autocapitalize="off" class="form-control" type="text" id="user_email_issues" /></dd></dl>
+    <auto-check src="/signup_check/email" csrf="KcLW+n+U4Cfln2dd2kIcONqkMWEaWM1FmVBO4f0a7szyjTfhzWn7bLsPDmEOSrLfHiSAWx81hJ+eW6N8Gf1hDw==">
+      <dl class="form-group"><dt class="input-label"><label name="user[email]" autocapitalize="off" for="user_email_issues">Email Address</label></dt><dd><input name="user[email]" autocapitalize="off" class="form-control" type="text" id="user_email_issues" /></dd></dl>
     </auto-check>
 
-    <dl class="form-group"><dt class="input-label"><label name="user[password]" data-facebox-id="user-password-issues" for="user_password_issues">Password</label></dt><dd><input name="user[password]" data-facebox-id="user-password-issues" class="form-control" type="password" id="user_password_issues" /></dd></dl>
+    <dl class="form-group"><dt class="input-label"><label name="user[password]" for="user_password_issues">Password</label></dt><dd><input name="user[password]" class="form-control" type="password" id="user_password_issues" /></dd></dl>
 
     <input type="hidden" name="source" class="js-signup-source" value="modal-issues">
-    <input type="text" name="required_field_8745" id="required_field_8745" hidden="hidden" class="form-control" />
-<input type="hidden" name="timestamp" value="1533046879674" class="form-control" />
-<input type="hidden" name="timestamp_secret" value="088a768447c79fb077b50aa1d239f1328e9f8a76cfe26245af20008f4ffb624c" class="form-control" />
+    <input type="text" name="required_field_7692" id="required_field_7692" hidden="hidden" class="form-control" />
+<input type="hidden" name="timestamp" value="1543668302071" class="form-control" />
+<input type="hidden" name="timestamp_secret" value="9f54b492074ad6ab15a2af24f734218cbe6cf3f0c858a67b3d02e2dd83d5ee72" class="form-control" />
 
 
     <button class="btn btn-primary mt-2 btn-block" type="submit" data-ga-click="(Logged out) New issue modal, clicked Sign up, text:sign-up">Sign up for GitHub</button>
@@ -460,7 +607,7 @@
         </div>
     </div>
     <div class="TableObject-item TableObject-item--primary">
-          <a class="author pull-header-username css-truncate css-truncate-target expandable" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
+          <a class="author pull-header-username css-truncate css-truncate-target expandable" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
    wants to merge 1 commit into
 
 
@@ -468,20 +615,18 @@
   <span title="OctoLinker/testrepo:master" class="commit-ref css-truncate user-select-contain expandable base-ref"><span class="css-truncate-target">master</span></span>
 
   <div class="commit-ref-dropdown">
-    <div class="select-menu js-menu-container js-select-menu commitish-suggester js-load-contents" data-contents-url="/OctoLinker/testrepo/pull/1/show_partial?partial=pull_requests%2Fdescription_branches_dropdown">
-      <button class="btn btn-sm select-menu-button js-menu-target branch" type="button" aria-label="Choose a base branch" aria-haspopup="true" aria-expanded="false">
+    <details class="details-reset details-overlay select-menu js-select-menu commitish-suggester js-load-contents" data-contents-url="/OctoLinker/testrepo/pull/1/show_partial?partial=pull_requests%2Fdescription_branches_dropdown">
+      <summary class="btn btn-sm select-menu-button branch" title="Choose a base branch" aria-haspopup="true">
         <i>base:</i>
-        <span class="js-select-button css-truncate css-truncate-target" title="base: master">master</span>
-      </button>
-      <div class="select-menu-modal-holder js-menu-content js-navigation-container">
-        <div class="select-menu-modal">
-          <div class="js-select-menu-deferred-content"></div>
-          <div class="select-menu-loading-overlay anim-pulse">
-            <svg height="32" class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"/></svg>
-          </div>
+        <span class="js-select-button css-truncate css-truncate-target" title="master">master</span>
+      </summary>
+      <details-menu class="select-menu-modal position-absolute" style="z-index: 90;">
+        <div class="js-select-menu-deferred-content"></div>
+        <div class="select-menu-loading-overlay anim-pulse">
+          <svg height="32" class="octicon octicon-octoface" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"/></svg>
         </div>
-      </div>
-    </div>
+      </details-menu>
+    </details>
   </div>
 
 from
@@ -499,14 +644,15 @@ from
 
   <nav class="tabnav-tabs">
       <link rel="pjax-prefetch" href="/OctoLinker/testrepo/pull/1">
-    <a href="/OctoLinker/testrepo/pull/1" class="tabnav-tab  js-pjax-history-navigate">
-      <svg class="octicon octicon-comment-discussion" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15 1H6c-.55 0-1 .45-1 1v2H1c-.55 0-1 .45-1 1v6c0 .55.45 1 1 1h1v3l3-3h4c.55 0 1-.45 1-1V9h1l3 3V9h1c.55 0 1-.45 1-1V2c0-.55-.45-1-1-1zM9 11H4.5L3 12.5V11H1V5h4v3c0 .55.45 1 1 1h3v2zm6-3h-2v1.5L11.5 8H6V2h9v6z"/></svg>
-      Conversation
 
-      <span id="conversation_tab_counter" class="Counter">
-        2
-      </span>
-    </a>
+      <a href="/OctoLinker/testrepo/pull/1" class="tabnav-tab  js-pjax-history-navigate">
+        <svg class="octicon octicon-comment-discussion" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M15 1H6c-.55 0-1 .45-1 1v2H1c-.55 0-1 .45-1 1v6c0 .55.45 1 1 1h1v3l3-3h4c.55 0 1-.45 1-1V9h1l3 3V9h1c.55 0 1-.45 1-1V2c0-.55-.45-1-1-1zM9 11H4.5L3 12.5V11H1V5h4v3c0 .55.45 1 1 1h3v2zm6-3h-2v1.5L11.5 8H6V2h9v6z"/></svg>
+        Conversation
+
+        <span id="conversation_tab_counter" class="Counter">
+          2
+        </span>
+      </a>
 
     <a href="/OctoLinker/testrepo/pull/1/commits" class="tabnav-tab  js-pjax-history-navigate">
       <svg class="octicon octicon-git-commit" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10.86 7c-.45-1.72-2-3-3.86-3-1.86 0-3.41 1.28-3.86 3H0v2h3.14c.45 1.72 2 3 3.86 3 1.86 0 3.41-1.28 3.86-3H14V7h-3.14zM7 10.2c-1.22 0-2.2-.98-2.2-2.2 0-1.22.98-2.2 2.2-2.2 1.22 0 2.2.98 2.2 2.2 0 1.22-.98 2.2-2.2 2.2z"/></svg>
@@ -547,8 +693,7 @@ from
     data-range-url="/OctoLinker/testrepo/pull/1/files/$range">
     <div class="js-select-button">
       <button type="button" class="btn-link muted-link select-menu-button js-menu-target" aria-expanded="false" aria-haspopup="true" data-hotkey="c">
-        Changes from
-          <strong>all commits</strong>
+           Changes from <strong>all commits</strong>
       </button>
     </div>
 
@@ -595,6 +740,7 @@ from
     </div>
   </div>
 </div>
+
 
               
 
@@ -667,25 +813,27 @@ from
 </details>
 
 
+
             </div>
 
-                  <div class="js-socket-channel js-updatable-content js-pull-refresh-on-pjax" data-channel="pull_request:90889453" data-url="/OctoLinker/testrepo/pull/1/show_partial_comparison?base_commit_oid=8c802922609af8721bae6f954a58f1b804e7d765&amp;end_commit_oid=9981d1a99ef8fff1f569c2ae24b136d5a0275132&amp;partial=pull_requests%2Fstale_comparison&amp;start_commit_oid=8c802922609af8721bae6f954a58f1b804e7d765"></div>
+                   <div class="js-socket-channel js-updatable-content js-pull-refresh-on-pjax" data-channel="pull_request:90889453" data-url="/OctoLinker/testrepo/pull/1/show_partial_comparison?base_commit_oid=8c802922609af8721bae6f954a58f1b804e7d765&amp;end_commit_oid=9981d1a99ef8fff1f569c2ae24b136d5a0275132&amp;partial=pull_requests%2Fstale_comparison&amp;start_commit_oid=8c802922609af8721bae6f954a58f1b804e7d765" data-gid="MDExOlB1bGxSZXF1ZXN0OTA4ODk0NTM="></div>
 
 
             <div class="modal-backdrop js-touch-events"></div>
+
           </div>
         </div>
+
         <div class="pr-toolbar-shadow"></div>
 
 
-
-          <div id="files" class="diff-view ">
+          <div id="files" class="diff-view">
 
   <div class="js-diff-progressive-container">
     
 <a name="diff-204feb679f46a3957d6d7747ad57958b"></a>
 <div id="diff-0"
-     class="file js-file js-details-container Details
+     class="file js-file js-details-container Details Details--on open
              
              
              
@@ -693,7 +841,13 @@ from
              
               show-inline-notes
            ">
-  <div class="file-header js-file-header" data-path="sourcereader/popular-cat-names.js" data-short-path="204feb6" data-anchor="diff-204feb679f46a3957d6d7747ad57958b">
+  <div class="file-header file-header--expandable js-file-header"
+    data-path="sourcereader/popular-cat-names.js"
+    data-short-path="204feb6"
+    data-anchor="diff-204feb679f46a3957d6d7747ad57958b"
+    data-file-type=".js"
+    data-file-deleted="false"
+    >
     <div class="file-actions">
 
         <span class="show-file-notes pt-1">
@@ -703,14 +857,25 @@ from
           </label>
         </span>
 
-          <a href="/OctoLinker/testrepo/blob/9981d1a99ef8fff1f569c2ae24b136d5a0275132/sourcereader/popular-cat-names.js" class="btn btn-sm tooltipped tooltipped-nw" rel="nofollow" aria-label="View the whole file">View</a>
+          <div class="BtnGroup">
+              <clipboard-copy value="/sourcereader/popular-cat-names.js" class="btn btn-sm BtnGroup-item" >
+                Copy path
+              </clipboard-copy>
+            <a href="/OctoLinker/testrepo/blob/9981d1a99ef8fff1f569c2ae24b136d5a0275132/sourcereader/popular-cat-names.js"
+              class="btn btn-sm tooltipped tooltipped-nw BtnGroup-item"
+              rel="nofollow"
+              aria-label="View the whole file"
+              >
+              View file
+            </a>
+          </div>
 
 
             <button type="button" disabled class="btn-link btn-octicon tooltipped tooltipped-nw" aria-label="You must be signed in and have push access to the stefanbuck-patch-1 branch to make changes."><svg class="octicon octicon-pencil" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"/></svg></button>
             <button type="button" disabled class="btn-link btn-octicon tooltipped tooltipped-nw" aria-label="You must be signed in and have push access to the stefanbuck-patch-1 branch to delete this file."><svg class="octicon octicon-trashcan" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"/></svg></button>
-      <button type="button" class="btn-octicon p-1 pr-2 js-details-target" aria-label="Toggle diff text" aria-expanded="true">
-        <svg class="octicon octicon-chevron-down Details-content--shown" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M5 11L0 6l1.5-1.5L5 8.25 8.5 4.5 10 6l-5 5z"/></svg>
-        <svg class="octicon octicon-chevron-up Details-content--hidden" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"/></svg>
+      <button type="button" class="btn-octicon p-1 pr-2 js-details-target tooltipped tooltipped-nw" aria-label="Toggle diff contents" aria-expanded="true">
+        <svg class="octicon octicon-chevron-down Details-content--hidden" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M5 11L0 6l1.5-1.5L5 8.25 8.5 4.5 10 6l-5 5z"/></svg>
+        <svg class="octicon octicon-chevron-up Details-content--shown" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5 5 5z"/></svg>
       </button>
     </div>
     <div class="file-info">
@@ -722,14 +887,14 @@ from
       
     </div>
   </div>
-  <div class="js-file-content Details-content--shown">
+  <div class="js-file-content Details-content--hidden">
 
-        <div class="data highlight js-blob-wrapper" style="overflow-x: auto">
-          <table class="diff-table tab-size  " data-tab-size="8">
+        <div class="data highlight js-blob-wrapper " style="overflow-x: auto">
+          <table class="diff-table js-diff-table tab-size  " data-tab-size="8" data-diff-anchor="diff-204feb679f46a3957d6d7747ad57958b">
             
-      <tr data-position="0">
-    <td id="diff-204feb679f46a3957d6d7747ad57958bL0" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
-    <td id="diff-204feb679f46a3957d6d7747ad57958bR0" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
+        <tr data-position="0">
+    <td id="diff-204feb679f46a3957d6d7747ad57958bHL0" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
+    <td id="diff-204feb679f46a3957d6d7747ad57958bHR0" class="blob-num blob-num-hunk non-expandable" data-line-number="..."></td>
     <td class="blob-code blob-code-inner blob-code-hunk">@@ -1,4 +1,4 @@</td>
   </tr>
 
@@ -797,19 +962,23 @@ from
 
       
 <tr class="inline-comments js-inline-comments-container">
-  <td class="line-comments  js-line-comments js-quote-selection-container"  colspan="3">
-    <div class="review-thread comment-holder js-line-comments js-resolvable-timeline-thread-container">
+  <td class="line-comments  js-line-comments js-quote-selection-container" data-quote-markdown=".js-comment-body" colspan="3">
+        
+<div class="review-thread comment-holder js-line-comments js-resolvable-timeline-thread-container" data-resolved="false">
 
   <div class="js-resolvable-thread-contents ">
     <div class="js-comments-holder">
         
 
-  <div class="review-comment js-minimizable-comment-group" id="r84998536">
+  <div class="review-comment js-minimizable-comment-group js-targetable-comment"
+       id="r84998536"
+       data-gid="MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDg0OTk4NTM2"
+       data-url="/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDg0OTk4NTM2/comments/review_comment">
 
     <div class="minimized-comment d-none">
-      
+        
 
-  <details class="Details-element details-reset "
+<details class="Details-element details-reset "
        data-body-version="3695f1fe03728aeb31d9d82dafac5d8d">
     <summary class="text-gray f6">
       <div class="d-flex flex-justify-between flex-items-center">
@@ -822,86 +991,68 @@ from
 
           </div>
         </h3>
-        <div class="Details-content--closed btn-link text-gray"><svg class="octicon octicon-unfold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11.5 7.5L14 10c0 .55-.45 1-1 1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0 5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1 1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z"/></svg>Show comment</div>
-        <div class="Details-content--open btn-link text-gray"><svg class="octicon octicon-fold mr-1" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"/></svg>Hide comment</div>
-      </div>
-    </summary>
-    <div class="py-2 pl-6 pr-0">
-      <div class="previewable-edit  js-task-list-container ">
-        <div class="edit-comment-hide">
-          <div class="timeline-comment-actions">
-            
-
-
-
-
-
-
-
-<!-- Closes div if we are showing the kebab menu -->
-
-          </div>
-            <a class="float-left mt-1" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar" height="28" width="28" alt="@stefanbuck" src="https://avatars1.githubusercontent.com/u/1393946?s=60&amp;v=4" /></a>
-          <div class="review-comment-contents">
-            <h4 class="f5 text-normal d-inline text-gray-dark">
-              <strong class="text-gray">
-                
-
-  <a class="author text-inherit css-truncate-target" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
-  
-
-              </strong>
-              <span class="text-gray">
-                  <a href="#r84998536" class="timestamp"><relative-time datetime="2016-10-25T20:53:36Z">Oct 25, 2016</relative-time></a>
-              </span>
-            </h4>
-            
-    <span class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is a member of the OctoLinker organization.">
-      Member
-    </span>
-
-            <task-lists disabled sortable>
-              <div class="comment-body markdown-body p-0 pt-1 js-comment-body ">
-                  <p><g-emoji class="g-emoji" alias="+1" fallback-src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f44d.png">👍</g-emoji></p>
-              </div>
-            </task-lists>
-          </div>
-        </div>
-
+      <div class="text-gray text-small">
+        <a rel="nofollow" class="link-gray" href="/login?return_to=https%3A%2F%2Fgithub.com%2FOctoLinker%2Ftestrepo%2Fpull%2F1%2Ffiles">Sign in to view</a>
       </div>
     </div>
-  </details>
+  </summary>
+</details>
+
 
     </div>
 
-  <div class="previewable-edit js-comment js-task-list-container unminimized-comment
-             
-             
-              "
-      data-body-version="3695f1fe03728aeb31d9d82dafac5d8d">
+  <div class="previewable-edit js-suggested-changes-container js-task-list-container unminimized-comment js-comment "
+       data-body-version="3695f1fe03728aeb31d9d82dafac5d8d"
+       data-thread-side="right">
     <div class="edit-comment-hide">
       <div class="timeline-comment-actions">
+        <details class="details-overlay details-reset position-relative d-inline-block js-dropdown-details" id="details-r84998536">
+          <summary
+              class="btn-link timeline-comment-action"
+              aria-haspopup="true"
+              aria-label="Show more options">
+            <svg aria-label="Show more options" class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/></svg>
+          </summary>
+
+          <div class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in">
+
+            <clipboard-copy
+              class="dropdown-item btn-link tooltipped tooltipped-nw"
+              for="r84998536-permalink"
+              aria-label="Copy link"
+              data-toggle-for="details-r84998536"
+              role="menuitem">
+              Copy link
+            </clipboard-copy>
+
+            <button type="button"
+                class="dropdown-item btn-link d-none js-comment-quote-reply"
+                data-toggle-for="details-r84998536">
+              Quote reply
+            </button>
 
 
 
 
 
-      <!-- Closes div if we are showing the kebab menu -->
+
+
+          </div>
+        </details>
       </div>
 
-
       <span class="float-left mt-1">
-        <a class="d-inline-block" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar" height="28" width="28" alt="@stefanbuck" src="https://avatars1.githubusercontent.com/u/1393946?s=60&amp;v=4" /></a>
+        <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar" height="28" width="28" alt="@stefanbuck" src="https://avatars1.githubusercontent.com/u/1393946?s=60&amp;v=4" /></a>
       </span>
 
-      <div class="review-comment-contents">
+      <div class="review-comment-contents js-suggested-changes-contents" data-thread-side="right">
         <h4 class="f5 text-normal d-inline">
           <strong>
-              <a class="author link-gray-dark" data-hovercard-user-id="1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a> 
+              <a class="author link-gray-dark" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a> 
           </strong>
           <span class="text-gray">
 
-              <a href="#r84998536" class="timestamp d-inline-block">
+              <a href="#r84998536" id="r84998536-permalink" class="js-timestamp timestamp d-inline-block">
                 <relative-time datetime="2016-10-25T20:53:36Z">Oct 25, 2016</relative-time>
               </a>
 
@@ -920,9 +1071,9 @@ from
         <task-lists disabled sortable>
           <div class="comment-body markdown-body  js-comment-body">
             <p><g-emoji class="g-emoji" alias="+1" fallback-src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f44d.png">👍</g-emoji></p>
-
           </div>
         </task-lists>
+
 
           
 
@@ -1007,10 +1158,32 @@ from
 
 
 
+        <div class="protip">
+          <svg class="octicon octicon-light-bulb text-gray" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M6.5 0C3.48 0 1 2.19 1 5c0 .92.55 2.25 1 3 1.34 2.25 1.78 2.78 2 4v1h5v-1c.22-1.22.66-1.75 2-4 .45-.75 1-2.08 1-3 0-2.81-2.48-5-5.5-5zm3.64 7.48c-.25.44-.47.8-.67 1.11-.86 1.41-1.25 2.06-1.45 3.23-.02.05-.02.11-.02.17H5c0-.06 0-.13-.02-.17-.2-1.17-.59-1.83-1.45-3.23-.2-.31-.42-.67-.67-1.11C2.44 6.78 2 5.65 2 5c0-2.2 2.02-4 4.5-4 1.22 0 2.36.42 3.22 1.19C10.55 2.94 11 3.94 11 5c0 .66-.44 1.78-.86 2.48zM4 14h5c-.23 1.14-1.3 2-2.5 2s-2.27-.86-2.5-2z"/></svg>
+          <strong>ProTip!</strong>
+          Use <kbd>n</kbd> and <kbd>p</kbd> to navigate between commits in a pull request.
+        </div>
 
         <div class="clearfix"></div>
     </div>
   </div>
+  <div hidden>
+  <span class="js-add-to-batch-enabled">Add this suggestion to a batch that can be applied as a single commit.</span>
+  <span class="js-unchanged-suggestion">This suggestion is invalid because no changes were made to the code.</span>
+  <span class="js-closed-pull">Suggestions cannot be applied while the pull request is closed.</span>
+  <span class="js-viewing-subset-changes">Suggestions cannot be applied while viewing a subset of changes.</span>
+  <span class="js-one-suggestion-per-line">Only one suggestion per line can be applied in a batch.</span>
+  <span class="js-reenable-add-to-batch">Add this suggestion to a batch that can be applied as a single commit.</span>
+  <span class="js-validation-on-left-blob">Applying suggestions on deleted lines is not supported.</span>
+  <span class="js-validation-on-right-blob">You must change the existing code in this line in order to create a valid suggestion.</span>
+  <span class="js-outdated-comment">Outdated suggestions cannot be applied.</span>
+  <span class="js-resolved-thread">This suggestion has been applied or marked resolved.</span>
+  <span class="js-pending-review">Suggestions cannot be applied from pending reviews.</span>
+  <div class="form-group errored m-0 error js-suggested-changes-inline-validation-template d-flex" style="cursor: default;">
+    <span class="js-suggested-changes-inline-error-message position-relative error m-0" style="max-width: inherit;"></span>
+  </div>
+</div>
+
 
   </div>
   <div class="modal-backdrop js-touch-events"></div>
@@ -1025,22 +1198,22 @@ from
 <div class="footer container-lg px-3" role="contentinfo">
   <div class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light ">
     <ul class="list-style-none d-flex flex-wrap ">
-      <li class="mr-3">&copy; 2018 <span title="0.42927s from unicorn-866872178-hxrg6">GitHub</span>, Inc.</li>
+      <li class="mr-3">&copy; 2018 <span title="0.41989s from unicorn-7494ccfb9c-qzp7d">GitHub</span>, Inc.</li>
         <li class="mr-3"><a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms">Terms</a></li>
         <li class="mr-3"><a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy">Privacy</a></li>
-        <li class="mr-3"><a href="https://help.github.com/articles/github-security/" data-ga-click="Footer, go to security, text:security">Security</a></li>
+        <li class="mr-3"><a href="/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
         <li class="mr-3"><a href="https://status.github.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
         <li><a data-ga-click="Footer, go to help, text:help" href="https://help.github.com">Help</a></li>
     </ul>
 
-    <a aria-label="Homepage" title="GitHub" class="footer-octicon" href="https://github.com">
+    <a aria-label="Homepage" title="GitHub" class="footer-octicon mr-lg-4" href="https://github.com">
       <svg height="24" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
 </a>
    <ul class="list-style-none d-flex flex-wrap ">
         <li class="mr-3"><a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact">Contact GitHub</a></li>
+        <li class="mr-3"><a href="https://github.com/pricing" data-ga-click="Footer, go to Pricing, text:Pricing">Pricing</a></li>
       <li class="mr-3"><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
       <li class="mr-3"><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
-      <li class="mr-3"><a href="https://shop.github.com" data-ga-click="Footer, go to shop, text:shop">Shop</a></li>
         <li class="mr-3"><a href="https://blog.github.com" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
         <li><a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a></li>
 
@@ -1062,10 +1235,10 @@ from
   </div>
 
 
-    <script crossorigin="anonymous" integrity="sha512-wIuAKDhvxe9wCaNR1tzCk3rtl+wXEWC28rmRpzmx0h98VEeWC6Y3xCWV1xAW6NP6eQQX+x8ZGhW6Sdut+mLRuw==" type="application/javascript" src="https://assets-cdn.github.com/assets/compat-a48960bafc17c30572990bbab3664e9c.js"></script>
-    <script crossorigin="anonymous" integrity="sha512-T5YBL6byTrSWXd5XhwPeN91OHxxm7jO3OKRwlJpSbnzS8StPr/8h7OJKbLnVFO11CIbQGfv4rsGdsyRP2hyPDw==" type="application/javascript" src="https://assets-cdn.github.com/assets/frameworks-1a53a87937bf67db3a8755ade0d1aa93.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-WnyO4VoIUwWWQOmFLjYf4UGg/c1z9VlaLN8IMuiI3uMhhl6rejyThRdLPDyePeUPW6N+38OoBMs6AkqcvWALtA==" type="application/javascript" src="https://assets-cdn.github.com/assets/compat-b66b5d97b4442a01f057c74b091c4368.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-glXpCrOqxNGPFRZ0xGRWMgpYC4Xn/c/CL82vk2eeRostCZHF7Px1wBjxv6Wohcq9+xhM1Lt7DvrkWcSvF3j28w==" type="application/javascript" src="https://assets-cdn.github.com/assets/frameworks-7fcedd2a70cd3dde438cbad4c2d08128.js"></script>
     
-    <script crossorigin="anonymous" async="async" integrity="sha512-ZrDYjGIqlGGaG1GSHOH63EE/l7t50rQzDVzGjouPFMRY7kaFss37h4UiSGfJj0BjL2gX4Yeo7xNEUVE5GHcWaQ==" type="application/javascript" src="https://assets-cdn.github.com/assets/github-a81c60bf5144275576e157b9f381c39c.js"></script>
+    <script crossorigin="anonymous" async="async" integrity="sha512-NnkR3Qo+4D5ma5koFlDfAf9bKKHnuAC5BlrEUdKfDKZo46qS4hjt+C4Uw5KtLsTBASZoMneayDVNRxQRucQXqw==" type="application/javascript" src="https://assets-cdn.github.com/assets/github-927061254931b1e409112c1baeed3a26.js"></script>
     
     
     
@@ -1083,6 +1256,18 @@ from
     </button>
   </div>
 </div>
+
+  <template id="site-details-dialog">
+  <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark" open>
+    <summary aria-haspopup="dialog" aria-label="Close dialog"></summary>
+    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast">
+      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
+        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+      </button>
+      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
+    </details-dialog>
+  </details>
+</template>
 
   <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
   <div class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large" style="width:360px;">

--- a/packages/blob-reader/helper.js
+++ b/packages/blob-reader/helper.js
@@ -51,7 +51,11 @@ function getPath(el) {
   // When current page is a diff view get path from "View" button
   let ret = $('.file-actions a', el.parentElement.parentElement)
     .filter(function() {
-      return $(this).text() === 'View';
+      return (
+        $(this)
+          .text()
+          .trim() === 'View file'
+      );
     })
     .attr('href');
 


### PR DESCRIPTION
Today I noticed that Travis is failing since almost 2 weeks. GitHub changed the markup for Pull Requests view and the original implementation wasn't able to handle this. They renamed the button which contains the full blob url from `View` to `View file`. 

I'm really surprised that no one has noticed this before.