### PR TITLE
Bump actions/checkout from v1 to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'
     - run: npm ci
     - run: npm run build
     - run: 'npm run release'
-      env:      
+      env:
         CLIENT_ID: ${{ secrets.PUBLISHER_CHROME_CLIENT_ID }}
         CLIENT_SECRET: ${{ secrets.PUBLISHER_CHROME_CLIENT_SECRET }}
         REFRESH_TOKEN: ${{ secrets.PUBLISHER_CHROME_REFRESH_TOKEN }}


### PR DESCRIPTION
There were changes in how the checkout is done between v1 and v2. This shouldn't effect the ci workflow but I'm not sure about the release workflow.

https://github.com/actions/checkout/releases/tag/v2.0.0

## Changelog

- Improved fetch performance
  - The default behavior now fetches only the commit being checked-out
- Script authenticated git commands
  - Persists the input `token` in the local git config
  - Enables your scripts to run authenticated git commands
  - Post-job cleanup removes the token
  - Opt out by setting the input `persist-credentials: false`
- Creates a local branch
  - No longer detached HEAD when checking out a branch
  - A local branch is created with the corresponding upstream branch set
- Improved layout
  - The input `path` is always relative to $GITHUB_WORKSPACE
  - Aligns better with container actions, where $GITHUB_WORKSPACE gets mapped in
- Fallback to REST API download
  - When Git 2.18 or higher is not in the PATH, the REST API will be used to download the files
- Removed input `submodules`
