### PR TITLE
Ensure GitHub Tree API is used for relative files

### DIFF
--- a/packages/core/app.js
+++ b/packages/core/app.js
@@ -38,9 +38,6 @@ async function run(rootElement) {
     }
   }
 
-  const [, user, repo] = window.location.pathname.split('/');
-  const currentRepoSlug = `${user}/${repo}`;
-
   matches = matches
     .filter(result => result !== undefined)
     .map(({ link, urls }) => {
@@ -48,7 +45,7 @@ async function run(rootElement) {
 
       return {
         link,
-        urls: normaliseResolverResults(urlsSorted, currentRepoSlug),
+        urls: normaliseResolverResults(urlsSorted),
       };
     });
 

--- a/packages/helper-normalise-resolver-results/index.js
+++ b/packages/helper-normalise-resolver-results/index.js
@@ -52,10 +52,12 @@ const registry = ({ registry: type, target }) => ({
   target,
 });
 
-export default function(urls, slug) {
+export default function(urls) {
   return [].concat(urls).map(url => {
     if (typeof url === 'string') {
-      if (url.startsWith(`{BASE_URL}/${slug}/`)) {
+      const [, user, repo] = url.split('/');
+
+      if (url.startsWith(`{BASE_URL}/${user}/${repo}/blob/`)) {
         return internal(url);
       }
 

--- a/packages/helper-normalise-resolver-results/test.js
+++ b/packages/helper-normalise-resolver-results/test.js
@@ -16,8 +16,6 @@ describe('normaliseResolverResults', () => {
     { registry: 'npm', target: 'foo' },
     () => {},
   ])('converts %s', url => {
-    expect(
-      normaliseResolverResults([].concat(url), 'foo/bar'),
-    ).toMatchSnapshot();
+    expect(normaliseResolverResults([].concat(url))).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Under certain circumstances relative file paths in a diff view were resolved using the ping resolver instead of the GitHub Tree API.
