### PR TITLE
Keep update notification closed when using close icon

### DIFF
--- a/packages/user-interface/index.js
+++ b/packages/user-interface/index.js
@@ -10,7 +10,7 @@ export const showNotification = ({ body, type = 'info', id = 'common' }) => {
   const el = document.createElement('div');
   el.innerHTML = `<div class="js-octolinker-flash flash flash-full ${typeClass[type]}">
     <div class="container">
-      <button class="flash-close js-flash-close js-flash-close-${id}" type="button" aria-label="Dismiss this message">
+      <button class="octolinker-flash-close flash-close js-flash-close js-flash-close-${id}" type="button" aria-label="Dismiss this message">
         <svg aria-hidden="true" class="octicon octicon-x" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"></path></svg>
       </button>
        <div class="octolinker-flash-image"></div>

--- a/packages/user-interface/style.css
+++ b/packages/user-interface/style.css
@@ -3,6 +3,10 @@
   padding-left: 60px;
 }
 
+.octolinker-flash-close svg {
+  pointer-events: none;
+}
+
 .octolinker-flash-image  {
   width: 58px;
   height: 40px;


### PR DESCRIPTION
Qhat you see is not what you get! Applies to `event.target` as well 😉 

The click handler condition to persist the state of the notification was never met, because `event.target` was pointing to the icon `<svg>` instead of the `<button>` 🤦‍♂ 

https://github.com/OctoLinker/OctoLinker/blob/bed093fbf5d20d2494cfae2514c8bf60c80e6fe7/packages/core/notification.js#L11-L14

