### PR TITLE
Add fixture for readme

### DIFF
--- a/e2e/fixtures/markdown/readme.md
+++ b/e2e/fixtures/markdown/readme.md
@@ -1,0 +1,9 @@
+```js
+```// @OctoLinkerResolve(https://nodejs.org/api/fs.html)
+require('fs');
+
+// @OctoLinkerResolve(https://github.com/lodash/lodash)
+import 'lodash'
+
+import './foo.js'
+```


### PR DESCRIPTION
Add fixture to cover markdown imports using End2End tests. 