### PR TITLE
Remove token from storage when user clears token field

### DIFF
--- a/packages/helper-settings/SettingsForm.js
+++ b/packages/helper-settings/SettingsForm.js
@@ -46,7 +46,7 @@ export default class Form extends Component {
       });
 
       storage.save({
-        githubToken: undefined,
+        githubToken: null,
       });
       return;
     }


### PR DESCRIPTION
Passing `undefined ` wasn't removing the value from store when users clears token field. 