### PR TITLE
Improve adding token UX

### DIFF
--- a/packages/helper-settings/SettingsForm.js
+++ b/packages/helper-settings/SettingsForm.js
@@ -90,7 +90,7 @@ export default class Form extends Component {
           error={errorMessage}
           onInput={event => {
             linkState(this, 'githubToken')(event);
-            this.validateToken();
+            setTimeout(this.validateToken.bind(this), 100);
           }}
         />
         <p className="note ">


### PR DESCRIPTION
The UX when adding a GitHub token felt very clunky. There seems to be a timing issue between `linkState` and `validateToken`. This isn't a proper fix, but it does the job. 