### PR TITLE
Disable no-console warnings

### DIFF
--- a/packages/helper-github-api/fetch-tree.js
+++ b/packages/helper-github-api/fetch-tree.js
@@ -22,6 +22,7 @@ export default async function({ user, repo, branch }) {
       },
     );
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error(error);
   }
 

--- a/packages/helper-insert-link/index.js
+++ b/packages/helper-insert-link/index.js
@@ -39,6 +39,7 @@ function injectUrl(node, value, startOffset, endOffset) {
       },
     });
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error(error);
   }
 

--- a/packages/helper-octolinker-api/index.js
+++ b/packages/helper-octolinker-api/index.js
@@ -50,6 +50,7 @@ export const bulkAction = async function(data) {
     const json = await response.json();
     return json.result;
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.log(error);
     return [];
   }


### PR DESCRIPTION
This should get rid of the warning annotations that keep showing up on each PR.
