### PR TITLE
Handle normalise resolver results

### DIFF
--- a/packages/helper-sort-urls/__tests__/index.js
+++ b/packages/helper-sort-urls/__tests__/index.js
@@ -29,6 +29,10 @@ describe('helper-sort-urls', () => {
     expect(helperSortUrls(urls, 'file')).toEqual(urls);
   });
 
+  it('returns an object if the given argument is not an array', () => {
+    expect(helperSortUrls({ foo: 'bar' }, 'file.txt')).toEqual({ foo: 'bar' });
+  });
+
   it('keeps order when file extension is not present', () => {
     expect(helperSortUrls(urls, 'file.txt')).toEqual(urls);
   });

--- a/packages/helper-sort-urls/index.js
+++ b/packages/helper-sort-urls/index.js
@@ -3,7 +3,7 @@ import { extname } from 'path';
 export default function(urls, fileName) {
   const fileExtension = extname(fileName);
 
-  if (!fileExtension) {
+  if (!fileExtension || !Array.isArray(urls)) {
     return urls;
   }
 


### PR DESCRIPTION
With the recent changes the helper-sort-urls needs to be able to handle results returned by helper-normalise-resolver-results.