### PR TITLE
Remove invalid ping urls before calling resolver api

### DIFF
--- a/packages/helper-normalise-resolver-results/__snapshots__/test.js.snap
+++ b/packages/helper-normalise-resolver-results/__snapshots__/test.js.snap
@@ -105,3 +105,9 @@ Array [
   },
 ]
 `;
+
+exports[`normaliseResolverResults converts https://novalidurl 1`] = `
+Array [
+  Object {},
+]
+`;

--- a/packages/helper-normalise-resolver-results/index.js
+++ b/packages/helper-normalise-resolver-results/index.js
@@ -2,6 +2,14 @@ import ghParse from 'github-url-parse';
 
 const BASE_URL = 'https://github.com';
 
+// https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url/22648406#22648406
+function isURL(str) {
+  const urlRegex =
+    '^(?!mailto:)(?:(?:http|https|ftp)://)(?:\\S+(?::\\S*)?@)?(?:(?:(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[0-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))|localhost)(?::\\d{2,5})?(?:(/|\\?|#)[^\\s]*)?$';
+  const url = new RegExp(urlRegex, 'i');
+  return str.length < 2083 && url.test(str);
+}
+
 // Resource within this repositroy
 const internal = url => {
   const fullUrl = url.replace('{BASE_URL}', BASE_URL);
@@ -18,10 +26,18 @@ const internal = url => {
 };
 
 // An external url like a documenation page
-const external = url => ({
-  type: 'ping',
-  target: url.replace('{BASE_URL}', BASE_URL),
-});
+const external = url => {
+  const target = url.replace('{BASE_URL}', BASE_URL);
+
+  if (!isURL(target)) {
+    return {};
+  }
+
+  return {
+    type: 'ping',
+    target,
+  };
+};
 
 // Async resolver
 const func = handler => ({

--- a/packages/helper-normalise-resolver-results/test.js
+++ b/packages/helper-normalise-resolver-results/test.js
@@ -7,6 +7,7 @@ describe('normaliseResolverResults', () => {
     '{BASE_URL}/foo/bar/blob/master/file.js',
     '{BASE_URL}/foo/bar/blob/1ab8cfd3b65d3b43335130d6cefbf8c62482680f/file.js',
     'https://foosearch.org/',
+    'https://novalidurl',
     ['{BASE_URL}/foo/bar/blob/master/file.js'],
     [
       '{BASE_URL}/foo/bar/blob/master/file.js',


### PR DESCRIPTION
The `ping` event caused 35M hits over the last 30 days. Most of them contained an invalid url like`https://fmt`. Filtering out those url will avoid unnecessary requests and delays on the live resolver server.