### PR TITLE
Fetch live resolver urls in background 

### DIFF
--- a/packages/core/loader.js
+++ b/packages/core/loader.js
@@ -1,0 +1,48 @@
+function createStore(json, payload) {
+  const store = global.__ocotlinker_cache || {};
+
+  payload.forEach(({ registry, target }, index) => {
+    store[registry] = store[registry] || {};
+    store[registry][target] = json[index];
+  });
+
+  global.__ocotlinker_cache = store;
+}
+
+async function runLiveQuery(matches) {
+  if (!matches.length) {
+    return [];
+  }
+
+  const payload = [].concat(...matches.map(match => match.urls));
+
+  const response = await fetch('https://githublinker.herokuapp.com/bulk', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+    headers: new Headers({
+      'Content-Type': 'application/json',
+    }),
+  });
+  const json = await response.json();
+
+  createStore(json, payload);
+}
+
+function filterLiveResolver(matches) {
+  return matches.reduce((memo, match) => {
+    match.urls.forEach(url => {
+      if (url.type !== 'registry') {
+        return;
+      }
+
+      memo.push(match);
+    });
+
+    return memo;
+  }, []);
+}
+
+export default function(matches) {
+  const registryMatch = filterLiveResolver(matches);
+  runLiveQuery(registryMatch);
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
     "@octolinker/helper-insert-link": "1.0.0",
     "@octolinker/helper-settings": "1.0.0",
     "@octolinker/helper-sort-urls": "1.0.0",
+    "@octolinker/helper-normalise-resolver-results": "1.0.0",
     "@octolinker/plugin-bower-manifest": "1.0.0",
     "@octolinker/plugin-composer-manifest": "1.0.0",
     "@octolinker/plugin-css": "1.0.0",

--- a/packages/helper-insert-link/__tests__/index.js
+++ b/packages/helper-insert-link/__tests__/index.js
@@ -101,5 +101,12 @@ describe('insert-link', () => {
       expect(helper(input).matches.length).toBe(1);
       expect(helper(input).matches).toMatchSnapshot();
     });
+
+    it('returns an array with values', () => {
+      const input = 'foo <span>"bar"</span>';
+
+      fakePlugin.resolve.mockReturnValue([undefined, null, '', 'bar']);
+      expect(helper(input).matches[0].urls).toEqual(['bar']);
+    });
   });
 });

--- a/packages/helper-insert-link/index.js
+++ b/packages/helper-insert-link/index.js
@@ -175,9 +175,15 @@ export default function(blob, regex, plugin, meta = {}) {
         .slice(1)
         .map(item => item.replace(/['|"]/g, ''));
 
+      let urls = plugin.resolve(blob.path, values, meta);
+
+      if (Array.isArray(urls)) {
+        urls = urls.filter(Boolean);
+      }
+
       matches.push({
         link,
-        urls: plugin.resolve(blob.path, values, meta),
+        urls,
       });
 
       return node;

--- a/packages/helper-normalise-resolver-results/__snapshots__/test.js.snap
+++ b/packages/helper-normalise-resolver-results/__snapshots__/test.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`normaliseResolverResults converts [object Object] 1`] = `
+Array [
+  Object {
+    "registry": "npm",
+    "target": "foo",
+    "type": "registry",
+  },
+]
+`;
+
+exports[`normaliseResolverResults converts {BASE_URL}/foo/bar/blob/1ab8cfd3b65d3b43335130d6cefbf8c62482680f/file.js 1`] = `
+Array [
+  Object {
+    "branch": "1ab8cfd3b65d3b43335130d6cefbf8c62482680f",
+    "path": "file.js",
+    "repo": "bar",
+    "type": "internal-link",
+    "url": "https://github.com/foo/bar/blob/1ab8cfd3b65d3b43335130d6cefbf8c62482680f/file.js",
+    "user": "foo",
+  },
+]
+`;
+
+exports[`normaliseResolverResults converts {BASE_URL}/foo/bar/blob/master/file.js 1`] = `
+Array [
+  Object {
+    "branch": "master",
+    "path": "file.js",
+    "repo": "bar",
+    "type": "internal-link",
+    "url": "https://github.com/foo/bar/blob/master/file.js",
+    "user": "foo",
+  },
+]
+`;
+
+exports[`normaliseResolverResults converts function () {} 1`] = `
+Array [
+  Object {
+    "handler": [Function],
+    "type": "function",
+  },
+]
+`;
+
+exports[`normaliseResolverResults converts https://foosearch.org/ 1`] = `
+Array [
+  Object {
+    "type": "external-link",
+    "url": "https://foosearch.org/",
+  },
+]
+`;

--- a/packages/helper-normalise-resolver-results/index.js
+++ b/packages/helper-normalise-resolver-results/index.js
@@ -1,0 +1,57 @@
+import ghParse from 'github-url-parse';
+
+const BASE_URL = 'https://github.com';
+
+// Resource within this repositroy
+const internal = url => {
+  const fullUrl = url.replace('{BASE_URL}', BASE_URL);
+  const { user, repo, branch, path } = ghParse(fullUrl);
+
+  return {
+    type: 'internal-link',
+    url: fullUrl,
+    user,
+    repo,
+    branch,
+    path,
+  };
+};
+
+// An external url like a documenation page
+const external = url => ({
+  type: 'external-link',
+  url,
+});
+
+// Async resolver
+const func = handler => ({
+  type: 'function',
+  handler,
+});
+
+// Needs to be validated through https://githublinker.herokuapp.com/
+const registry = ({ registry: type, target }) => ({
+  type: 'registry',
+  registry: type,
+  target,
+});
+
+export default function(urls) {
+  return [].concat(urls).map(url => {
+    if (typeof url === 'string') {
+      if (url.startsWith('{BASE_URL}')) {
+        return internal(url);
+      }
+
+      return external(url);
+    }
+
+    if (url.registry) {
+      return registry(url);
+    }
+
+    if (typeof url === 'function') {
+      return func(url);
+    }
+  });
+}

--- a/packages/helper-normalise-resolver-results/package.json
+++ b/packages/helper-normalise-resolver-results/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@octolinker/helper-normalise-resolver-results",
+  "version": "1.0.0",
+  "description": "",
+  "repository": "https://github.com/octolinker/octolinker/tree/master/packages/helper-normalise-resolver-results",
+  "license": "MIT",
+  "main": "./index.js",
+  "dependencies": {
+    "github-url-parse": "^0.1.0"
+  }
+}

--- a/packages/helper-normalise-resolver-results/test.js
+++ b/packages/helper-normalise-resolver-results/test.js
@@ -1,0 +1,13 @@
+import normaliseResolverResults from './index.js';
+
+describe('normaliseResolverResults', () => {
+  test.each([
+    '{BASE_URL}/foo/bar/blob/master/file.js',
+    '{BASE_URL}/foo/bar/blob/1ab8cfd3b65d3b43335130d6cefbf8c62482680f/file.js',
+    'https://foosearch.org/',
+    { registry: 'npm', target: 'foo' },
+    () => {},
+  ])('converts %s', url => {
+    expect(normaliseResolverResults([url])).toMatchSnapshot();
+  });
+});

--- a/packages/plugin-java/__tests__/index.js
+++ b/packages/plugin-java/__tests__/index.js
@@ -16,8 +16,9 @@ describe('Java', () => {
   });
 
   it('resolves community packages', () => {
-    expect(Java.resolve(path, ['com.company.app'])).toBe(
-      'https://githublinker.herokuapp.com/q/java/com.company.app',
-    );
+    expect(Java.resolve(path, ['com.company.app'])).toEqual({
+      registry: 'java',
+      target: 'com.company.app',
+    });
   });
 });

--- a/packages/plugin-javascript/__tests__/index.js
+++ b/packages/plugin-javascript/__tests__/index.js
@@ -12,8 +12,8 @@ describe('javascript-universal', () => {
 
   it("resolves '@angular/core/bar.js' to '@angular/core'", () => {
     const type = 'npm';
-    expect(plugin.resolve(path, ['@angular/core/bar.js'], { type })[0]).toBe(
-      'https://githublinker.herokuapp.com/q/npm/@angular/core',
+    expect(plugin.resolve(path, ['@angular/core/bar.js'], { type })[0]).toEqual(
+      { registry: 'npm', target: '@angular/core' },
     );
   });
 

--- a/packages/plugin-rust/__tests__/index.js
+++ b/packages/plugin-rust/__tests__/index.js
@@ -4,8 +4,9 @@ describe('rust-crate', () => {
   const path = '/blob/path/dummy';
 
   it('resolves hamcrest using the live-resolver', () => {
-    expect(rustCrate.resolve(path, ['hamcrest'])).toBe(
-      'https://githublinker.herokuapp.com/q/crates/hamcrest',
-    );
+    expect(rustCrate.resolve(path, ['hamcrest'])).toEqual({
+      registry: 'crates',
+      target: 'hamcrest',
+    });
   });
 });

--- a/packages/resolver-live-query/index.js
+++ b/packages/resolver-live-query/index.js
@@ -1,3 +1,6 @@
 export default function({ type, target }) {
-  return `https://githublinker.herokuapp.com/q/${type}/${target}`;
+  return {
+    registry: type,
+    target,
+  };
 }


### PR DESCRIPTION
This is one (of a few) changes which are needed to implement #277.

On app startup it prefetch all live resolver urls at once in the background by calling a bulk endpoint. For details check out https://github.com/OctoLinker/live-resolver/pull/59. If a user clicks on a link, the click handler will check an internal cache first. If the requested resource isn't available it will fallback to the old behaviour. 

With this Pull Request I want to verify that our live resolver server is able to handle such traffic increase. The timing for this is perfect. It's one week before Christmas which I assume is already a less busy week than any other week. Also in case something goes really bad, it won't affect that many people. 