### PR TITLE
Add support for .net global tool configs

### DIFF
--- a/e2e/fixtures/dotnet/dotnet-tools.json
+++ b/e2e/fixtures/dotnet/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "//": "@OctoLinkerResolve(https://www.nuget.org/packages/dotnet-format)",
+    "dotnet-format": {
+      "version": "3.2.107702",
+      "commands": [
+        "dotnet-format"
+      ]
+    }
+  }
+}

--- a/packages/core/load-plugins.js
+++ b/packages/core/load-plugins.js
@@ -4,6 +4,7 @@ export { default as CSS } from '@octolinker/plugin-css';
 export { default as Docker } from '@octolinker/plugin-docker';
 export { default as DotNetCore } from '@octolinker/plugin-dot-net-core';
 export { default as DotNet } from '@octolinker/plugin-dot-net';
+export { default as DotNetGlobalTools } from '@octolinker/plugin-dot-net-global-tools';
 export { default as DotNetProject } from '@octolinker/plugin-dot-net-project';
 export { default as Rubygems } from '@octolinker/plugin-gemfile-manifest';
 export { default as Go } from '@octolinker/plugin-go';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "@octolinker/plugin-docker": "1.0.0",
     "@octolinker/plugin-dot-net": "1.0.0",
     "@octolinker/plugin-dot-net-core": "1.0.0",
+    "@octolinker/plugin-dot-net-global-tools": "1.0.0",
     "@octolinker/plugin-dot-net-project": "1.0.0",
     "@octolinker/plugin-gemfile-manifest": "1.0.0",
     "@octolinker/plugin-github-actions": "1.0.0",

--- a/packages/helper-regex-builder/__tests__/index.js
+++ b/packages/helper-regex-builder/__tests__/index.js
@@ -3,14 +3,14 @@ import { jsonRegExValue, jsonRegExKeyValue } from '../index';
 describe('helper-regex-builder', () => {
   it('jsonRegExValue', () => {
     expect(jsonRegExValue('foo', 'bar')).toEqual(/"foo"\s*:\s*"(bar)"/g);
-    expect(jsonRegExValue('foo', 'bar', false)).toEqual(/"foo"\s*:\s*"(bar)"/g);
+    expect(jsonRegExValue('foo', 'bar', false)).toEqual(/"foo"\s*:\s*"(bar)"/);
     expect(jsonRegExValue('foo', 'bar', true)).toEqual(/"foo"\s*:\s*"(bar)"/g);
   });
 
   it('jsonRegExKeyValue', () => {
     expect(jsonRegExKeyValue('foo', 'bar')).toEqual(/("foo")\s*:\s*"(bar)"/g);
     expect(jsonRegExKeyValue('foo', 'bar', false)).toEqual(
-      /("foo")\s*:\s*"(bar)"/g,
+      /("foo")\s*:\s*"(bar)"/,
     );
     expect(jsonRegExKeyValue('foo', 'bar', true)).toEqual(
       /("foo")\s*:\s*"(bar)"/g,

--- a/packages/helper-regex-builder/index.js
+++ b/packages/helper-regex-builder/index.js
@@ -1,21 +1,24 @@
 import escapeRegexString from 'escape-regex-string';
 
-function regexBuilder(key, value, groupKey) {
+function regexBuilder(key, value, groupKey, global) {
   const regexKey = escapeRegexString(key);
   const keyField = groupKey ? `("${regexKey}")` : `"${regexKey}"`;
   if (Object.prototype.toString.call(value) !== '[object String]') {
-    return new RegExp(`${keyField}`, 'g');
+    return new RegExp(`${keyField}`, global ? 'g' : undefined);
   }
 
   const regexValue = escapeRegexString(value);
   const valueField = `"(${regexValue})"`;
-  return new RegExp(`${keyField}\\s*:\\s*${valueField}`, 'g');
+  return new RegExp(
+    `${keyField}\\s*:\\s*${valueField}`,
+    global ? 'g' : undefined,
+  );
 }
 
-export function jsonRegExKeyValue(key, value) {
-  return regexBuilder(key, value, true);
+export function jsonRegExKeyValue(key, value, global = true) {
+  return regexBuilder(key, value, true, global);
 }
 
-export function jsonRegExValue(key, value) {
-  return regexBuilder(key, value, false);
+export function jsonRegExValue(key, value, global = true) {
+  return regexBuilder(key, value, false, global);
 }

--- a/packages/plugin-dot-net-core/package.json
+++ b/packages/plugin-dot-net-core/package.json
@@ -6,9 +6,9 @@
   "license": "MIT",
   "main": "./index.js",
   "dependencies": {
+    "@octolinker/helper-insert-link": "1.0.0",
     "@octolinker/helper-process-json": "1.0.0",
     "@octolinker/helper-regex-builder": "1.0.0",
-    "@octolinker/resolver-nuget": "1.0.0",
-    "@octolinker/helper-insert-link": "1.0.0"
+    "@octolinker/resolver-nuget": "1.0.0"
   }
 }

--- a/packages/plugin-dot-net-global-tools/__tests__/index.js
+++ b/packages/plugin-dot-net-global-tools/__tests__/index.js
@@ -1,0 +1,12 @@
+import dotNetGlobalTools from '../index';
+
+describe('dotNetGlobalTools', () => {
+  const path = '/blob/path/dummy';
+
+  it('resolves dotnet-format to https://www.nuget.org/packages/dotnet-format', () => {
+    expect(dotNetGlobalTools.resolve(path, ['dotnet-format'])).toEqual({
+      target: 'https://www.nuget.org/packages/dotnet-format',
+      type: 'trusted-url',
+    });
+  });
+});

--- a/packages/plugin-dot-net-global-tools/index.js
+++ b/packages/plugin-dot-net-global-tools/index.js
@@ -1,0 +1,31 @@
+import insertLink from '@octolinker/helper-insert-link';
+import processJSON from '@octolinker/helper-process-json';
+import { jsonRegExKeyValue } from '@octolinker/helper-regex-builder';
+import nugetResolver from '@octolinker/resolver-nuget';
+
+function linkDependency(blob, key, value) {
+  const regex = jsonRegExKeyValue(key, value, true);
+  return insertLink(blob, regex, this);
+}
+
+export default {
+  name: 'DotNetCoreGlobalTools',
+  needsContext: true,
+
+  resolve(path, [target]) {
+    return nugetResolver({ target });
+  },
+
+  getPattern() {
+    return {
+      pathRegexes: [/dotnet-tools\.json$/],
+      githubClasses: [],
+    };
+  },
+
+  parseBlob(blob) {
+    return processJSON(blob, this, {
+      '$.tools': linkDependency,
+    });
+  },
+};

--- a/packages/plugin-dot-net-global-tools/package.json
+++ b/packages/plugin-dot-net-global-tools/package.json
@@ -6,9 +6,9 @@
   "license": "MIT",
   "main": "./index.js",
   "dependencies": {
+    "@octolinker/helper-insert-link": "1.0.0",
     "@octolinker/helper-process-json": "1.0.0",
     "@octolinker/helper-regex-builder": "1.0.0",
-    "@octolinker/resolver-nuget": "1.0.0",
-    "@octolinker/helper-insert-link": "1.0.0"
+    "@octolinker/resolver-nuget": "1.0.0"
   }
 }

--- a/packages/plugin-dot-net-global-tools/package.json
+++ b/packages/plugin-dot-net-global-tools/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@octolinker/plugin-dot-net-global-tools",
+  "version": "1.0.0",
+  "description": "",
+  "repository": "https://github.com/octolinker/octolinker/tree/master/packages/plugin-dot-net-global-tools",
+  "license": "MIT",
+  "main": "./index.js",
+  "dependencies": {
+    "@octolinker/helper-process-json": "1.0.0",
+    "@octolinker/helper-regex-builder": "1.0.0",
+    "@octolinker/resolver-nuget": "1.0.0",
+    "@octolinker/helper-insert-link": "1.0.0"
+  }
+}

--- a/packages/plugin-dot-net/package.json
+++ b/packages/plugin-dot-net/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "./index.js",
   "dependencies": {
-    "@octolinker/resolver-nuget": "1.0.0",
-    "@octolinker/helper-grammar-regex-collection": "1.0.0"
+    "@octolinker/helper-grammar-regex-collection": "1.0.0",
+    "@octolinker/resolver-nuget": "1.0.0"
   }
 }


### PR DESCRIPTION
### Checklist:

- [x] If this PR is a new feature, please provide at least one example link
- [x] Make sure all of the significant new logic is covered by tests

**Sample files**

- https://github.com/dotnet/runtime/blob/ac68cdeeea2abbff988448fe7915f2bcf5ee3cfd/.config/dotnet-tools.json
- https://github.com/dotnet/roslyn/blob/e3a461796d3cb4917367af73778d2ab34f6812e9/dotnet-tools.json

The changes to the regex builder are needed to allow turning off the `g` flag because some tools have commands of the same name, such as in the second link, and both instances of `dotnet-format` were being linkified.