### PR TITLE
Limit Markdown-related style to Markdown files only

### DIFF
--- a/packages/helper-insert-link/style.css
+++ b/packages/helper-insert-link/style.css
@@ -41,8 +41,8 @@ body.octolinker-debug .octolinker-link {
   cursor: default;
 }
 
-/* Fix line indicator for issue code blocks */
-div.highlight {
+/* Keep line indicator inside the box in Markdown `pre` blocks */
+.markdown-body .highlight {
   position: relative;
 }
 


### PR DESCRIPTION
This should fix #639, can you ensure that it doesn't break other parts I might have not considered?

### Checklist:

- [x] If this PR is a new feature, please provide at least one example link
- [ ] Make sure all of the significant new logic is covered by tests

### Tests

Both should remain unchanged

<blockquote>

```js
require('mem')
```

</blockquote>

https://github.com/OctoLinker/OctoLinker/pull/624/files#diff-6d7f932c7f64e54bb76f6a42949338bbR5