### PR TITLE
Remove trailing slash to fix E2E

### DIFF
--- a/e2e/fixtures/docker/Dockerfile
+++ b/e2e/fixtures/docker/Dockerfile
@@ -1,4 +1,4 @@
-// @OctoLinkerResolve(https://hub.docker.com/_/php/)
+// @OctoLinkerResolve(https://hub.docker.com/_/php)
 FROM php:php:5.6-apache
 
 // @OctoLinkerResolve(<root>/docker/docker-entrypoint.sh)


### PR DESCRIPTION
Looks like hub.docker.com was updating some webserver config to remove trailing slashes.
