### PR TITLE
Add support for json config files

### DIFF
--- a/packages/core/load-plugins.js
+++ b/packages/core/load-plugins.js
@@ -13,6 +13,7 @@ export { default as Homebrew } from '@octolinker/plugin-homebrew-manifest';
 export { default as HTML } from '@octolinker/plugin-html';
 export { default as Java } from '@octolinker/plugin-java';
 export { default as JavaScript } from '@octolinker/plugin-javascript';
+export { default as Jsonconfig } from '@octolinker/plugin-json-config';
 export { default as Less } from '@octolinker/plugin-less';
 export { default as NodejsRelativePath } from '@octolinker/plugin-nodejs-relative-path';
 export { default as NpmManifest } from '@octolinker/plugin-npm-manifest';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,7 @@
     "@octolinker/plugin-html": "1.0.0",
     "@octolinker/plugin-java": "1.0.0",
     "@octolinker/plugin-javascript": "1.0.0",
+    "@octolinker/plugin-json-config": "1.0.0",
     "@octolinker/plugin-less": "1.0.0",
     "@octolinker/plugin-nodejs-relative-path": "1.0.0",
     "@octolinker/plugin-npm-manifest": "1.0.0",

--- a/packages/helper-regex-builder/index.js
+++ b/packages/helper-regex-builder/index.js
@@ -23,6 +23,10 @@ export function jsonRegExValue(key, value, global = true) {
   return regexBuilder(key, value, false, global);
 }
 
+export function jsonRegExArrayValue(value) {
+  return new RegExp(`("${value}")`, 'g');
+}
+
 export function tomlRegExKeyValue(key, value) {
   const regexKey = escapeRegexString(key);
   const regexValue = escapeRegexString(value);

--- a/packages/plugin-json-config/index.js
+++ b/packages/plugin-json-config/index.js
@@ -30,6 +30,7 @@ export default {
     return {
       pathRegexes: [
         /\.babelrc\.json$/,
+        /babel\.config\.json$/,
         /\.stylelintrc\.json$/,
         /tsconfig\.json$/,
       ],

--- a/packages/plugin-json-config/index.js
+++ b/packages/plugin-json-config/index.js
@@ -8,7 +8,7 @@ import liveResolverQuery from '@octolinker/resolver-live-query';
 
 function linkDependency(blob, key, value) {
   let regex;
-  
+
   if (Number.isNaN(key)) {
     regex = jsonRegExValue(key, value, true);
   } else {
@@ -28,7 +28,11 @@ export default {
 
   getPattern() {
     return {
-      pathRegexes: [/\.stylelintrc\.json$/, /tsconfig\.json$/],
+      pathRegexes: [
+        /\.babelrc\.json$/,
+        /\.stylelintrc\.json$/,
+        /tsconfig\.json$/,
+      ],
       githubClasses: [],
     };
   },
@@ -36,6 +40,8 @@ export default {
   parseBlob(blob) {
     return processJSON(blob, this, {
       '$.extends': linkDependency,
+      '$.presets': linkDependency,
+      '$.plugins': linkDependency,
     });
   },
 };

--- a/packages/plugin-json-config/index.js
+++ b/packages/plugin-json-config/index.js
@@ -1,0 +1,41 @@
+import insertLink from '@octolinker/helper-insert-link';
+import processJSON from '@octolinker/helper-process-json';
+import {
+  jsonRegExValue,
+  jsonRegExArrayValue,
+} from '@octolinker/helper-regex-builder';
+import liveResolverQuery from '@octolinker/resolver-live-query';
+
+function linkDependency(blob, key, value) {
+  let regex;
+  
+  if (Number.isNaN(key)) {
+    regex = jsonRegExValue(key, value, true);
+  } else {
+    regex = jsonRegExArrayValue(value);
+  }
+
+  return insertLink(blob, regex, this);
+}
+
+export default {
+  name: 'JsonConfig',
+  needsContext: true,
+
+  resolve(path, values) {
+    return liveResolverQuery({ type: 'npm', target: values[0] });
+  },
+
+  getPattern() {
+    return {
+      pathRegexes: [/\.stylelintrc\.json$/, /tsconfig\.json$/],
+      githubClasses: [],
+    };
+  },
+
+  parseBlob(blob) {
+    return processJSON(blob, this, {
+      '$.extends': linkDependency,
+    });
+  },
+};

--- a/packages/plugin-json-config/package.json
+++ b/packages/plugin-json-config/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@octolinker/plugin-json-config",
+  "version": "1.0.0",
+  "description": "",
+  "repository": "https://github.com/octolinker/octolinker/tree/master/packages/plugin-npm-manifest",
+  "license": "MIT",
+  "main": "./index.js",
+  "dependencies": {
+    "@octolinker/helper-process-json": "1.0.0",
+    "@octolinker/helper-regex-builder": "1.0.0",
+    "@octolinker/resolver-live-query": "1.0.0",
+    "@octolinker/helper-insert-link": "1.0.0"
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please provide at least one example link
- [ ] Make sure all of the significant new logic is covered by tests

This is a quick attempt at adding support for the json config format used by linting tools (they usually support js, json, and yaml but this is just for json right now). @fregante this was your request, do you know of any other json config files we could add to the list? I was looking at eslint but their format doesn't really work with this.

Closes #552 

---

## babel

- [.babelrc.json](https://github.com/AtofStryker/vue-monorepo-example/blob/57e1804b4fa140c85ac7052ca51383c3361f8d54/.babelrc.json)
- [babel.config.json](https://github.com/costaline/yr-cinema/blob/16672279153a095bd1ceb9512127e8b1ce410599/babel.config.json) - this format seems a little buggy still

## stylelint

- [single value](https://github.com/doong-jo/frontend-boilerplate/blob/8a256e90fc9c6330d8119b75ba492a2b4cd37c4e/.stylelintrc.json)
- [array of values](https://github.com/tc39/tc39.github.io/blob/49054344a33b6716ad4c29444187280c13da439a/.stylelintrc.json)

## tslint

- [single value](https://github.com/bfred-it/doma/blob/master/tsconfig.json)
