### PR TITLE
Add support for github: in package.json

### DIFF
--- a/e2e/fixtures/javascript/package.json
+++ b/e2e/fixtures/javascript/package.json
@@ -15,6 +15,8 @@
         "//": "@OctoLinkerResolve(https://github.com/mochajs/mocha/tree/v7.0.0)",
         "mocha": "mochajs/mocha#v7.0.0",
         "//": "@OctoLinkerResolve(https://github.com/angular/angular)",
-        "angular": "git@github.com:angular/angular.git"
+        "angular": "git@github.com:angular/angular.git",
+        "//": "@OctoLinkerResolve(https://github.com/pinkipi/log)",
+        "log": "github:pinkipi/log"
     }
 }

--- a/packages/plugin-npm-manifest/index.js
+++ b/packages/plugin-npm-manifest/index.js
@@ -51,7 +51,7 @@ export default {
     return [
       githubShorthand({ target: values[1] }),
       gitUrl({ target: values[1] }),
-    ].map(url => resolverTrustedUrl({ target: url }));
+    ].map(url => url && resolverTrustedUrl({ target: url }));
   },
 
   getPattern() {

--- a/packages/resolver-github-shorthand/__tests__/index.js
+++ b/packages/resolver-github-shorthand/__tests__/index.js
@@ -1,0 +1,10 @@
+import resolver from '../index';
+
+describe('resolver-github-shorthand', () => {
+  test.each([['https://github.com/foo/bar'], ['github:foo/bar']])(
+    'resolves "%s" to https://github.com/foo/bar',
+    target => {
+      expect(resolver({ target })).toEqual('https://github.com/foo/bar');
+    },
+  );
+});

--- a/packages/resolver-github-shorthand/index.js
+++ b/packages/resolver-github-shorthand/index.js
@@ -1,5 +1,6 @@
 import ghShorthand from 'github-url-from-username-repo';
 
 export default function({ target }) {
+  target = target.replace(/^github\:/, '');
   return ghShorthand(target.replace(/^https:\/\/github.com\//, ''), true);
 }


### PR DESCRIPTION
This PR adds support for `github:user/repo` format in a package.json file

```json
"dependencies": {
  "express": "github:expressjs/express"
}
```

Solves #790 