### PR TITLE
Does not bail out when capture group is empty

### DIFF
--- a/packages/helper-insert-link/__tests__/__snapshots__/index.js.snap
+++ b/packages/helper-insert-link/__tests__/__snapshots__/index.js.snap
@@ -18,6 +18,17 @@ exports[`insert-link does not remove closing parentheses from commented out requ
 </div>
 `;
 
+exports[`insert-link does not wrap element when capture group empty 1`] = `
+<div>
+  foo 
+  <span>
+    '
+    foo:
+    bar'
+  </span>
+</div>
+`;
+
 exports[`insert-link returns returns an array 1`] = `
 Array [
   Object {

--- a/packages/helper-insert-link/__tests__/index.js
+++ b/packages/helper-insert-link/__tests__/index.js
@@ -94,6 +94,13 @@ describe('insert-link', () => {
     expect(helper(input, REQUIRE).el).toMatchSnapshot();
   });
 
+  it('does not wrap element when capture group empty', () => {
+    const regex = /foo:([0-9])?/;
+    const input = "foo <span>'foo:bar'</span>";
+
+    expect(helper(input, regex).el).toMatchSnapshot();
+  });
+
   describe('returns', () => {
     it('returns an array', () => {
       const input = 'foo <span>"bar"</span>';

--- a/packages/helper-insert-link/index.js
+++ b/packages/helper-insert-link/index.js
@@ -104,6 +104,14 @@ function replace(portion, match) {
 
   const matchValue = match[1];
 
+  if (matchValue === undefined) {
+    return {
+      isMatch: false,
+      node: text,
+      link: null,
+    };
+  }
+
   if (node.textContent.includes(matchValue)) {
     const el = wrapsInnerString(text, matchValue);
 

--- a/packages/plugin-npm-manifest/index.js
+++ b/packages/plugin-npm-manifest/index.js
@@ -20,6 +20,10 @@ function linkDependency(blob, key, value) {
 }
 
 function linkFile(blob, key, value) {
+  if (typeof value !== 'string') {
+    return;
+  }
+
   const regex = jsonRegExValue(key, value, blob.isDiff);
   return insertLink(blob, regex, this, { type: 'file' });
 }


### PR DESCRIPTION
Bugfix for #539.

OctoLinker stopped working, because the key `decompress-response` was defined with a boolean value instead of a string. 

```
	"browser": {
		"decompress-response": false,
		"electron": false
	},
```

This was causing the following runtime error
`TypeError: Cannot read property 'length' of undefined`. 

https://github.com/OctoLinker/OctoLinker/blob/cbbb95b5757e275cc98f16f355a532fe40aa92d3/packages/helper-insert-link/index.js#L32

I fixed this issue in two places. First, the npm plugin returns early if the given value is not from type string. Second, if a capture group is empty (which should be never the case), the current node will be returned without adding a link.


