### PR TITLE
Adjust responsive design for MS Edge

### DIFF
--- a/packages/helper-settings/components/input.js
+++ b/packages/helper-settings/components/input.js
@@ -21,6 +21,7 @@ export default ({
     </dt>
     <dd>
       <input
+        style={{ width: '100%' }}
         className="form-control"
         type={type}
         id={name}


### PR DESCRIPTION
The settings dialog in Microsoft Edge is slightly smaller which cut off the input field. This PR adjust the input field width.

### Before

<img width="453" alt="Screenshot 2020-01-07 at 22 47 49" src="https://user-images.githubusercontent.com/1393946/71932303-e634c300-319f-11ea-83fa-b89fe559eb46.png">

### After
<img width="465" alt="Screenshot 2020-01-07 at 22 47 56" src="https://user-images.githubusercontent.com/1393946/71932302-e59c2c80-319f-11ea-845e-b48c2ac21245.png">