### PR TITLE
Bypass OctoLinker API for nuget urls

### DIFF
--- a/packages/plugin-dot-net-core/__tests__/index.js
+++ b/packages/plugin-dot-net-core/__tests__/index.js
@@ -4,9 +4,10 @@ describe('dotNetCore', () => {
   const path = '/blob/path/dummy';
 
   it('resolves Microsoft.NETCore.App to https://www.nuget.org/packages/Microsoft.NETCore.App', () => {
-    expect(dotNetCore.resolve(path, ['Microsoft.NETCore.App'])).toBe(
-      'https://www.nuget.org/packages/Microsoft.NETCore.App',
-    );
+    expect(dotNetCore.resolve(path, ['Microsoft.NETCore.App'])).toEqual({
+      target: 'https://www.nuget.org/packages/Microsoft.NETCore.App',
+      type: 'trusted-url',
+    });
   });
 
   it('resolves Microsoft.Extensions.Configuration.FileExtensions to https://www.nuget.org/packages/Microsoft.Extensions.Configuration.FileExtensions', () => {
@@ -14,8 +15,10 @@ describe('dotNetCore', () => {
       dotNetCore.resolve(path, [
         'Microsoft.Extensions.Configuration.FileExtensions',
       ]),
-    ).toBe(
-      'https://www.nuget.org/packages/Microsoft.Extensions.Configuration.FileExtensions',
-    );
+    ).toEqual({
+      target:
+        'https://www.nuget.org/packages/Microsoft.Extensions.Configuration.FileExtensions',
+      type: 'trusted-url',
+    });
   });
 });

--- a/packages/plugin-dot-net/__tests__/index.js
+++ b/packages/plugin-dot-net/__tests__/index.js
@@ -4,14 +4,16 @@ describe('dotNet', () => {
   const path = '/blob/path/dummy';
 
   it('resolves EntityFramework to https://www.nuget.org/packages/EntityFramework', () => {
-    expect(dotNet.resolve(path, ['EntityFramework'])).toBe(
-      'https://www.nuget.org/packages/EntityFramework',
-    );
+    expect(dotNet.resolve(path, ['EntityFramework'])).toEqual({
+      target: 'https://www.nuget.org/packages/EntityFramework',
+      type: 'trusted-url',
+    });
   });
 
   it('resolves Stanford.NLP.CoreNLP to https://www.nuget.org/packages/Stanford.NLP.CoreNLP', () => {
-    expect(dotNet.resolve(path, ['Stanford.NLP.CoreNLP'])).toBe(
-      'https://www.nuget.org/packages/Stanford.NLP.CoreNLP',
-    );
+    expect(dotNet.resolve(path, ['Stanford.NLP.CoreNLP'])).toEqual({
+      target: 'https://www.nuget.org/packages/Stanford.NLP.CoreNLP',
+      type: 'trusted-url',
+    });
   });
 });

--- a/packages/resolver-nuget/index.js
+++ b/packages/resolver-nuget/index.js
@@ -1,3 +1,7 @@
+import resolverTrustedUrl from '@octolinker/resolver-trusted-url';
+
 export default function({ target }) {
-  return `https://www.nuget.org/packages/${target}`;
+  return resolverTrustedUrl({
+    target: `https://www.nuget.org/packages/${target}`,
+  });
 }

--- a/packages/resolver-nuget/package.json
+++ b/packages/resolver-nuget/package.json
@@ -4,5 +4,8 @@
   "description": "",
   "repository": "https://github.com/octolinker/octolinker/tree/master/packages/resolver-nuget",
   "license": "MIT",
-  "main": "./index.js"
+  "main": "./index.js",
+  "dependencies": {
+    "@octolinker/resolver-trusted-url": "1.0.0"
+  }
 }


### PR DESCRIPTION
By default OctoLinker validates external URLs via https://octolinker-api.now.sh/ to ensure the linked URL is valid and reachable. This obviously slows down the startup since OctoLinker needs to wait for the API response. There is a special resolver called `resolver-trusted-url` which allows you to opt-out from this behaviour. This is useful for documentation pages or registry urls where you can ensure the right url.
