### PR TITLE
Fix URLs as dependencies in package.json

### DIFF
--- a/e2e/fixtures/javascript/package.json
+++ b/e2e/fixtures/javascript/package.json
@@ -9,6 +9,12 @@
     },
     "devDependencies": {
         "//": "@OctoLinkerResolve(https://github.com/jashkenas/underscore)",
-        "underscore": "1.2.3"
+        "underscore": "1.2.3",
+        "//": "@OctoLinkerResolve(https://github.com/expressjs/express)",
+        "express": "expressjs/express",
+        "//": "@OctoLinkerResolve(https://github.com/mochajs/mocha/tree/v7.0.0)",
+        "mocha": "mochajs/mocha#v7.0.0",
+        "//": "@OctoLinkerResolve(https://github.com/angular/angular)",
+        "angular": "git@github.com:angular/angular.git"
     }
 }

--- a/packages/helper-insert-link/__tests__/__snapshots__/get-position.js.snap
+++ b/packages/helper-insert-link/__tests__/__snapshots__/get-position.js.snap
@@ -189,3 +189,19 @@ Array [
   },
 ]
 `;
+
+exports[`get-position returns an empty array when capture group is empty 1`] = `
+Array [
+  Object {
+    "endPos": 3,
+    "endPosInBlob": 3,
+    "lineNumber": 1,
+    "startPos": 0,
+    "startPosInBlob": 0,
+    "values": Array [
+      "foo",
+      "bar",
+    ],
+  },
+]
+`;

--- a/packages/helper-insert-link/__tests__/get-position.js
+++ b/packages/helper-insert-link/__tests__/get-position.js
@@ -35,4 +35,7 @@ describe('get-position', () => {
   test('returns an empty array when capture group is empty', () => {
     expect(getPosition('foo:bar', /foo:([0-9])?/g)).toStrictEqual([]);
   });
+  test('returns an empty array when capture group is empty', () => {
+    expect(getPosition('foo:bar', /(foo):(bar)/g)).toMatchSnapshot();
+  });
 });

--- a/packages/helper-insert-link/get-position.js
+++ b/packages/helper-insert-link/get-position.js
@@ -49,7 +49,7 @@ export default function(blobString, regex) {
         endPosInBlob,
         startPos,
         endPos,
-        values: [matchValueStriped],
+        values: [matchValueStriped, ...match.slice(2)],
       };
     })
     .filter(Boolean);

--- a/packages/helper-insert-link/index.js
+++ b/packages/helper-insert-link/index.js
@@ -111,7 +111,6 @@ export default function(blob, regex, plugin, meta = {}) {
         endPos = endPosInBlob;
       }
 
-      // TODO push link el into matches along with the urls prop
       const retEl = injectUrl(el, values[0], startPos, endPos);
       if (retEl) {
         matches.push({

--- a/packages/helper-regex-builder/__tests__/index.js
+++ b/packages/helper-regex-builder/__tests__/index.js
@@ -2,18 +2,18 @@ import { jsonRegExValue, jsonRegExKeyValue } from '../index';
 
 describe('helper-regex-builder', () => {
   it('jsonRegExValue', () => {
-    expect(jsonRegExValue('foo', 'bar')).toEqual(/"foo"\s*:\s*("bar")/g);
-    expect(jsonRegExValue('foo', 'bar', false)).toEqual(/"foo"\s*:\s*("bar")/g);
-    expect(jsonRegExValue('foo', 'bar', true)).toEqual(/"foo"\s*:\s*("bar")/g);
+    expect(jsonRegExValue('foo', 'bar')).toEqual(/"foo"\s*:\s*"(bar)"/g);
+    expect(jsonRegExValue('foo', 'bar', false)).toEqual(/"foo"\s*:\s*"(bar)"/g);
+    expect(jsonRegExValue('foo', 'bar', true)).toEqual(/"foo"\s*:\s*"(bar)"/g);
   });
 
   it('jsonRegExKeyValue', () => {
-    expect(jsonRegExKeyValue('foo', 'bar')).toEqual(/("foo")\s*:\s*("bar")/g);
+    expect(jsonRegExKeyValue('foo', 'bar')).toEqual(/("foo")\s*:\s*"(bar)"/g);
     expect(jsonRegExKeyValue('foo', 'bar', false)).toEqual(
-      /("foo")\s*:\s*("bar")/g,
+      /("foo")\s*:\s*"(bar)"/g,
     );
     expect(jsonRegExKeyValue('foo', 'bar', true)).toEqual(
-      /("foo")\s*:\s*("bar")/g,
+      /("foo")\s*:\s*"(bar)"/g,
     );
   });
 });

--- a/packages/helper-regex-builder/index.js
+++ b/packages/helper-regex-builder/index.js
@@ -8,7 +8,7 @@ function regexBuilder(key, value, groupKey) {
   }
 
   const regexValue = escapeRegexString(value);
-  const valueField = `("${regexValue}")`;
+  const valueField = `"(${regexValue})"`;
   return new RegExp(`${keyField}\\s*:\\s*${valueField}`, 'g');
 }
 


### PR DESCRIPTION
Referencing dependencies using github shorthands or as git urls worked in the past, but seems to be broken since quite a while. 

```json
"dependencies": {
  "express": "expressjs/express",
  "mocha": "mochajs/mocha#v7.0.0",
   "angular": "git@github.com:angular/angular.git"
}
```