### PR TITLE
More GitHub actions support

### DIFF
--- a/e2e/fixtures/.github/workflows/ci.yml
+++ b/e2e/fixtures/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
     - uses: actions/upload-artifact@master
     # @OctoLinkerResolve(https://github.com/github/codeql-action/tree/master/init)
     - uses: github/codeql-action/init@v1
-    # @OctoLinkerResolve(https://github.com/OctoLinker/OctoLinker)
+    # @OctoLinkerResolve(https://github.com/OctoLinker/OctoLinker/tree/<sha>/)
     - uses: ./
     

--- a/e2e/fixtures/.github/workflows/ci.yml
+++ b/e2e/fixtures/.github/workflows/ci.yml
@@ -11,6 +11,5 @@ jobs:
     - uses: actions/setup-node
     # @OctoLinkerResolve(https://github.com/actions/upload-artifact)
     - uses: actions/upload-artifact@master
-    # @OctoLinkerResolve(https://github.com/github/codeql-action/tree/master/init)
+    # @OctoLinkerResolve(https://github.com/github/codeql-action/tree/main/init)
     - uses: github/codeql-action/init@v1
-    

--- a/e2e/fixtures/.github/workflows/ci.yml
+++ b/e2e/fixtures/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     - uses: actions/setup-node
     # @OctoLinkerResolve(https://github.com/actions/upload-artifact)
     - uses: actions/upload-artifact@master
+    # @OctoLinkerResolve(https://github.com/github/codeql-action/tree/master/init)
+    - uses: github/codeql-action/init@v1
     # @OctoLinkerResolve(https://github.com/OctoLinker/OctoLinker)
     - uses: ./
     

--- a/e2e/fixtures/.github/workflows/ci.yml
+++ b/e2e/fixtures/.github/workflows/ci.yml
@@ -13,6 +13,4 @@ jobs:
     - uses: actions/upload-artifact@master
     # @OctoLinkerResolve(https://github.com/github/codeql-action/tree/master/init)
     - uses: github/codeql-action/init@v1
-    # @OctoLinkerResolve(https://github.com/OctoLinker/OctoLinker/tree/<sha>/)
-    - uses: ./
     

--- a/e2e/fixtures/.github/workflows/ci.yml
+++ b/e2e/fixtures/.github/workflows/ci.yml
@@ -11,3 +11,6 @@ jobs:
     - uses: actions/setup-node
     # @OctoLinkerResolve(https://github.com/actions/upload-artifact)
     - uses: actions/upload-artifact@master
+    # @OctoLinkerResolve(https://github.com/OctoLinker/OctoLinker)
+    - uses: ./
+    

--- a/e2e/generate-fixtures-json.js
+++ b/e2e/generate-fixtures-json.js
@@ -28,6 +28,7 @@ if (process.env.GITHUB_EVENT_PATH) {
 
 const user = username || 'OctoLinker';
 const branch = process.env.GITHUB_HEAD_REF || 'master';
+const sha = process.env.GITHUB_SHA || 'HEAD';
 const fixturesRoot = `https://github.com/${user}/OctoLinker/blob/${branch}/e2e`;
 
 console.log('Fixtures root:', fixturesRoot); // eslint-disable-line no-console
@@ -62,7 +63,7 @@ function findTests(contents) {
         const targetUrl = line
           .match(/@OctoLinkerResolve(Above)?\((.*?)\)/)[2]
           .replace('<root>', '')
-          .replace('<sha>', branch)
+          .replace('<sha>', sha)
           .replace(
             'https://github.com/OctoLinker/OctoLinker/tree/',
             `https://github.com/${user}/OctoLinker/tree/`,

--- a/e2e/generate-fixtures-json.js
+++ b/e2e/generate-fixtures-json.js
@@ -32,6 +32,7 @@ const sha = process.env.GITHUB_SHA || 'HEAD';
 const fixturesRoot = `https://github.com/${user}/OctoLinker/blob/${branch}/e2e`;
 
 console.log('Fixtures root:', fixturesRoot); // eslint-disable-line no-console
+console.log('Fixtures sha:', sha); // eslint-disable-line no-console
 
 async function readContent(files) {
   const readFile = util.promisify(fs.readFile);

--- a/e2e/generate-fixtures-json.js
+++ b/e2e/generate-fixtures-json.js
@@ -25,7 +25,7 @@ if (process.env.GITHUB_EVENT_PATH) {
   if (json && json.pull_request) {
     username = json.pull_request.head.user.login;
     // eslint-disable-next-line prefer-destructuring
-    sha = json.payload.pull_request.head.sha;
+    sha = json.pull_request.head.sha;
   }
 }
 

--- a/e2e/generate-fixtures-json.js
+++ b/e2e/generate-fixtures-json.js
@@ -61,7 +61,12 @@ function findTests(contents) {
 
         const targetUrl = line
           .match(/@OctoLinkerResolve(Above)?\((.*?)\)/)[2]
-          .replace('<root>', '');
+          .replace('<root>', '')
+          .replace('<sha>', branch)
+          .replace(
+            'https://github.com/OctoLinker/OctoLinker/tree/',
+            `https://github.com/${user}/OctoLinker/tree/`,
+          );
 
         const filePath = file.replace(__dirname, '');
 

--- a/e2e/generate-fixtures-json.js
+++ b/e2e/generate-fixtures-json.js
@@ -18,17 +18,19 @@ const async = require('async');
 // ]
 
 let username;
+let sha = 'HEAD';
 
 if (process.env.GITHUB_EVENT_PATH) {
   const json = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH));
   if (json && json.pull_request) {
     username = json.pull_request.head.user.login;
+    // eslint-disable-next-line prefer-destructuring
+    sha = json.payload.pull_request.head.sha;
   }
 }
 
 const user = username || 'OctoLinker';
 const branch = process.env.GITHUB_HEAD_REF || 'master';
-const sha = process.env.GITHUB_SHA || 'HEAD';
 const fixturesRoot = `https://github.com/${user}/OctoLinker/blob/${branch}/e2e`;
 
 console.log('Fixtures root:', fixturesRoot); // eslint-disable-line no-console

--- a/packages/plugin-github-actions/index.js
+++ b/packages/plugin-github-actions/index.js
@@ -15,6 +15,12 @@ export default {
       return `{BASE_URL}/${join(org, repo, 'tree', sha, target)}`;
     }
 
+    const [org, repo, ...folder] = target.split('/');
+
+    if (folder.length) {
+      return `{BASE_URL}/${join(org, repo, 'tree', 'master', ...folder)}`;
+    }
+
     return `{BASE_URL}/${target}`;
   },
 

--- a/packages/plugin-github-actions/index.js
+++ b/packages/plugin-github-actions/index.js
@@ -1,3 +1,4 @@
+import { join } from 'path';
 import { GITHUB_ACTIONS } from '@octolinker/helper-grammar-regex-collection';
 
 export default {
@@ -6,6 +7,12 @@ export default {
   resolve(path, [target]) {
     if (!path.includes('.github/workflows')) {
       return '';
+    }
+
+    if (target.startsWith('.')) {
+      const [, org, repo, , sha] = path.split('/');
+
+      return `{BASE_URL}/${join(org, repo, 'tree', sha, target)}`;
     }
 
     return `{BASE_URL}/${target}`;

--- a/packages/plugin-github-actions/index.js
+++ b/packages/plugin-github-actions/index.js
@@ -18,7 +18,10 @@ export default {
     const [org, repo, ...folder] = target.split('/');
 
     if (folder.length) {
-      return `{BASE_URL}/${join(org, repo, 'tree', 'master', ...folder)}`;
+      return [
+        `{BASE_URL}/${join(org, repo, 'tree', 'main', ...folder)}`,
+        `{BASE_URL}/${join(org, repo, 'tree', 'master', ...folder)}`,
+      ];
     }
 
     return `{BASE_URL}/${target}`;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please provide at least one example link
- [x] Make sure all of the significant new logic is covered by tests

This builds on the existing support and adds links for local actions in the current repo, as well as actions that have sub actions which are located in a sub folder for the given action.

I had to hard code `master` for one of the urls because we don't have branch/commit information for it. What we could do is adjust the regex to capture the `@v1` value and use that. That should be a tag or commit which both work in the url and would be more accurate.

**Local**

https://github.com/github/codeql-action/blob/a0d60d5d9e3126a00bed89fd89cc89b7e52a56f2/.github/workflows/codeql.yml#L24-L28

**Sub folders**

https://github.com/twbs/bootstrap/blob/5faf41eb4837491fa8193910c5816efadb4dbc5a/.github/workflows/codeql.yml#L22-L25