### PR TITLE
Fetch internal files using the GitHub tree API

### DIFF
--- a/packages/core/app.js
+++ b/packages/core/app.js
@@ -38,6 +38,9 @@ async function run(rootElement) {
     }
   }
 
+  const [, user, repo] = window.location.pathname.split('/');
+  const currentRepoSlug = `${user}/${repo}`;
+
   matches = matches
     .filter(result => result !== undefined)
     .map(({ link, urls }) => {
@@ -45,7 +48,7 @@ async function run(rootElement) {
 
       return {
         link,
-        urls: normaliseResolverResults(urlsSorted),
+        urls: normaliseResolverResults(urlsSorted, currentRepoSlug),
       };
     });
 

--- a/packages/helper-normalise-resolver-results/__snapshots__/test.js.snap
+++ b/packages/helper-normalise-resolver-results/__snapshots__/test.js.snap
@@ -13,12 +13,8 @@ Array [
 exports[`normaliseResolverResults converts {BASE_URL}/file.js 1`] = `
 Array [
   Object {
-    "branch": undefined,
-    "path": undefined,
-    "repo": undefined,
-    "type": "internal-link",
-    "url": "https://github.com/file.js",
-    "user": "file.js",
+    "target": "https://github.com/file.js",
+    "type": "ping",
   },
 ]
 `;
@@ -65,12 +61,20 @@ Array [
 exports[`normaliseResolverResults converts {BASE_URL}/foo/bar/blob/master/file.js,{BASE_URL}/foo/bar/blob/master/file.js 1`] = `
 Array [
   Object {
-    "target": "https://github.com/foo/bar/blob/master/file.js",
-    "type": "ping",
+    "branch": "master",
+    "path": "file.js",
+    "repo": "bar",
+    "type": "internal-link",
+    "url": "https://github.com/foo/bar/blob/master/file.js",
+    "user": "foo",
   },
   Object {
-    "target": "https://github.com/foo/bar/blob/master/file.js",
-    "type": "ping",
+    "branch": "master",
+    "path": "file.js",
+    "repo": "bar",
+    "type": "internal-link",
+    "url": "https://github.com/foo/bar/blob/master/file.js",
+    "user": "foo",
   },
 ]
 `;
@@ -78,12 +82,8 @@ Array [
 exports[`normaliseResolverResults converts {BASE_URL}file.js 1`] = `
 Array [
   Object {
-    "branch": undefined,
-    "path": undefined,
-    "repo": undefined,
-    "type": "internal-link",
-    "url": "https://github.comfile.js",
-    "user": undefined,
+    "target": "https://github.comfile.js",
+    "type": "ping",
   },
 ]
 `;

--- a/packages/helper-normalise-resolver-results/index.js
+++ b/packages/helper-normalise-resolver-results/index.js
@@ -52,10 +52,10 @@ const registry = ({ registry: type, target }) => ({
   target,
 });
 
-export default function(urls) {
+export default function(urls, slug) {
   return [].concat(urls).map(url => {
     if (typeof url === 'string') {
-      if (url.startsWith('{BASE_URL}') && urls.length === 1) {
+      if (url.startsWith(`{BASE_URL}/${slug}/`)) {
         return internal(url);
       }
 

--- a/packages/helper-normalise-resolver-results/test.js
+++ b/packages/helper-normalise-resolver-results/test.js
@@ -16,6 +16,8 @@ describe('normaliseResolverResults', () => {
     { registry: 'npm', target: 'foo' },
     () => {},
   ])('converts %s', url => {
-    expect(normaliseResolverResults([].concat(url))).toMatchSnapshot();
+    expect(
+      normaliseResolverResults([].concat(url), 'foo/bar'),
+    ).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
The changes made in #650 caused an issue, which stopped linking relative files in private repos. All files were resolved through the [OctoLinker API](https://github.com/octolinker/api) which obviously doesn't work for private repos. 