### PR TITLE
Ruby require_relative fixes

### DIFF
--- a/e2e/fixtures/ruby/mystic-wind.rb
+++ b/e2e/fixtures/ruby/mystic-wind.rb
@@ -1,2 +1,5 @@
 # @OctoLinkerResolve(https://github.com/rack/rack)
 require "rack"
+
+# @OctoLinkerResolve(<root>/ruby/relative/foo.rb)
+require_relative "relative/foo"

--- a/e2e/generate-fixtures-json.js
+++ b/e2e/generate-fixtures-json.js
@@ -29,8 +29,8 @@ if (process.env.GITHUB_EVENT_PATH) {
   }
 }
 
-const user = username || 'OctoLinker';
-const branch = process.env.GITHUB_HEAD_REF || 'master';
+const user = username || 'MatthewDG';
+const branch = process.env.GITHUB_HEAD_REF || '773-ruby-require-fixes';
 const fixturesRoot = `https://github.com/${user}/OctoLinker/blob/${branch}/e2e`;
 
 console.log('Fixtures root:', fixturesRoot); // eslint-disable-line no-console

--- a/e2e/generate-fixtures-json.js
+++ b/e2e/generate-fixtures-json.js
@@ -29,8 +29,8 @@ if (process.env.GITHUB_EVENT_PATH) {
   }
 }
 
-const user = username || 'MatthewDG';
-const branch = process.env.GITHUB_HEAD_REF || '773-ruby-require-fixes';
+const user = username || 'OctoLinker';
+const branch = process.env.GITHUB_HEAD_REF || 'master';
 const fixturesRoot = `https://github.com/${user}/OctoLinker/blob/${branch}/e2e`;
 
 console.log('Fixtures root:', fixturesRoot); // eslint-disable-line no-console

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -42,7 +42,13 @@ export const NODEJS_RELATIVE_PATH_JOIN = regex`
 `;
 
 export const REQUIRE = regex`
-  ( require(\.resolve)? | proxyquire | import | require_relative )
+  ( require(\.resolve)? | proxyquire | import )
+  \s* ( \s | \( ) \s*
+  ${captureJsQuotedWord}
+`;
+
+export const REQUIRE_RELATIVE = regex`
+  ( require_relative )
   \s* ( \s | \( ) \s*
   ${captureJsQuotedWord}
 `;

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -86,7 +86,6 @@ const fixtures = {
         ['./foo', './bar'],
       ],
       ['require "foo"', ['foo']],
-      ['require_relative "foo"', ['foo']],
       // require.resolve
       ['require.resolve "foo"', ['foo']],
       ['require.resolve("foo")', ['foo']],
@@ -172,6 +171,18 @@ const fixtures = {
       'import.resolve(\t"foo"\t)',
       'var foo = import.resolve("foo")',
       'var foo = import.resolve("foo")var bar = import.resolve("bar")',
+    ],
+  },
+  REQUIRE_RELATIVE: {
+    valid: [
+      ['require_relative "foo"', ['foo']],
+      ['require_relative "channel_prefix"', ['channel_prefix']],
+    ],
+    invalid: [
+      'require_relative(foo)',
+      'require_relative"foo"',
+      'require_relative (foo)',
+      'require_relative("fo o")',
     ],
   },
   GEM: {

--- a/packages/helper-insert-link/index.js
+++ b/packages/helper-insert-link/index.js
@@ -70,7 +70,7 @@ export default function (blob, regex, plugin, meta = {}) {
       endPosInBlob,
       values,
     }) => {
-      let urls = plugin.resolve(blob.path, values, meta);
+      let urls = plugin.resolve(blob.path, values, meta, regex);
       if (Array.isArray(urls)) {
         urls = urls.filter(Boolean);
       }

--- a/packages/plugin-ruby/index.js
+++ b/packages/plugin-ruby/index.js
@@ -14,6 +14,13 @@ export default {
 
     const isRequireRelative = regex.toString() === REQUIRE_RELATIVE.toString();
 
+    if (isRequireRelative) {
+      let resolvedPath = path;
+      const splitPath = path.split('/');
+      const currentFile = splitPath[splitPath.length - 1];
+      resolvedPath = resolvedPath.replace(currentFile, `${target}.rb`);
+      return `{BASE_URL}${resolvedPath}`;
+    }
 
     if (isPath) {
       let splitPath = path.split('/lib/');
@@ -22,14 +29,6 @@ export default {
       }
       const basePath = join(splitPath[0], 'lib');
       return `{BASE_URL}${join(basePath, `${target}.rb`)}`;
-    }
-
-    if (isRequireRelative) {
-      let resolvedPath = path;
-      const splitPath = path.split('/');
-      const currentFile = splitPath[splitPath.length - 1];
-      resolvedPath = resolvedPath.replace(currentFile, `${target}.rb`);
-      return `{BASE_URL}${resolvedPath}`;
     }
 
     return liveResolverQuery({ type: 'rubygems', target });

--- a/packages/plugin-ruby/index.js
+++ b/packages/plugin-ruby/index.js
@@ -10,8 +10,10 @@ export default {
 
   resolve(path, [target], meta, regex) {
     const isPath = !!target.match(/\//);
-    const isRequireRelative = regex.toString() === REQUIRE_RELATIVE.toString();
     // https://github.com/github/pages-gem/blob/master/lib/github-pages/dependencies.rb
+
+    const isRequireRelative = regex.toString() === REQUIRE_RELATIVE.toString();
+
 
     if (isPath) {
       let splitPath = path.split('/lib/');

--- a/packages/plugin-ruby/index.js
+++ b/packages/plugin-ruby/index.js
@@ -1,19 +1,33 @@
 import { join } from 'path';
-import { REQUIRE } from '@octolinker/helper-grammar-regex-collection';
+import {
+  REQUIRE,
+  REQUIRE_RELATIVE,
+} from '@octolinker/helper-grammar-regex-collection';
 import liveResolverQuery from '@octolinker/resolver-live-query';
 
 export default {
   name: 'Ruby',
 
-  resolve(path, [target]) {
+  resolve(path, [target], meta, regex) {
     const isPath = !!target.match(/\//);
-
+    const isRequireRelative = regex.toString() === REQUIRE_RELATIVE.toString();
     // https://github.com/github/pages-gem/blob/master/lib/github-pages/dependencies.rb
 
     if (isPath) {
-      const basePath = join(path.split('/lib/')[0], 'lib');
-
+      let splitPath = path.split('/lib/');
+      if (splitPath.length < 2) {
+        splitPath = path.split('/test/');
+      }
+      const basePath = join(splitPath[0], 'lib');
       return `{BASE_URL}${join(basePath, `${target}.rb`)}`;
+    }
+
+    if (isRequireRelative) {
+      let resolvedPath = path;
+      const splitPath = path.split('/');
+      const currentFile = splitPath[splitPath.length - 1];
+      resolvedPath = resolvedPath.replace(currentFile, `${target}.rb`);
+      return `{BASE_URL}${resolvedPath}`;
     }
 
     return liveResolverQuery({ type: 'rubygems', target });
@@ -27,6 +41,6 @@ export default {
   },
 
   getLinkRegexes() {
-    return REQUIRE;
+    return [REQUIRE, REQUIRE_RELATIVE];
   },
 };


### PR DESCRIPTION
Issue #773 

### Checklist:

- [X] If this PR is a new feature, please provide at least one example link
 * [`require_relative "channel_prefix"`](https://github.com/rails/rails/blob/f891a8d7d43eb3e66f65f5d74217133b713967c4/actioncable/test/subscription_adapter/redis_test.rb#L5)
 * [`require "action_cable/subscription_adapter/redis"`](https://github.com/rails/rails/blob/f891a8d7d43eb3e66f65f5d74217133b713967c4/actioncable/test/subscription_adapter/redis_test.rb#L7)
* Some require_relatives were resolving to a RubyGems page instead of a relative file such as [`require_relative "common"`](https://github.com/rails/rails/blob/f891a8d7d43eb3e66f65f5d74217133b713967c4/actioncable/test/subscription_adapter/redis_test.rb#L5)

- [X] Make sure all of the significant new logic is covered by tests
