### PR TITLE
Deduplicate matches for OctoLinker API only

### DIFF
--- a/e2e/diff-fixtures.json
+++ b/e2e/diff-fixtures.json
@@ -14,9 +14,5 @@
   {
     "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R42",
     "targetUrl": "https://github.com/eslint/eslint"
-  },
-  {
-    "url": "https://github.com/OctoLinker/OctoLinker/pull/791/files#diff-6d7f932c7f64e54bb76f6a42949338bbR11",
-    "targetUrl": "https://nodejs.org/api/http.html"
   }
 ]

--- a/e2e/diff-fixtures.json
+++ b/e2e/diff-fixtures.json
@@ -14,5 +14,9 @@
   {
     "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R42",
     "targetUrl": "https://github.com/eslint/eslint"
+  },
+  {
+    "url": "https://github.com/OctoLinker/OctoLinker/pull/791/files#diff-6d7f932c7f64e54bb76f6a42949338bbR11",
+    "targetUrl": "https://nodejs.org/api/http.html"
   }
 ]

--- a/packages/core/loader.js
+++ b/packages/core/loader.js
@@ -27,18 +27,16 @@ function injectLiveDemoUrl(url) {
 }
 
 function groupMatchesByType(matches) {
-  const flattenUrls = removeDuplicates(
-    [].concat(
-      ...matches.map(match =>
-        match.urls.map(url => ({
-          ...url,
-          link: match.link,
-        })),
-      ),
+  const flattenUrls = [].concat(
+    ...matches.map(match =>
+      match.urls.map(url => ({
+        ...url,
+        link: match.link,
+      })),
     ),
   );
 
-  const apiItems = flattenUrls.filter(({ type }) =>
+  const apiItems = removeDuplicates(flattenUrls).filter(({ type }) =>
     ['registry', 'ping'].includes(type),
   );
 


### PR DESCRIPTION
As raised in https://github.com/OctoLinker/OctoLinker/pull/785#issuecomment-580069754 some references are not linked in a diff view. It turned out that the removing of duplicates was causing this issue for certain matches. Original implemented to remove duplicates before calling the OctoLinker API, this cleanup was performed on all matches regardless their type. Only matches with type  `registry` and `ping` need this cleanup.

Examples:
- https://github.com/OctoLinker/OctoLinker/pull/785/files#diff-9222904f7ff80fd69544d107fbf18b0a
- https://github.com/facebook/jest/pull/9443/files#diff-a568cf5f01a8aa0032eca9f2692ba0b0R8
