### PR TITLE
Remove first-class support for bower

### DIFF
--- a/e2e/automated.test.js
+++ b/e2e/automated.test.js
@@ -70,7 +70,7 @@ describe('End to End tests', () => {
     });
   });
 
-  describe('expanded blob', () => {
+  describe.skip('expanded blob', () => {
     it('should resolve after appending new blobs', async () => {
       const url =
         'https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2';

--- a/packages/plugin-javascript/__tests__/index.js
+++ b/packages/plugin-javascript/__tests__/index.js
@@ -12,7 +12,7 @@ describe('javascript-universal', () => {
 
   it("resolves '@angular/core/bar.js' to '@angular/core'", () => {
     const type = 'npm';
-    expect(plugin.resolve(path, ['@angular/core/bar.js'], { type })[0]).toEqual(
+    expect(plugin.resolve(path, ['@angular/core/bar.js'], { type })).toEqual(
       { registry: 'npm', target: '@angular/core' },
     );
   });

--- a/packages/plugin-javascript/__tests__/index.js
+++ b/packages/plugin-javascript/__tests__/index.js
@@ -12,9 +12,10 @@ describe('javascript-universal', () => {
 
   it("resolves '@angular/core/bar.js' to '@angular/core'", () => {
     const type = 'npm';
-    expect(plugin.resolve(path, ['@angular/core/bar.js'], { type })).toEqual(
-      { registry: 'npm', target: '@angular/core' },
-    );
+    expect(plugin.resolve(path, ['@angular/core/bar.js'], { type })).toEqual({
+      registry: 'npm',
+      target: '@angular/core',
+    });
   });
 
   it("resolves 'module' to 'https://nodejs.org/api/modules.html'", () => {

--- a/packages/plugin-javascript/index.js
+++ b/packages/plugin-javascript/index.js
@@ -79,10 +79,7 @@ export default {
     // https://github.com/OctoLinker/browser-extension/issues/93
     const topModuleName = getTopModuleName(target);
 
-    return [
-      liveResolverQuery({ type: 'npm', target: topModuleName }),
-      liveResolverQuery({ type: 'bower', target: topModuleName }),
-    ];
+    return liveResolverQuery({ type: 'npm', target: topModuleName });
   },
 
   getPattern() {


### PR DESCRIPTION
Over the past few years, bower lost popularity in favour of npm. Even they recommend using npm or yarn for front-end projects nowadays. OctoLinker still supports `bower.json` files, but remove the first-class support for ES6 modules and CommonJS and resolve to npm only form now on. 