### PR TITLE
Use relative resolver for nodejs plugin

### DIFF
--- a/packages/plugin-nodejs-relative-path/index.js
+++ b/packages/plugin-nodejs-relative-path/index.js
@@ -5,12 +5,13 @@ import {
 } from '@octolinker/helper-grammar-regex-collection';
 import JavaScript from '@octolinker/plugin-javascript';
 import TypeScript from '@octolinker/plugin-typescript';
+import relativeFile from '@octolinker/resolver-relative-file';
 
 export default {
   name: 'NodejsRelativePath',
 
   resolve(path, [target]) {
-    return `{BASE_URL}${join(dirname(path), target)}`;
+    return relativeFile({ path, target });
   },
 
   getPattern() {

--- a/packages/plugin-nodejs-relative-path/package.json
+++ b/packages/plugin-nodejs-relative-path/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@octolinker/plugin-javascript": "1.0.0",
     "@octolinker/plugin-typescript": "1.0.0",
+    "@octolinker/resolver-relative-file": "1.0.0",
     "@octolinker/helper-grammar-regex-collection": "1.0.0"
   }
 }


### PR DESCRIPTION
There are a few places which are doing something very similar to the relative file resolver that we already have. #796 lists all of them, but apart from the NodeJS plugin, all the others are slightly different so let's start easy 😉 