### PR TITLE
Do not link relative imports in code snippets

### DIFF
--- a/packages/blob-reader/helper.js
+++ b/packages/blob-reader/helper.js
@@ -78,6 +78,10 @@ function getPath(el) {
     .attr('href');
 
   if (!ret) {
+    if (el.classList.contains('highlight')) {
+      // Markdown code snippets does not support relative imports
+      return;
+    }
     ret = $('.js-permalink-shortcut').attr('href');
   }
 


### PR DESCRIPTION
Markdown code snippets are not represented in git. Therefore linking does not work and we return `undefined` as a path. This caused issues with relative imports in readmes which then failed the GitHub API call.
