### PR TITLE
Auto store token after pasting

### DIFF
--- a/packages/helper-settings/SettingsForm.js
+++ b/packages/helper-settings/SettingsForm.js
@@ -88,7 +88,10 @@ export default class Form extends Component {
           description={githubTokenDescription()}
           value={state.githubToken}
           error={errorMessage}
-          onInput={linkState(this, 'githubToken')}
+          onInput={event => {
+            linkState(this, 'githubToken')(event);
+            this.validateToken();
+          }}
         />
         <p className="note ">
           For public repositories,{' '}


### PR DESCRIPTION
The previous behaviour to store a token was quite confusing and not obvious at all. After entering the token you had to press ENTER to actual store it. Most of the times a token is insert from the clipboard and this PR supports this scenario. 


