### PR TITLE
Fix to not duplicate package send to live-resolver

### DIFF
--- a/packages/core/loader.js
+++ b/packages/core/loader.js
@@ -28,15 +28,15 @@ async function runLiveQuery(matches) {
   createStore(json, payload);
 }
 
+function matchContainsOnlyRegistyMatches(match) {
+  return match.urls.every(url => url.type === 'registry');
+}
+
 function filterLiveResolver(matches) {
   return matches.reduce((memo, match) => {
-    match.urls.forEach(url => {
-      if (url.type !== 'registry') {
-        return;
-      }
-
+    if (matchContainsOnlyRegistyMatches(match)) {
       memo.push(match);
-    });
+    }
 
     return memo;
   }, []);


### PR DESCRIPTION
I did a stupid mistake in the previous implementation. For every URL within a resolve item it was duplicating the resolves items wich caused N+1 requests for every package. Luckily it was just sending two request for each package
