### PR TITLE
Add hint to disable OctoLinker for private repos

### DIFF
--- a/packages/ratelimit-notification/__tests__/__snapshots__/messages.js.snap
+++ b/packages/ratelimit-notification/__tests__/__snapshots__/messages.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ratelimit-notification needsTokenForPrivate 1`] = `
 Object {
-  "body": "OctoLinker needs a GitHub API token to retrieve repository metadata for private repositories. <a href=\\"#\\" class=\\"js-octolinker-open-settings\\">Create a token</a> to enable OctoLinker for all your private repositories.",
+  "body": "OctoLinker needs a GitHub API token to retrieve repository metadata for private repositories. <a href=\\"#\\" class=\\"js-octolinker-open-settings\\">Create a token</a> to enable OctoLinker for all your private repositories. <a href=\\"#\\" class=\\"js-octolinker-open-settings\\">Disable OctoLinker for private repositories</a> to get rid of this notification.",
   "type": "info",
 }
 `;

--- a/packages/ratelimit-notification/messages.js
+++ b/packages/ratelimit-notification/messages.js
@@ -34,7 +34,7 @@ export const needsTokenForPrivate = () => {
   showNotification({
     type: 'info',
     body:
-      'OctoLinker needs a GitHub API token to retrieve repository metadata for private repositories. <a href="#" class="js-octolinker-open-settings">Create a token</a> to enable OctoLinker for all your private repositories.',
+      'OctoLinker needs a GitHub API token to retrieve repository metadata for private repositories. <a href="#" class="js-octolinker-open-settings">Create a token</a> to enable OctoLinker for all your private repositories. <a href="#" class="js-octolinker-open-settings">Disable OctoLinker for private repositories</a> to get rid of this notification.',
   });
 };
 


### PR DESCRIPTION
Small improvement to point people to settings page in case they don't need private repo support

![image](https://user-images.githubusercontent.com/1393946/76171905-9ae36480-6190-11ea-9640-290d88808039.png)
