### PR TITLE
Declare api.github.com as permission

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -28,7 +28,6 @@
     {
       "matches": [
         "https://github.com/*",
-        "https://api.github.com/*",
         "https://gist.github.com/*"
       ],
       "js": [
@@ -41,6 +40,7 @@
   "permissions": [
     "storage",
     "https://github.com/",
+    "https://api.github.com/",
     "https://gist.github.com/",
     "https://octolinker-api.now.sh/"
   ]


### PR DESCRIPTION
While working on #870 I added https://api.github.com to the wrong array in the manifest.json file. It needs to be part of the permissions field.

This mistake is really annoying and leads to another permission ask when updating the extension next time 😞 