### PR TITLE
Add support for GitHub CODEOWNERS

### DIFF
--- a/e2e/fixtures/.github/CODEOWNERS
+++ b/e2e/fixtures/.github/CODEOWNERS
@@ -1,22 +1,3 @@
-# @OctoLinkerResolve(<root>/docker)
-/docker @stefanbuck
-
-# @OctoLinkerResolve(<root>/go)
-./go @stefanbuck
-
-# @OctoLinkerResolve(<root>/java/)
-java/ @stefanbuck
-
-# @OctoLinkerResolve(<root>/ruby/)
-/ruby/ @stefanbuck
-
-# @OctoLinkerResolve(<root>/javascript/relative)
-/javascript/relative/** @stefanbuck
-
-# @OctoLinkerResolve(<root>/.github/CODEOWNERS)
-.github/CODEOWNERS @stefanbuck
-
-
 # should ignore lines below
 
 *

--- a/e2e/fixtures/.github/CODEOWNERS
+++ b/e2e/fixtures/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# @OctoLinkerResolve(<root>/docker)
+/docker @stefanbuck
+
+# @OctoLinkerResolve(<root>/go)
+./go @stefanbuck
+
+# @OctoLinkerResolve(<root>/java/)
+java/ @stefanbuck
+
+# @OctoLinkerResolve(<root>/ruby/)
+/ruby/ @stefanbuck
+
+# @OctoLinkerResolve(<root>/javascript/relative)
+/javascript/relative/** @stefanbuck
+
+# @OctoLinkerResolve(<root>/.github/CODEOWNERS)
+.github/CODEOWNERS @stefanbuck
+
+
+# should ignore lines below
+
+*
+javascript/**/*.js @stefanbuck
+# /docker @stefanbuck

--- a/packages/core/load-plugins.js
+++ b/packages/core/load-plugins.js
@@ -22,3 +22,4 @@ export { default as Sass } from '@octolinker/plugin-sass';
 export { default as TypeScript } from '@octolinker/plugin-typescript';
 export { default as Vim } from '@octolinker/plugin-vim';
 export { default as GitHubActions } from '@octolinker/plugin-github-actions';
+export { default as GitHubCodeowners } from '@octolinker/plugin-github-codeowners';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
     "@octolinker/plugin-dot-net-core": "1.0.0",
     "@octolinker/plugin-gemfile-manifest": "1.0.0",
     "@octolinker/plugin-github-actions": "1.0.0",
+    "@octolinker/plugin-github-codeowners": "1.0.0",
     "@octolinker/plugin-go": "1.0.0",
     "@octolinker/plugin-haskell": "1.0.0",
     "@octolinker/plugin-homebrew-manifest": "1.0.0",

--- a/packages/helper-insert-link/index.js
+++ b/packages/helper-insert-link/index.js
@@ -20,9 +20,10 @@ function injectUrl(node, value, startOffset, endOffset) {
   try {
     // Take quote marks into account to narrow down match
     // in case value is given on the left and right hand side
-    const textMatch = node.textContent
-      .slice(startOffset - 1, endOffset + 1)
-      .trim(); // we don't want to include whitespace in the link
+    if (startOffset > 0) {
+      startOffset -= 1;
+    }
+    const textMatch = node.textContent.slice(startOffset, endOffset + 1).trim(); // we don't want to include whitespace in the link
 
     findAndReplaceDOMText(node, {
       find: textMatch,

--- a/packages/plugin-github-codeowners/index.js
+++ b/packages/plugin-github-codeowners/index.js
@@ -1,0 +1,47 @@
+import { join, dirname, extname } from 'path';
+import relativeFile from '@octolinker/resolver-relative-file';
+import resolverTrustedUrl from '@octolinker/resolver-trusted-url';
+
+export default {
+  name: 'GithubCodeowners',
+
+  resolve(path, [target]) {
+    if (target.endsWith('/**')) {
+      target = target.replace('/**', '');
+    }
+
+    if (target.endsWith('/*')) {
+      target = target.replace('/*', '');
+    }
+
+    if (target.includes('*')) {
+      return '';
+    }
+
+    if (target.startsWith('/')) {
+      target = `.${target}`;
+    }
+
+    target = join('../', target);
+
+    const basePath = join(dirname(path), target);
+    const fileExt = extname(basePath);
+
+    if (!fileExt) {
+      return resolverTrustedUrl({ target: basePath });
+    }
+
+    return relativeFile({ path, target });
+  },
+
+  getPattern() {
+    return {
+      pathRegexes: [/\.github\/CODEOWNERS$/],
+      githubClasses: [],
+    };
+  },
+
+  getLinkRegexes() {
+    return /^([^\s#]+)/gm;
+  },
+};

--- a/packages/plugin-github-codeowners/package.json
+++ b/packages/plugin-github-codeowners/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@octolinker/plugin-github-codeowners",
+  "version": "1.0.0",
+  "description": "",
+  "repository": "https://github.com/octolinker/octolinker/tree/master/packages/plugin-github-codeowners",
+  "license": "MIT",
+  "main": "./index.js",
+  "dependencies": {
+    "@octolinker/resolver-relative-file": "1.0.0",
+    "@octolinker/resolver-trusted-url": "1.0.0",
+    "@octolinker/helper-grammar-regex-collection": "1.0.0"
+  }
+}


### PR DESCRIPTION
Fixes #550 

![image](https://user-images.githubusercontent.com/1393946/73104045-c3bbdd00-3ef5-11ea-8f76-89ce7a734acd.png)


The following patterns will be ignored

- `*`
- `**/foo`
- `foo/*.bar`
- `foo/*/*.bar`
- `# /foo`

all other patterns should work. 