### PR TITLE
Add support for .net references

### DIFF
--- a/e2e/fixtures/dotnet/sdk/Project.csproj
+++ b/e2e/fixtures/dotnet/sdk/Project.csproj
@@ -17,11 +17,17 @@
   <ItemGroup>
     <!-- @OctoLinkerResolve(https://www.nuget.org/packages/Microsoft.Extensions.Hosting.Abstractions) -->
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.1" />
+
+    <!-- @OctoLinkerResolve(https://www.nuget.org/packages/Microsoft.Extensions.Hosting.Abstractions) -->
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
     <!-- @OctoLinkerResolve(https://www.nuget.org/packages/Microsoft.AspNetCore.Hosting.Abstractions) -->
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
+    <PackageReference Update="Microsoft.AspNetCore.Hosting.Abstractions" />
+
+    <!-- @OctoLinkerResolve(https://www.nuget.org/packages/Microsoft.Extensions.Hosting.Abstractions) -->
+    <Reference Update="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/e2e/fixtures/dotnet/sdk/Project.csproj
+++ b/e2e/fixtures/dotnet/sdk/Project.csproj
@@ -3,7 +3,7 @@
 
   <ItemGroup>
     <!-- @OctoLinkerResolve(https://www.nuget.org/packages/Microsoft.VisualStudio.Web.CodeGeneration.Tools) -->
-     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" />
 
     <!-- @OctoLinkerResolve(https://www.nuget.org/packages/Microsoft.DotNet.Watcher.Tools) -->
     <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -201,7 +201,7 @@ export const JAVA_IMPORT = regex`
 `;
 
 export const NET_PROJ_PACKAGE = regex`
-  <(PackageReference|DotNetCliToolReference|FrameworkReference|Reference)
+  <(DotNetCliTool|Framework|Package)?Reference
   \s+
   .*
   (Include|Update)=${captureQuotedWord}

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -201,7 +201,7 @@ export const JAVA_IMPORT = regex`
 `;
 
 export const NET_PROJ_PACKAGE = regex`
-  <(PackageReference|DotNetCliToolReference|FrameworkReference)
+  <(PackageReference|DotNetCliToolReference|FrameworkReference|Reference)
   \s+
   .*
   (Include|Update)=${captureQuotedWord}


### PR DESCRIPTION
### Checklist:

- [x] If this PR is a new feature, please provide at least one example link
- [x] Make sure all of the significant new logic is covered by tests

An example of these can be seen here https://github.com/dotnet/aspnetcore/blob/f7b5aec5d7de6f782622a2dc40de74d7dedd0a91/src/Analyzers/Analyzers/test/Microsoft.AspNetCore.Analyzers.Test.csproj#L21-L33.

One of the dependencies being linked to in that example is https://www.nuget.org/packages/Microsoft.AspNetCore.Analyzer.Testing but the package doesn't exist. Do we need to add an entry for NuGet to https://github.com/OctoLinker/api/blob/master/src/registries/config.json?