### PR TITLE
Stop using sync API for settings in favor of local storage

### DIFF
--- a/packages/helper-settings/index.js
+++ b/packages/helper-settings/index.js
@@ -16,29 +16,17 @@ export const set = async (key, value) => {
     [key]: value,
   };
 
-  try {
-    return await browser.storage.sync.set(data);
-  } catch (err) {
-    return browser.storage.local.set(data);
-  }
+  return browser.storage.local.set(data);
 };
 
-export const save = async data => {
-  try {
-    return await browser.storage.sync.set(data);
-  } catch (err) {
-    return browser.storage.local.set(data);
-  }
-};
+export const save = async data => browser.storage.local.set(data);
 
 export const load = async () => {
-  let data;
+  // Clear legacy storage strategy without migration
+  // Can be removed at the end of April 2019
+  await browser.storage.sync.clear();
 
-  try {
-    data = await browser.storage.sync.get(null);
-  } catch (err) {
-    data = await browser.storage.local.get(null);
-  }
+  const data = await browser.storage.local.get(null);
 
   Object.assign(store, defaults, data);
 


### PR DESCRIPTION
OctoLinker is using the Chrome Storage API (not to be confused with localStorage ) to store settings. In some case user data where automatically synced with the Chrome profile. Today, I came across this quote from the documentation:

> Confidential user information should not be stored! The storage area isn't encrypted.

Chrome storage is isolated between extensions, there is no way leak data with another extensions or script running on the same webpage. This PR disables the  sync functionality and stores all data just in the local browser storage.


