### PR TITLE
Fix broken private repo check

### DIFF
--- a/packages/user-interface/index.js
+++ b/packages/user-interface/index.js
@@ -31,4 +31,7 @@ export const removeAllNotifications = () => {
     .forEach((el) => el.remove());
 };
 
-export const isPrivateRepository = () => !!document.querySelector('h1.private');
+export const isPrivateRepository = () => {
+  const privateLabel = document.querySelector('h1 > .Label');
+  return !!privateLabel && privateLabel.textContent === 'Private';
+};


### PR DESCRIPTION
<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please provide at least one example link
- [ ] Make sure all of the significant new logic is covered by tests

I noticed this while trying to test #975. I never got the popup until I adjusted this check.

Unfortunately there's no classes on the page that indicate if this is a private repo now that they've moved everything to utility classes. I confirmed the site is only served in English (for now) so checking for the label's text like this should be ok.

**Current HTML**
```html
<h1 class=" d-flex flex-wrap flex-items-center break-word f3 text-normal">
  <svg class="octicon octicon-repo-forked text-gray" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M5 3.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm0 2.122a2.25 2.25 0 10-1.5 0v.878A2.25 2.25 0 005.75 8.5h1.5v2.128a2.251 2.251 0 101.5 0V8.5h1.5a2.25 2.25 0 002.25-2.25v-.878a2.25 2.25 0 10-1.5 0v.878a.75.75 0 01-.75.75h-4.5A.75.75 0 015 6.25v-.878zm3.75 7.378a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm3-8.75a.75.75 0 100-1.5.75.75 0 000 1.5z"></path></svg>
  <span class="author ml-2 flex-self-stretch" itemprop="author">
    <a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/OctoLinker/hovercard" href="/OctoLinker">OctoLinker</a>
  </span>
  <span class="mx-1 flex-self-stretch">/</span>
  <strong itemprop="name" class="mr-2 flex-self-stretch">
    <a data-pjax="#js-repo-pjax-container" href="/OctoLinker/octolinker-testrepo-private">octolinker-testrepo-private</a>
  </strong>
  <span class="Label Label--outline v-align-middle ">Private</span>
</h1>
```