### PR TITLE
Add hover card to preview to repositories

### DIFF
--- a/packages/core/loader.js
+++ b/packages/core/loader.js
@@ -100,6 +100,14 @@ function insertLinks({
 
         if (finalUrl && finalUrl.result) {
           link.href = finalUrl.result;
+
+          if (finalUrl.result.startsWith('https://github.com')) {
+            [, , , user, repo] = finalUrl.result.split('/');
+            link.dataset.repositoryHovercardsEnabled = true;
+            link.dataset.hovercardType = 'repository';
+            link.dataset.hovercardUrl = `/${user}/${repo}/hovercard`;
+          }
+
           if (process.env.OCTOLINKER_LIVE_DEMO) {
             link.href = injectLiveDemoUrl(link.href);
           }


### PR DESCRIPTION
@xt0rted pointed me to this amazing idea which allows us to show a sneak preview of the linked repository using hover cards. I hope you like it as much as I do.

![image](https://user-images.githubusercontent.com/1393946/78191378-28eff980-7476-11ea-8b84-c7da5320fe48.png)
