### PR TITLE
Track personal usage of OctoLinker

### DIFF
--- a/packages/core/app.js
+++ b/packages/core/app.js
@@ -9,6 +9,7 @@ import Plugins from './plugin-manager.js';
 import debugMode from './debug-mode.js';
 import loader from './loader.js';
 import * as loadPlugins from './load-plugins';
+import './stats.js';
 
 const blobReader = new BlobReader();
 const pluginManager = new Plugins(loadPlugins);

--- a/packages/core/stats.js
+++ b/packages/core/stats.js
@@ -1,0 +1,34 @@
+import * as storage from '@octolinker/helper-settings';
+
+const CLASS_NAME = 'octolinker-link';
+
+let tid = null;
+
+function updateCounter() {
+  const stats = storage.get('stats') || {
+    since: Date.now(),
+    counter: 0,
+  };
+
+  storage.set('stats', {
+    ...stats,
+    counter: stats.counter + 1,
+  });
+}
+
+function init() {
+  function statsHandler(event) {
+    if (!event.target.classList.contains(CLASS_NAME)) {
+      return;
+    }
+
+    if (tid) clearTimeout(tid);
+
+    tid = setTimeout(updateCounter, 1000);
+  }
+
+  document.body.addEventListener('click', statsHandler);
+  document.body.addEventListener('mouseover', statsHandler);
+}
+
+init();


### PR DESCRIPTION
This is an idea that I have had for some time. I want to show the value of OctoLinker by tracking how often OctoLinker is being used to gain insights. With the recently added hover card #869 we need to monitor hover events as well.

## What information are tracked?

- The date of the first track event.
- A counter which increases by one whenever you click or hover over a OctoLinker link

 This information will be used at some point to show you a message like this. `Since April 28th, 2020 you clicked on 124 links provided by OctoLinker.


## Where is my data stored? 

We store data on on your computer in the browser's local storage only. No sync, no upload, we respect your privacy!



