### PR TITLE
Add PHP manual support

### DIFF
--- a/e2e/fixtures/php/foo.php
+++ b/e2e/fixtures/php/foo.php
@@ -9,6 +9,12 @@ use Exception;
 // @OctoLinkerResolve(https://www.php.net/manual/en/class.arrayaccess.php)
 use ArrayAccess;
 
+// @OctoLinkerResolve(https://www.php.net/manual/en/function.is-array.php)
+use function is_array;
+
+// @OctoLinkerResolve(https://www.php.net/manual/en/function.preg-last-error.php)
+use function preg_last_error;
+
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 

--- a/e2e/fixtures/php/foo.php
+++ b/e2e/fixtures/php/foo.php
@@ -1,0 +1,15 @@
+<?php
+
+// @OctoLinkerResolve(https://www.php.net/manual/en/class.closure.php)
+use Closure;
+
+// @OctoLinkerResolve(https://www.php.net/manual/en/class.exception.php)
+use Exception;
+
+// @OctoLinkerResolve(https://www.php.net/manual/en/class.arrayaccess.php)
+use ArrayAccess;
+
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Container\Container as ContainerContract;
+
+?>

--- a/packages/blob-reader/fixtures/github.com/issue/code.html
+++ b/packages/blob-reader/fixtures/github.com/issue/code.html
@@ -3,7 +3,6 @@
 
 
 
-
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -18,13 +17,14 @@
 
 
 
-  <link crossorigin="anonymous" media="all" integrity="sha512-InGiw0uqrfrV1EXLEoQR8zhoNQs4RhOXAZIoTEr+QaNPzbnLcqgPASwPZOSxhLC/ydy1tqek+nufQayviU4NRA==" rel="stylesheet" href="https://github.githubassets.com/assets/frameworks-c0ad6862340d6d1a2594b40111c17bf7.css" />
-  <link crossorigin="anonymous" media="all" integrity="sha512-q0uE9UAtjRgctFaLFVvUGVtXC6ggCD9Qcg86uwRaLx2RdC7FIE+hPfB4YDaM8lCecPVMwsxDyvqkXI2XEKDCOA==" rel="stylesheet" href="https://github.githubassets.com/assets/site-d2ea9f95eb7121ca3a5f9571e0012f11.css" />
-    <link crossorigin="anonymous" media="all" integrity="sha512-JedmoBWaUotKU3Fc6fDpBbcfTTMhoAiSb4IPTqwmqhD3pBHWUtHDyYYgVGuNwIKt08sVud5nLKZCb8DBdPvtNQ==" rel="stylesheet" href="https://github.githubassets.com/assets/github-0c16774092b1ce5288b91585e3d6617b.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-QLgu+HpQvHV00FunhsB3ueQCfgM7dkyMXKp1BrwCifVinFow2alu90jbiIbSdyn4/rXsaRo3otCqeYgmRmTCEA==" rel="stylesheet" href="https://github.githubassets.com/assets/frameworks-40b82ef87a50bc7574d05ba786c077b9.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-hGexWKDFEVgBAzW3wUFBdK0U2pZIJL3ppeWMQiD8uWJoaQVZsnG6d+jaPmtlTjtuFPNGcHe91A9o5Hv0tD/Fyg==" rel="stylesheet" href="https://github.githubassets.com/assets/site-8467b158a0c51158010335b7c1414174.css" />
+    <link crossorigin="anonymous" media="all" integrity="sha512-LO/A7AF7AWloUwd8ofJYVaUSbIwxrV6VObJ0HNwkfZz0190ca0jjmA/BEcC4uSuasl+XYBBOSd32B+lHipxwDQ==" rel="stylesheet" href="https://github.githubassets.com/assets/github-2cefc0ec017b01696853077ca1f25855.css" />
     
     
     
     
+
 
   <meta name="viewport" content="width=device-width">
   
@@ -33,32 +33,48 @@
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
   <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
   <meta property="fb:app_id" content="1401488693436528">
+  <meta name="apple-itunes-app" content="app-id=1477376905">
 
     <meta name="twitter:image:src" content="https://avatars3.githubusercontent.com/u/10505593?s=400&amp;v=4" /><meta name="twitter:site" content="@github" /><meta name="twitter:card" content="summary" /><meta name="twitter:title" content="Issue with some code blocks · Issue #2 · OctoLinker/testrepo" /><meta name="twitter:description" content="python import os rust extern crate failure_derive; ts require(&amp;amp;#39;fs&amp;amp;#39;) js require(&amp;amp;#39;fs&amp;amp;#39;) javascript require(&amp;amp;#39;fs&amp;amp;#39;) uby require(&amp;amp;#39;log&amp;amp;#39;) coff..." />
     <meta property="og:image" content="https://avatars3.githubusercontent.com/u/10505593?s=400&amp;v=4" /><meta property="og:site_name" content="GitHub" /><meta property="og:type" content="object" /><meta property="og:title" content="Issue with some code blocks · Issue #2 · OctoLinker/testrepo" /><meta property="og:url" content="https://github.com/OctoLinker/testrepo/issues/2" /><meta property="og:description" content="python import os rust extern crate failure_derive; ts require(&amp;#39;fs&amp;#39;) js require(&amp;#39;fs&amp;#39;) javascript require(&amp;#39;fs&amp;#39;) uby require(&amp;#39;log&amp;#39;) coffee require(&amp;#39;fs&amp;#39;) package..." />
 
+
+
+  
+
   <link rel="assets" href="https://github.githubassets.com/">
   
-  
-  <meta name="request-id" content="2B74:1E6FB:3F6137C:5FEA689:5DA39DC0" data-pjax-transient>
+
+  <meta name="request-id" content="1768:73A7:4EFFED2:7109673:5F692FC8" data-pjax-transient="true"/><meta name="html-safe-nonce" content="ecc314250339a3781adc82d39c0219b5623fa035" data-pjax-transient="true"/><meta name="visitor-payload" content="eyJyZWZlcnJlciI6IiIsInJlcXVlc3RfaWQiOiIxNzY4OjczQTc6NEVGRkVEMjo3MTA5NjczOjVGNjkyRkM4IiwidmlzaXRvcl9pZCI6IjU1MjMyNTY1MzMzNTcxNTc4NCIsInJlZ2lvbl9lZGdlIjoiZnJhIiwicmVnaW9uX3JlbmRlciI6ImZyYSJ9" data-pjax-transient="true"/><meta name="visitor-hmac" content="3ce882e5ab6f1da8a950ccf8721069f6637055c5f8171c774d5eb568c07c57a3" data-pjax-transient="true"/><meta name="cookie-consent-required" content="true" data-pjax-transient="true"/>
 
     <meta name="hovercard-subject-tag" content="issue:185246647" data-pjax-transient>
+
+
+  <meta name="github-keyboard-shortcuts" content="repository,issues" data-pjax-transient="true" />
 
   
 
   <meta name="selected-link" value="repo_issues" data-pjax-transient>
 
-      <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
-    <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
-    <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
+    <meta name="google-site-verification" content="c1kuD-K2HIVF635lypcsWPoD4kilo5-jA_wBFyT4uMY">
+  <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+  <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+  <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
 
-  <meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="2B74:1E6FB:3F6137C:5FEA689:5DA39DC0" /><meta name="octolytics-dimension-region_edge" content="ams" /><meta name="octolytics-dimension-region_render" content="iad" /><meta name="octolytics-dimension-ga_id" content="" class="js-octo-ga-id" /><meta name="octolytics-dimension-visitor_id" content="8015029147709709761" />
-<meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/issues/show" data-pjax-transient="true" />
+  <meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-ga_id" content="" class="js-octo-ga-id" />
+
+  <meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/issues/show" data-pjax-transient="true" />
+
+  
+
+
 
 
 
     <meta name="google-analytics" content="UA-3769691-2">
 
+
+<meta class="js-ga-set" name="dimension10" content="Responsive" data-pjax-transient>
 
 <meta class="js-ga-set" name="dimension1" content="Logged Out">
 
@@ -69,17 +85,16 @@
       <meta name="hostname" content="github.com">
     <meta name="user-login" content="">
 
+
       <meta name="expected-hostname" content="github.com">
-    <meta name="js-proxy-site-detection-payload" content="MmM3NGRlMzlkNzVlM2RhMTk5YTU4Njk1MGQ0YjJhOWQ2ODVkZDA1Y2Y5ZTk1YWQ4Yzc5YWU5YjRiMTA2YzEyN3x7InJlbW90ZV9hZGRyZXNzIjoiNDYuMjIzLjE5My4xMzciLCJyZXF1ZXN0X2lkIjoiMkI3NDoxRTZGQjozRjYxMzdDOjVGRUE2ODk6NURBMzlEQzAiLCJ0aW1lc3RhbXAiOjE1NzEwMDM4NDEsImhvc3QiOiJnaXRodWIuY29tIn0=">
 
-    <meta name="enabled-features" content="ACTIONS_V2_ON_MARKETPLACE,MARKETPLACE_FEATURED_BLOG_POSTS,MARKETPLACE_INVOICED_BILLING,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_RECOMMENDATIONS,MARKETPLACE_PENDING_INSTALLATIONS">
 
-  <meta name="html-safe-nonce" content="5f81b000bcfda4ec0573455ab76f06fb15ddc22c">
+    <meta name="enabled-features" content="MARKETPLACE_PENDING_INSTALLATIONS">
 
-  <meta http-equiv="x-pjax-version" content="44b9ec2c05411d52010d6e44b7f2e495">
+  <meta http-equiv="x-pjax-version" content="616b7a9fdf54b3a4a6f63342b5c7cd54563379a95c7ef8f7c5849e312e1b381e">
   
 
-      <link href="https://github.com/OctoLinker/testrepo/commits/master.atom" rel="alternate" title="Recent Commits to testrepo:master" type="application/atom+xml">
+        <link href="https://github.com/OctoLinker/testrepo/commits/master.atom" rel="alternate" title="Recent Commits to testrepo:master" type="application/atom+xml">
 
   <meta name="go-import" content="github.com/OctoLinker/testrepo git https://github.com/OctoLinker/testrepo.git">
 
@@ -93,71 +108,83 @@
   <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
 
   <link rel="mask-icon" href="https://github.githubassets.com/pinned-octocat.svg" color="#000000">
-  <link rel="icon" type="image/x-icon" class="js-site-favicon" href="https://github.githubassets.com/favicon.ico">
+  <link rel="alternate icon" class="js-site-favicon" type="image/png" href="https://github.githubassets.com/favicons/favicon.png">
+  <link rel="icon" class="js-site-favicon" type="image/svg+xml" href="https://github.githubassets.com/favicons/favicon.svg">
 
 <meta name="theme-color" content="#1e2327">
-
-
-
 
 
   <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
 
   </head>
 
-  <body class="logged-out env-production min-width-lg">
+  <body class="logged-out env-production page-responsive">
     
 
-  <div class="position-relative js-header-wrapper ">
-    <a href="#start-of-content" tabindex="1" class="px-2 py-4 bg-blue text-white show-on-focus js-skip-to-content">Skip to content</a>
-    <span class="Progress progress-pjax-loader position-fixed width-full js-pjax-loader-bar">
-      <span class="progress-pjax-loader-bar top-0 left-0" style="width: 0%;"></span>
-    </span>
-
-    
-    
-    
+    <div class="position-relative js-header-wrapper ">
+      <a href="#start-of-content" class="px-2 py-4 bg-blue text-white show-on-focus js-skip-to-content">Skip to content</a>
+      <span class="progress-pjax-loader width-full js-pjax-loader-bar Progress position-fixed">
+    <span style="background-color: #79b8ff;width: 0%;" class="Progress-item progress-pjax-loader-bar "></span>
+</span>      
+      
 
 
-        <header class="Header-old header-logged-out  position-relative f4 py-2" role="banner">
-  <div class="container-lg d-flex px-3">
+
+          <header class="Header-old header-logged-out js-details-container Details position-relative f4 py-2" role="banner">
+  <div class="container-xl d-lg-flex flex-items-center p-responsive">
     <div class="d-flex flex-justify-between flex-items-center">
         <a class="mr-4" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark">
-          <svg height="32" class="octicon octicon-mark-github text-white" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+          <svg height="32" class="octicon octicon-mark-github text-white" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
         </a>
+
+          <div class="d-lg-none css-truncate css-truncate-target width-fit p-2">
+            
+
+          </div>
+
+        <div class="d-flex flex-items-center">
+              <a href="/join?ref_cta=Sign+up&amp;ref_loc=header+logged+out&amp;ref_page=%2F%3Cuser-name%3E%2F%3Crepo-name%3E%2Fissues%2Fshow&amp;source=header-repo"
+                class="d-inline-block d-lg-none f5 text-white no-underline border border-gray-dark rounded-2 px-2 py-1 mr-3 mr-sm-5"
+                data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="cee77e05486f80f66a0c1453cfb4ad39445aa89399ddaf1df201d27cfd4c7bef"
+                data-ga-click="Sign up, click to sign up for account, ref_page:/&lt;user-name&gt;/&lt;repo-name&gt;/issues/show;ref_cta:Sign up;ref_loc:header logged out">
+                Sign&nbsp;up
+              </a>
+
+          <button class="btn-link d-lg-none mt-1 js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <svg height="24" class="octicon octicon-three-bars text-white" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M1 2.75A.75.75 0 011.75 2h12.5a.75.75 0 110 1.5H1.75A.75.75 0 011 2.75zm0 5A.75.75 0 011.75 7h12.5a.75.75 0 110 1.5H1.75A.75.75 0 011 7.75zM1.75 12a.75.75 0 100 1.5h12.5a.75.75 0 100-1.5H1.75z"></path></svg>
+          </button>
+        </div>
     </div>
 
-    <div class="HeaderMenu HeaderMenu--logged-out d-flex flex-justify-between flex-items-center flex-auto">
-      <div class="d-none">
+    <div class="HeaderMenu HeaderMenu--logged-out position-fixed top-0 right-0 bottom-0 height-fit position-lg-relative d-lg-flex flex-justify-between flex-items-center flex-auto">
+      <div class="d-flex d-lg-none flex-justify-end border-bottom bg-gray-light p-3">
         <button class="btn-link js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
-          <svg height="24" class="octicon octicon-x text-gray" viewBox="0 0 12 16" version="1.1" width="18" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+          <svg height="24" class="octicon octicon-x text-gray" viewBox="0 0 24 24" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M5.72 5.72a.75.75 0 011.06 0L12 10.94l5.22-5.22a.75.75 0 111.06 1.06L13.06 12l5.22 5.22a.75.75 0 11-1.06 1.06L12 13.06l-5.22 5.22a.75.75 0 01-1.06-1.06L10.94 12 5.72 6.78a.75.75 0 010-1.06z"></path></svg>
         </button>
       </div>
 
-        <nav class="mt-0" aria-label="Global">
-          <ul class="d-flex list-style-none">
-              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+        <nav class="mt-0 px-3 px-lg-0 mb-5 mb-lg-0" aria-label="Global">
+          <ul class="d-lg-flex list-style-none">
+              <li class="d-block d-lg-flex flex-lg-nowrap flex-lg-items-center border-bottom border-lg-bottom-0 mr-0 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
                 <details class="HeaderMenu-details details-overlay details-reset width-full">
-                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap d-block d-lg-inline-block">
                     Why GitHub?
-                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-absolute position-lg-relative">
                       <path d="M1,1l6.2,6L13,1"></path>
                     </svg>
                   </summary>
-                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 mt-0  p-4 left-n4 position-absolute">
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 mt-0 pb-4 p-lg-4 position-relative position-lg-absolute left-0 left-lg-n4">
                     <a href="/features" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Features <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
                     <ul class="list-style-none f5 pb-3">
                       <li class="edge-item-fix"><a href="/features/code-review/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code review">Code review</a></li>
                       <li class="edge-item-fix"><a href="/features/project-management/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Project management">Project management</a></li>
                       <li class="edge-item-fix"><a href="/features/integrations" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Integrations">Integrations</a></li>
-                      <li class="edge-item-fix"><a href="/features/actions" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Actions">Actions</a>
-                          <li class="edge-item-fix"><a href="/features/package-registry" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Package Registry">Package registry</a>
-
-                      <li class="edge-item-fix"><a href="/features/security" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Security">Security</a>
+                      <li class="edge-item-fix"><a href="/features/actions" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Actions">Actions</a></li>
+                      <li class="edge-item-fix"><a href="/features/packages" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to GitHub Packages">Packages</a></li>
+                      <li class="edge-item-fix"><a href="/features/security" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Security">Security</a></li>
                       <li class="edge-item-fix"><a href="/features#team-management" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team management">Team management</a></li>
-                      <li class="edge-item-fix"><a href="/features#social-coding" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Social coding">Social coding</a></li>
-                      <li class="edge-item-fix"><a href="/features#documentation" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Documentation">Documentation</a></li>
-                      <li class="edge-item-fix"><a href="/features#code-hosting" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code hosting">Code hosting</a></li>
+                      <li class="edge-item-fix"><a href="/features#hosting" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code hosting">Hosting</a></li>
+                      <li class="edge-item-fix hide-xl"><a href="/mobile" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Mobile">Mobile</a></li>
                     </ul>
 
                     <ul class="list-style-none mb-0 border-lg-top pt-lg-3">
@@ -167,25 +194,28 @@
                   </div>
                 </details>
               </li>
-              <li class=" mr-3 mr-lg-3">
+              <li class="border-bottom border-lg-bottom-0 mr-0 mr-lg-3">
+                <a href="/team" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Team">Team</a>
+              </li>
+              <li class="border-bottom border-lg-bottom-0 mr-0 mr-lg-3">
                 <a href="/enterprise" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Enterprise">Enterprise</a>
               </li>
 
-              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+              <li class="d-block d-lg-flex flex-lg-nowrap flex-lg-items-center border-bottom border-lg-bottom-0 mr-0 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
                 <details class="HeaderMenu-details details-overlay details-reset width-full">
-                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap d-block d-lg-inline-block">
                     Explore
-                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-absolute position-lg-relative">
                       <path d="M1,1l6.2,6L13,1"></path>
                     </svg>
                   </summary>
 
-                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-0 mt-0  p-4 left-n4 position-absolute">
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-0 mt-0 pb-4 p-lg-4 position-relative position-lg-absolute left-0 left-lg-n4">
                     <ul class="list-style-none mb-3">
                       <li class="edge-item-fix"><a href="/explore" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Explore">Explore GitHub <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
                     </ul>
 
-                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Learn &amp; contribute</h4>
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2 border-lg-top pt-lg-3">Learn &amp; contribute</h4>
                     <ul class="list-style-none mb-3">
                       <li class="edge-item-fix"><a href="/topics" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Topics">Topics</a></li>
                         <li class="edge-item-fix"><a href="/collections" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Collections">Collections</a></li>
@@ -194,30 +224,31 @@
                       <li class="edge-item-fix"><a href="https://opensource.guide" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Open source guides">Open source guides</a></li>
                     </ul>
 
-                    <h4 class="text-gray-light text-normal text-mono f5 mb-2  border-top pt-3">Connect with others</h4>
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2 border-lg-top pt-lg-3">Connect with others</h4>
                     <ul class="list-style-none mb-0">
                       <li class="edge-item-fix"><a href="https://github.com/events" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Events">Events</a></li>
                       <li class="edge-item-fix"><a href="https://github.community" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Community forum">Community forum</a></li>
-                      <li class="edge-item-fix"><a href="https://education.github.com" class="py-2 pb-0 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to GitHub Education">GitHub Education</a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to GitHub Education">GitHub Education</a></li>
+                      <li class="edge-item-fix"><a href="https://stars.github.com" class="py-2 pb-0 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to GitHub Stars Program">GitHub Stars program</a></li>
                     </ul>
                   </div>
                 </details>
               </li>
 
-              <li class=" mr-3 mr-lg-3">
+              <li class="border-bottom border-lg-bottom-0 mr-0 mr-lg-3">
                 <a href="/marketplace" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Marketplace">Marketplace</a>
               </li>
 
-              <li class=" mr-3 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+              <li class="d-block d-lg-flex flex-lg-nowrap flex-lg-items-center border-bottom border-lg-bottom-0 mr-0 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
                 <details class="HeaderMenu-details details-overlay details-reset width-full">
-                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap  d-inline-block">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap d-block d-lg-inline-block">
                     Pricing
-                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-relative">
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-absolute position-lg-relative">
                        <path d="M1,1l6.2,6L13,1"></path>
                     </svg>
                   </summary>
 
-                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-4 mt-0  p-4 left-n4 position-absolute">
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-4 mt-0 p-lg-4 position-relative position-lg-absolute left-0 left-lg-n4">
                     <a href="/pricing" class="pb-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Pricing">Plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
 
                     <ul class="list-style-none mb-3">
@@ -225,7 +256,7 @@
                       <li class="edge-item-fix"><a href="https://enterprise.github.com/contact" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Contact Sales">Contact Sales</a></li>
                     </ul>
 
-                    <ul class="list-style-none mb-0  border-top pt-3">
+                    <ul class="list-style-none mb-0 border-lg-top pt-lg-3">
                       <li class="edge-item-fix"><a href="/nonprofit" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Nonprofits">Nonprofit <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
                       <li class="edge-item-fix"><a href="https://education.github.com" class="py-2 pb-0 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover"  data-ga-click="(Logged out) Header, go to Education">Education <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
                     </ul>
@@ -235,9 +266,11 @@
           </ul>
         </nav>
 
-      <div class="d-flex flex-items-center px-0 text-center text-left">
-          <div class="d-lg-flex ">
-            <div class="header-search mr-3 scoped-search site-scoped-search js-site-search position-relative js-jump-to"
+      <div class="d-lg-flex flex-items-center px-3 px-lg-0 text-center text-lg-left">
+          <div class="d-lg-flex mb-3 mb-lg-0">
+              <div hidden class="d-none">
+</div>
+<div class="header-search header-search-current js-header-search-current flex-auto js-site-search position-relative flex-self-stretch flex-md-self-auto mr-0 mr-md-3 mb-3 mb-md-0 scoped-search site-scoped-search js-jump-to js-header-search-current-jump-to"
   role="combobox"
   aria-owns="jump-to-results"
   aria-label="Search or jump to"
@@ -245,8 +278,8 @@
   aria-expanded="false"
 >
   <div class="position-relative">
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-site-search-form" role="search" aria-label="Site" data-scope-type="Repository" data-scope-id="45358638" data-scoped-search-url="/OctoLinker/testrepo/search" data-unscoped-search-url="/search" action="/OctoLinker/testrepo/search" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
-      <label class="form-control input-sm header-search-wrapper p-0 header-search-wrapper-jump-to position-relative d-flex flex-justify-between flex-items-center js-chromeless-input-container">
+    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-site-search-form" role="search" aria-label="Site" data-scope-type="Repository" data-scope-id="45358638" data-scoped-search-url="/OctoLinker/testrepo/search" data-unscoped-search-url="/search" action="/OctoLinker/testrepo/search" accept-charset="UTF-8" method="get">
+      <label class="form-control input-sm header-search-wrapper p-0 js-chromeless-input-container header-search-wrapper-jump-to position-relative d-flex flex-justify-between flex-items-center">
         <input type="text"
           class="form-control input-sm header-search-input jump-to-field js-jump-to-field js-site-search-focus js-site-search-field is-clearable"
           data-hotkey="s,/"
@@ -259,10 +292,11 @@
           aria-autocomplete="list"
           aria-controls="jump-to-results"
           aria-label="Search"
-          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=rO76SNUVrFVDMi+PLqDrElRW3C5XdbLrGVODapPOAjzDx4y1K5d1FmK6X9aMkcBEHVShCvNP2DqzPJ2DWErAEQ=="
+          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations"
           spellcheck="false"
           autocomplete="off"
           >
+          <input type="hidden" data-csrf="true" class="js-data-jump-to-suggestions-path-csrf" value="PcfgTNQpMUfwGDzB4dQaVZqWJNN+vzAeZi3HcUk+NJXQxOa1hISFjMLQbrXSgSgf6Kwf+bdj40dHmqGT7CiOOw==" />
           <input type="hidden" class="js-site-search-type-field" name="type" >
             <img src="https://github.githubassets.com/images/search-key-slash.svg" alt="" class="mr-2 header-search-key-slash">
 
@@ -274,9 +308,9 @@
 <li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-suggestion" role="option">
   <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
     <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
-      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 011-1h8zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z"></path></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M1.75 0A1.75 1.75 0 000 1.75v12.5C0 15.216.784 16 1.75 16h12.5A1.75 1.75 0 0016 14.25V1.75A1.75 1.75 0 0014.25 0H1.75zM1.5 1.75a.25.25 0 01.25-.25h12.5a.25.25 0 01.25.25v12.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25V1.75zM11.75 3a.75.75 0 00-.75.75v7.5a.75.75 0 001.5 0v-7.5a.75.75 0 00-.75-.75zm-8.25.75a.75.75 0 011.5 0v5.5a.75.75 0 01-1.5 0v-5.5zM8 3a.75.75 0 00-.75.75v3.5a.75.75 0 001.5 0v-3.5A.75.75 0 008 3z"></path></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path></svg>
     </div>
 
     <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
@@ -315,9 +349,9 @@
 <li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-scoped-search d-none" role="option">
   <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
     <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
-      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 011-1h8zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z"></path></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M1.75 0A1.75 1.75 0 000 1.75v12.5C0 15.216.784 16 1.75 16h12.5A1.75 1.75 0 0016 14.25V1.75A1.75 1.75 0 0014.25 0H1.75zM1.5 1.75a.25.25 0 01.25-.25h12.5a.25.25 0 01.25.25v12.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25V1.75zM11.75 3a.75.75 0 00-.75.75v7.5a.75.75 0 001.5 0v-7.5a.75.75 0 00-.75-.75zm-8.25.75a.75.75 0 011.5 0v5.5a.75.75 0 01-1.5 0v-5.5zM8 3a.75.75 0 00-.75.75v3.5a.75.75 0 001.5 0v-3.5A.75.75 0 008 3z"></path></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path></svg>
     </div>
 
     <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
@@ -347,9 +381,9 @@
 <li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-global-search d-none" role="option">
   <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
     <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
-      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
-      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 011-1h8zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z"></path></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M1.75 0A1.75 1.75 0 000 1.75v12.5C0 15.216.784 16 1.75 16h12.5A1.75 1.75 0 0016 14.25V1.75A1.75 1.75 0 0014.25 0H1.75zM1.5 1.75a.25.25 0 01.25-.25h12.5a.25.25 0 01.25.25v12.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25V1.75zM11.75 3a.75.75 0 00-.75.75v7.5a.75.75 0 001.5 0v-7.5a.75.75 0 00-.75-.75zm-8.25.75a.75.75 0 011.5 0v5.5a.75.75 0 01-1.5 0v-5.5zM8 3a.75.75 0 00-.75.75v3.5a.75.75 0 001.5 0v-3.5A.75.75 0 008 3z"></path></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path></svg>
     </div>
 
     <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
@@ -386,61 +420,99 @@
 
         <a href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fissues%2F2"
           class="HeaderMenu-link no-underline mr-3"
-          data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;2B74:1E6FB:3F6137C:5FEA689:5DA39DC0&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;referrer&quot;:null,&quot;user_id&quot;:null}}" data-hydro-click-hmac="49f503694b46379a864c0c4b23b206d51ee00ead048546cfdb4aa7453dcbcfaf"
+          data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="07bbb0cf3d0196b41400372cdaaf2d78991b9dff86d3fec03d42a66e20b5f129"
           data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">
           Sign&nbsp;in
         </a>
-          <a href="/join"
-            class="HeaderMenu-link d-inline-block no-underline border border-gray-dark rounded-1 px-2 py-1"
-            data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;2B74:1E6FB:3F6137C:5FEA689:5DA39DC0&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;referrer&quot;:null,&quot;user_id&quot;:null}}" data-hydro-click-hmac="49f503694b46379a864c0c4b23b206d51ee00ead048546cfdb4aa7453dcbcfaf"
-            data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">
-            Sign&nbsp;up
-          </a>
+            <a href="/join?ref_cta=Sign+up&amp;ref_loc=header+logged+out&amp;ref_page=%2F%3Cuser-name%3E%2F%3Crepo-name%3E%2Fissues%2Fshow&amp;source=header-repo&amp;source_repo=OctoLinker%2Ftestrepo"
+              class="HeaderMenu-link d-inline-block no-underline border border-gray-dark rounded-1 px-2 py-1"
+              data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="07bbb0cf3d0196b41400372cdaaf2d78991b9dff86d3fec03d42a66e20b5f129"
+              data-ga-click="Sign up, click to sign up for account, ref_page:/&lt;user-name&gt;/&lt;repo-name&gt;/issues/show;ref_cta:Sign up;ref_loc:header logged out">
+              Sign&nbsp;up
+            </a>
       </div>
     </div>
   </div>
 </header>
 
-  </div>
+    </div>
 
   <div id="start-of-content" class="show-on-focus"></div>
 
 
+
+
     <div id="js-flash-container">
 
+
+  <template class="js-flash-template">
+    <div class="flash flash-full  {{ className }}">
+  <div class=" px-2" >
+    <button class="flash-close js-flash-close" type="button" aria-label="Dismiss this message">
+      <svg class="octicon octicon-x" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path></svg>
+    </button>
+    
+      <div>{{ message }}</div>
+
+  </div>
+</div>
+  </template>
 </div>
 
 
+  
 
-  <div class="application-main " data-commit-hovercards-enabled>
+  <include-fragment class="js-notification-shelf-include-fragment" data-base-src="https://github.com/notifications/beta/shelf"></include-fragment>
+
+
+
+  <div
+    class="application-main "
+    data-commit-hovercards-enabled
+    data-discussion-hovercards-enabled
+    data-issue-and-pr-hovercards-enabled
+  >
         <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
     <main id="js-repo-pjax-container" data-pjax-container >
       
+    
+
+
+    
+
+
+
+
+
+
   
 
 
+  <div class="bg-gray-light pt-3 hide-full-screen mb-5">
 
+      <div class="d-flex mb-3 px-3 px-md-4 px-lg-5">
+
+        <div class="flex-auto min-width-0 width-fit mr-3">
+            <h1 class=" d-flex flex-wrap flex-items-center break-word f3 text-normal">
+    <svg class="octicon octicon-repo text-gray" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 011-1h8zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z"></path></svg>
+  <span class="author ml-2 flex-self-stretch" itemprop="author">
+    <a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/OctoLinker/hovercard" href="/OctoLinker">OctoLinker</a>
+  </span>
+  <span class="mx-1 flex-self-stretch">/</span>
+  <strong itemprop="name" class="mr-2 flex-self-stretch">
+    <a data-pjax="#js-repo-pjax-container" href="/OctoLinker/testrepo">testrepo</a>
+  </strong>
   
+</h1>
 
 
+        </div>
 
-
-
-
-
-
-  <div class="pagehead repohead instapaper_ignore readability-menu experiment-repo-nav  ">
-    <div class="repohead-details-container clearfix container">
-
-      <ul class="pagehead-actions">
-
-
-
+          <ul class="pagehead-actions flex-shrink-0 d-none d-md-inline" style="padding: 2px 0;">
 
   <li>
-    
-  <a class="tooltipped tooltipped-s btn btn-sm btn-with-count" aria-label="You must be signed in to watch a repository" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;notification subscription menu watch&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;2B74:1E6FB:3F6137C:5FEA689:5DA39DC0&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;referrer&quot;:null,&quot;user_id&quot;:null}}" data-hydro-click-hmac="5f2870f3cca56d553bdc72a862f2a1846f75907741ec8711dcd7b45dd85dd2d5" href="/login?return_to=%2FOctoLinker%2Ftestrepo">
-    <svg class="octicon octicon-eye v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
+          <a class="tooltipped tooltipped-s btn btn-sm btn-with-count" aria-label="You must be signed in to watch a repository" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;notification subscription menu watch&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="690e8f4f5637c53b48b3185a286c2d4e6d0f2b7157a2990a8864da17487236cb" href="/login?return_to=%2FOctoLinker%2Ftestrepo">
+    <svg height="16" class="octicon octicon-eye" viewBox="0 0 16 16" version="1.1" width="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.679 7.932c.412-.621 1.242-1.75 2.366-2.717C5.175 4.242 6.527 3.5 8 3.5c1.473 0 2.824.742 3.955 1.715 1.124.967 1.954 2.096 2.366 2.717a.119.119 0 010 .136c-.412.621-1.242 1.75-2.366 2.717C10.825 11.758 9.473 12.5 8 12.5c-1.473 0-2.824-.742-3.955-1.715C2.92 9.818 2.09 8.69 1.679 8.068a.119.119 0 010-.136zM8 2c-1.981 0-3.67.992-4.933 2.078C1.797 5.169.88 6.423.43 7.1a1.619 1.619 0 000 1.798c.45.678 1.367 1.932 2.637 3.024C4.329 13.008 6.019 14 8 14c1.981 0 3.67-.992 4.933-2.078 1.27-1.091 2.187-2.345 2.637-3.023a1.619 1.619 0 000-1.798c-.45-.678-1.367-1.932-2.637-3.023C11.671 2.992 9.981 2 8 2zm0 8a2 2 0 100-4 2 2 0 000 4z"></path></svg>
     Watch
 </a>    <a class="social-count" href="/OctoLinker/testrepo/watchers"
        aria-label="0 users are watching this repository">
@@ -450,8 +522,8 @@
   </li>
 
   <li>
-        <a class="btn btn-sm btn-with-count tooltipped tooltipped-s" aria-label="You must be signed in to star a repository" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;star button&quot;,&quot;repository_id&quot;:45358638,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;2B74:1E6FB:3F6137C:5FEA689:5DA39DC0&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;referrer&quot;:null,&quot;user_id&quot;:null}}" data-hydro-click-hmac="8faa8fa1d2c78b409bb6689cd2aad41cd16c3f087ced907b8149f90bfbb80628" href="/login?return_to=%2FOctoLinker%2Ftestrepo">
-      <svg class="octicon octicon-star v-align-text-bottom" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
+          <a class="btn btn-sm btn-with-count  tooltipped tooltipped-s" aria-label="You must be signed in to star a repository" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;star button&quot;,&quot;repository_id&quot;:45358638,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="633c5a6f53242f91850c1c155f99b866d2e5c67ee9205093a41578bacaa76b26" href="/login?return_to=%2FOctoLinker%2Ftestrepo">
+      <svg vertical_align="text_bottom" height="16" class="octicon octicon-star v-align-text-bottom" viewBox="0 0 16 16" version="1.1" width="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z"></path></svg>
       Star
 </a>
     <a class="social-count js-social-count" href="/OctoLinker/testrepo/stargazers"
@@ -462,115 +534,149 @@
   </li>
 
   <li>
-      <a class="btn btn-sm btn-with-count tooltipped tooltipped-s" aria-label="You must be signed in to fork a repository" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;repo details fork button&quot;,&quot;repository_id&quot;:45358638,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;2B74:1E6FB:3F6137C:5FEA689:5DA39DC0&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;referrer&quot;:null,&quot;user_id&quot;:null}}" data-hydro-click-hmac="cb6d53523a47f49d5b049ba4db7a7915040b9f474c881938fee31124a53a7804" href="/login?return_to=%2FOctoLinker%2Ftestrepo">
-        <svg class="octicon octicon-repo-forked v-align-text-bottom" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
-        Fork
+        <a class="btn btn-sm btn-with-count tooltipped tooltipped-s" aria-label="You must be signed in to fork a repository" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;repo details fork button&quot;,&quot;repository_id&quot;:45358638,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="a43645ca8d5cfce97a364235e68faae23c5c43b67923a4a3889bda1e5dda468b" href="/login?return_to=%2FOctoLinker%2Ftestrepo">
+          <svg class="octicon octicon-repo-forked" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M5 3.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm0 2.122a2.25 2.25 0 10-1.5 0v.878A2.25 2.25 0 005.75 8.5h1.5v2.128a2.251 2.251 0 101.5 0V8.5h1.5a2.25 2.25 0 002.25-2.25v-.878a2.25 2.25 0 10-1.5 0v.878a.75.75 0 01-.75.75h-4.5A.75.75 0 015 6.25v-.878zm3.75 7.378a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm3-8.75a.75.75 0 100-1.5.75.75 0 000 1.5z"></path></svg>
+          Fork
 </a>
-    <a href="/OctoLinker/testrepo/network/members" class="social-count"
-       aria-label="2 users forked this repository">
-      2
-    </a>
+      <a href="/OctoLinker/testrepo/network/members" class="social-count"
+         aria-label="2 users forked this repository">
+        2
+      </a>
   </li>
 </ul>
 
-      <h1 class="public ">
-    <svg class="octicon octicon-repo" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
-  <span class="author" itemprop="author"><a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/OctoLinker/hovercard" href="/OctoLinker">OctoLinker</a></span><!--
---><span class="path-divider">/</span><!--
---><strong itemprop="name"><a data-pjax="#js-repo-pjax-container" href="/OctoLinker/testrepo">testrepo</a></strong>
+      </div>
+        
+<nav aria-label="Repository" data-pjax="#js-repo-pjax-container" class="js-repo-nav js-sidenav-container-pjax js-responsive-underlinenav overflow-hidden UnderlineNav px-3 px-md-4 px-lg-5 bg-gray-light">
+  <ul class="UnderlineNav-body list-style-none ">
+          <li class="d-flex">
+        <a class="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item" data-tab-item="code-tab" data-hotkey="g c" data-ga-click="Repository, Navigation click, Code tab" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages repo_deployments /OctoLinker/testrepo" href="/OctoLinker/testrepo">
+              <svg classes="UnderlineNav-octicon" display="none inline" height="16" class="octicon octicon-code UnderlineNav-octicon d-none d-sm-inline" viewBox="0 0 16 16" version="1.1" width="16" aria-hidden="true"><path fill-rule="evenodd" d="M4.72 3.22a.75.75 0 011.06 1.06L2.06 8l3.72 3.72a.75.75 0 11-1.06 1.06L.47 8.53a.75.75 0 010-1.06l4.25-4.25zm6.56 0a.75.75 0 10-1.06 1.06L13.94 8l-3.72 3.72a.75.75 0 101.06 1.06l4.25-4.25a.75.75 0 000-1.06l-4.25-4.25z"></path></svg>
+            <span data-content="Code">Code</span>
+              <span title="Not available" class="Counter "></span>
+</a>      </li>
+      <li class="d-flex">
+        <a class="js-selected-navigation-item selected UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item" data-tab-item="issues-tab" data-hotkey="g i" data-ga-click="Repository, Navigation click, Issues tab" aria-current="page" data-selected-links="repo_issues repo_labels repo_milestones /OctoLinker/testrepo/issues" href="/OctoLinker/testrepo/issues">
+              <svg classes="UnderlineNav-octicon" display="none inline" height="16" class="octicon octicon-issue-opened UnderlineNav-octicon d-none d-sm-inline" viewBox="0 0 16 16" version="1.1" width="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm9 3a1 1 0 11-2 0 1 1 0 012 0zm-.25-6.25a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z"></path></svg>
+            <span data-content="Issues">Issues</span>
+              <span title="1" class="Counter ">1</span>
+</a>      </li>
+      <li class="d-flex">
+        <a class="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item" data-tab-item="pull-requests-tab" data-hotkey="g p" data-ga-click="Repository, Navigation click, Pull requests tab" data-selected-links="repo_pulls checks /OctoLinker/testrepo/pulls" href="/OctoLinker/testrepo/pulls">
+              <svg classes="UnderlineNav-octicon" display="none inline" height="16" class="octicon octicon-git-pull-request UnderlineNav-octicon d-none d-sm-inline" viewBox="0 0 16 16" version="1.1" width="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"></path></svg>
+            <span data-content="Pull requests">Pull requests</span>
+              <span title="3" class="Counter ">3</span>
+</a>      </li>
+      <li class="d-flex">
+        <a class="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item" data-tab-item="actions-tab" data-hotkey="g a" data-ga-click="Repository, Navigation click, Actions tab" data-selected-links="repo_actions /OctoLinker/testrepo/actions" href="/OctoLinker/testrepo/actions">
+              <svg classes="UnderlineNav-octicon" display="none inline" height="16" class="octicon octicon-play UnderlineNav-octicon d-none d-sm-inline" viewBox="0 0 16 16" version="1.1" width="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0zM8 0a8 8 0 100 16A8 8 0 008 0zM6.379 5.227A.25.25 0 006 5.442v5.117a.25.25 0 00.379.214l4.264-2.559a.25.25 0 000-.428L6.379 5.227z"></path></svg>
+            <span data-content="Actions">Actions</span>
+              <span title="Not available" class="Counter "></span>
+</a>      </li>
+      <li class="d-flex">
+        <a class="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item" data-tab-item="security-tab" data-hotkey="g s" data-ga-click="Repository, Navigation click, Security tab" data-selected-links="security overview alerts policy token_scanning code_scanning /OctoLinker/testrepo/security" href="/OctoLinker/testrepo/security">
+              <svg classes="UnderlineNav-octicon" display="none inline" height="16" class="octicon octicon-shield UnderlineNav-octicon d-none d-sm-inline" viewBox="0 0 16 16" version="1.1" width="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.467.133a1.75 1.75 0 011.066 0l5.25 1.68A1.75 1.75 0 0115 3.48V7c0 1.566-.32 3.182-1.303 4.682-.983 1.498-2.585 2.813-5.032 3.855a1.7 1.7 0 01-1.33 0c-2.447-1.042-4.049-2.357-5.032-3.855C1.32 10.182 1 8.566 1 7V3.48a1.75 1.75 0 011.217-1.667l5.25-1.68zm.61 1.429a.25.25 0 00-.153 0l-5.25 1.68a.25.25 0 00-.174.238V7c0 1.358.275 2.666 1.057 3.86.784 1.194 2.121 2.34 4.366 3.297a.2.2 0 00.154 0c2.245-.956 3.582-2.104 4.366-3.298C13.225 9.666 13.5 8.36 13.5 7V3.48a.25.25 0 00-.174-.237l-5.25-1.68zM9 10.5a1 1 0 11-2 0 1 1 0 012 0zm-.25-5.75a.75.75 0 10-1.5 0v3a.75.75 0 001.5 0v-3z"></path></svg>
+            <span data-content="Security">Security</span>
+              <include-fragment src="/OctoLinker/testrepo/security/overall-count" accept="text/fragment+html"></include-fragment>
+</a>      </li>
+      <li class="d-flex">
+        <a class="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item" data-tab-item="insights-tab" data-ga-click="Repository, Navigation click, Insights tab" data-selected-links="repo_graphs repo_contributors dependency_graph dependabot_updates pulse people /OctoLinker/testrepo/pulse" href="/OctoLinker/testrepo/pulse">
+              <svg classes="UnderlineNav-octicon" display="none inline" height="16" class="octicon octicon-graph UnderlineNav-octicon d-none d-sm-inline" viewBox="0 0 16 16" version="1.1" width="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 1.75a.75.75 0 00-1.5 0v12.5c0 .414.336.75.75.75h14.5a.75.75 0 000-1.5H1.5V1.75zm14.28 2.53a.75.75 0 00-1.06-1.06L10 7.94 7.53 5.47a.75.75 0 00-1.06 0L3.22 8.72a.75.75 0 001.06 1.06L7 7.06l2.47 2.47a.75.75 0 001.06 0l5.25-5.25z"></path></svg>
+            <span data-content="Insights">Insights</span>
+              <span title="Not available" class="Counter "></span>
+</a>      </li>
+
+</ul>        <div class="position-absolute right-0 pr-3 pr-md-4 pr-lg-5 js-responsive-underlinenav-overflow" style="visibility:hidden;">
+      <details class="details-overlay details-reset position-relative">
+  <summary role="button">
+    <div class="UnderlineNav-item mr-0 border-0">
+            <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path d="M8 9a1.5 1.5 0 100-3 1.5 1.5 0 000 3zM1.5 9a1.5 1.5 0 100-3 1.5 1.5 0 000 3zm13 0a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path></svg>
+            <span class="sr-only">More</span>
+          </div>
+</summary>  <div>
+    <details-menu role="menu" class="dropdown-menu dropdown-menu-sw ">
   
+            <ul>
+                <li data-menu-item="code-tab" hidden>
+                  <a role="menuitem" class="js-selected-navigation-item dropdown-item" data-selected-links=" /OctoLinker/testrepo" href="/OctoLinker/testrepo">
+                    Code
+</a>                </li>
+                <li data-menu-item="issues-tab" hidden>
+                  <a role="menuitem" class="js-selected-navigation-item dropdown-item" data-selected-links=" /OctoLinker/testrepo/issues" href="/OctoLinker/testrepo/issues">
+                    Issues
+</a>                </li>
+                <li data-menu-item="pull-requests-tab" hidden>
+                  <a role="menuitem" class="js-selected-navigation-item dropdown-item" data-selected-links=" /OctoLinker/testrepo/pulls" href="/OctoLinker/testrepo/pulls">
+                    Pull requests
+</a>                </li>
+                <li data-menu-item="actions-tab" hidden>
+                  <a role="menuitem" class="js-selected-navigation-item dropdown-item" data-selected-links=" /OctoLinker/testrepo/actions" href="/OctoLinker/testrepo/actions">
+                    Actions
+</a>                </li>
+                <li data-menu-item="security-tab" hidden>
+                  <a role="menuitem" class="js-selected-navigation-item dropdown-item" data-selected-links=" /OctoLinker/testrepo/security" href="/OctoLinker/testrepo/security">
+                    Security
+</a>                </li>
+                <li data-menu-item="insights-tab" hidden>
+                  <a role="menuitem" class="js-selected-navigation-item dropdown-item" data-selected-links=" /OctoLinker/testrepo/pulse" href="/OctoLinker/testrepo/pulse">
+                    Insights
+</a>                </li>
+            </ul>
 
-</h1>
-
-    </div>
-    
-<nav class="hx_reponav reponav js-repo-nav js-sidenav-container-pjax container"
-     itemscope
-     itemtype="http://schema.org/BreadcrumbList"
-    aria-label="Repository"
-     data-pjax="#js-repo-pjax-container">
-
-  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-    <a class="js-selected-navigation-item reponav-item" itemprop="url" data-hotkey="g c" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /OctoLinker/testrepo" href="/OctoLinker/testrepo">
-      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"/></svg>
-      <span itemprop="name">Code</span>
-      <meta itemprop="position" content="1">
-</a>  </span>
-
-    <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-      <a itemprop="url" data-hotkey="g i" class="js-selected-navigation-item selected reponav-item" aria-current="page" data-selected-links="repo_issues repo_labels repo_milestones /OctoLinker/testrepo/issues" href="/OctoLinker/testrepo/issues">
-        <svg class="octicon octicon-issue-opened" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"/></svg>
-        <span itemprop="name">Issues</span>
-        <span class="Counter">1</span>
-        <meta itemprop="position" content="2">
-</a>    </span>
-
-  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
-    <a data-hotkey="g p" itemprop="url" class="js-selected-navigation-item reponav-item" data-selected-links="repo_pulls checks /OctoLinker/testrepo/pulls" href="/OctoLinker/testrepo/pulls">
-      <svg class="octicon octicon-git-pull-request" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
-      <span itemprop="name">Pull requests</span>
-      <span class="Counter">3</span>
-      <meta itemprop="position" content="3">
-</a>  </span>
-
-
-
-
-
-    <a data-skip-pjax="true" class="js-selected-navigation-item reponav-item" data-selected-links="security alerts policy code_scanning /OctoLinker/testrepo/security/advisories" href="/OctoLinker/testrepo/security/advisories">
-      <svg class="octicon octicon-shield" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 2l7-2 7 2v6.02C14 12.69 8.69 16 7 16c-1.69 0-7-3.31-7-7.98V2zm1 .75L7 1l6 1.75v5.268C13 12.104 8.449 15 7 15c-1.449 0-6-2.896-6-6.982V2.75zm1 .75L7 2v12c-1.207 0-5-2.482-5-5.985V3.5z"/></svg>
-      Security
-</a>
-    <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse people /OctoLinker/testrepo/pulse" href="/OctoLinker/testrepo/pulse">
-      <svg class="octicon octicon-graph" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"/></svg>
-      Insights
-</a>
+</details-menu>
+</div></details>    </div>
 
 </nav>
-
-
   </div>
-<div class="container-lg clearfix new-discussion-timeline experiment-repo-nav  px-3">
-  <div class="repository-content ">
+
+<div class="container-xl clearfix new-discussion-timeline  px-3 px-md-4 px-lg-5">
+  <div class="repository-content " >
 
     
-    
+      
   <div class="js-check-all-container" data-pjax>
     
-        <div class="signup-prompt-bg rounded-1">
-      <div class="signup-prompt p-4 text-center mb-4 rounded-1">
-        <div class="position-relative">
-          <!-- '"` --><!-- </textarea></xmp> --></option></form><form action="/prompt_dismissals/signup" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="rHNSzBxEKiqXl837dmpUxkfKU/3satghR3A01Nfc5iQ42ETNKQ0m08l/gEkUzbr58evoUw1GjUtmmE9ElBRSHA==" />
-            <button type="submit" class="position-absolute top-0 right-0 btn-link link-gray" data-ga-click="(Logged out) Sign up prompt, clicked Dismiss, text:dismiss">
-              Dismiss
-            </button>
-</form>          <h3 class="pt-2">Join GitHub today</h3>
-          <p class="col-6 mx-auto">GitHub is home to over 40 million developers working together to host and review code, manage projects, and build software together.</p>
-          <a class="btn btn-primary" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;files signup prompt&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;2B74:1E6FB:3F6137C:5FEA689:5DA39DC0&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;referrer&quot;:null,&quot;user_id&quot;:null}}" data-hydro-click-hmac="a354eae5be756882123ef2ddc76d2803f39cc436b49c9c90f1f120316162c7eb" data-ga-click="(Logged out) Sign up prompt, clicked Sign up, text:sign-up" href="/join?source=prompt-issue-show">Sign up</a>
-        </div>
+      <signup-prompt class="signup-prompt-bg rounded-1" data-prompt="signup" hidden>
+    <div class="signup-prompt p-4 text-center mb-4 rounded-1">
+      <div class="position-relative">
+        <button
+          type="button"
+          class="position-absolute top-0 right-0 btn-link link-gray"
+          data-action="click:signup-prompt#dismiss"
+          data-ga-click="(Logged out) Sign up prompt, clicked Dismiss, text:dismiss"
+        >
+          Dismiss
+        </button>
+        <h3 class="pt-2">Join GitHub today</h3>
+        <p class="col-6 mx-auto">GitHub is home to over 50 million developers working together to host and review code, manage projects, and build software together.</p>
+        <a class="btn btn-primary" data-ga-click="(Logged out) Sign up prompt, clicked Sign up, text:sign-up" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;files signup prompt&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="aea31d49ec46b81677e29cb7d7169d91ae094c8c387c51ebc3adf963b03cd955" href="/join?source=prompt-issue-show&amp;source_repo=OctoLinker%2Ftestrepo">Sign up</a>
       </div>
     </div>
+  </signup-prompt>
+
 
 
   <div id="show_issue"
         class="js-issues-results js-socket-channel js-updatable-content"
-        data-channel="issue:185246647:timeline">
+        data-channel="eyJjIjoiaXNzdWU6MTg1MjQ2NjQ3OnRpbWVsaW5lIiwidCI6MTYwMDcyOTAzMn0=--de2cb94edbca82cbce8e3c43e446cb5477033d0cb80ad951471a3218620aac80">
 
     
   <div
     id="partial-discussion-header"
-    class="gh-header js-details-container Details js-socket-channel js-updatable-content issue"
-    data-channel="issue:185246647"
+    class="gh-header mb-3 js-details-container Details js-socket-channel js-updatable-content issue"
+    data-channel="eyJjIjoiaXNzdWU6MTg1MjQ2NjQ3IiwidCI6MTYwMDcyOTAzMn0=--d0d6c5127fae96067b86363e7e9feeba2cdc1cbb3cc32629be2c42656231a487"
     data-url="/OctoLinker/testrepo/issues/2/show_partial?partial=issues%2Ftitle&amp;sticky=true"
     data-gid="MDU6SXNzdWUxODUyNDY2NDc=">
   <div class="gh-header-show ">
-    
-      <div class="gh-header-actions ">
+    <div class="d-flex flex-column flex-md-row">
+      <div class="gh-header-actions mt-0 mt-md-2 mb-3 mb-md-0 ml-0 flex-md-order-1 flex-shrink-0 d-flex flex-items-start">
+
 
           
 <details class="details-reset details-overlay details-overlay-dark float-right" >
   <summary
-    class="btn btn-sm btn-primary"
+    class="btn btn-sm btn-primary m-0 ml-0 ml-md-2"
+    
     
     data-ga-click="Issues, create new issue, view:issue_show location:issue_header style:button logged_in:false"
 >
@@ -578,12 +684,12 @@
     New issue
   </summary>
   <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast overflow-auto" aria-label="Sign up for GitHub">
-    <button class="position-absolute p-4 right-0 btn-link muted-link" type="button" aria-label="Close dialog" data-close-dialog>
-      <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
-    </button>
-    <div class="p-4 d-flex flex-column">
+      <button class="position-absolute p-4 right-0 btn-link muted-link" type="button" aria-label="Close dialog" data-close-dialog>
+        <svg class="octicon octicon-x" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path></svg>
+      </button>
+    <div class="d-flex flex-column p-4">
             <div class="mt-3 mb-2 text-center">
-  <svg height="60" class="octicon octicon-comment-discussion text-blue" viewBox="0 0 16 16" version="1.1" width="60" aria-hidden="true"><path fill-rule="evenodd" d="M15 1H6c-.55 0-1 .45-1 1v2H1c-.55 0-1 .45-1 1v6c0 .55.45 1 1 1h1v3l3-3h4c.55 0 1-.45 1-1V9h1l3 3V9h1c.55 0 1-.45 1-1V2c0-.55-.45-1-1-1zM9 11H4.5L3 12.5V11H1V5h4v3c0 .55.45 1 1 1h3v2zm6-3h-2v1.5L11.5 8H6V2h9v6z"/></svg>
+  <svg height="60" class="octicon octicon-comment-discussion text-blue" viewBox="0 0 24 24" version="1.1" width="60" aria-hidden="true"><path fill-rule="evenodd" d="M1.75 1A1.75 1.75 0 000 2.75v9.5C0 13.216.784 14 1.75 14H3v1.543a1.457 1.457 0 002.487 1.03L8.061 14h6.189A1.75 1.75 0 0016 12.25v-9.5A1.75 1.75 0 0014.25 1H1.75zM1.5 2.75a.25.25 0 01.25-.25h12.5a.25.25 0 01.25.25v9.5a.25.25 0 01-.25.25h-6.5a.75.75 0 00-.53.22L4.5 15.44v-2.19a.75.75 0 00-.75-.75h-2a.25.25 0 01-.25-.25v-9.5z"></path><path d="M22.5 8.75a.25.25 0 00-.25-.25h-3.5a.75.75 0 010-1.5h3.5c.966 0 1.75.784 1.75 1.75v9.5A1.75 1.75 0 0122.25 20H21v1.543a1.457 1.457 0 01-2.487 1.03L15.939 20H10.75A1.75 1.75 0 019 18.25v-1.465a.75.75 0 011.5 0v1.465c0 .138.112.25.25.25h5.5a.75.75 0 01.53.22l2.72 2.72v-2.19a.75.75 0 01.75-.75h2a.25.25 0 00.25-.25v-9.5z"></path></svg>
 </div>
 
 <div class="px-4">
@@ -591,29 +697,32 @@
   <strong>Have a question about this project?</strong> Sign up for a free GitHub account to open an issue and contact its maintainers and the community.
   </p>
 
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-signup-form" autocomplete="off" action="/join?return_to=%2FOctoLinker%2Ftestrepo%2Fissues%2Fnew" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="vKnS8SZ7gRmL1LxhKKnbhx6F/gWa25L1t71CA2VX72DM6Iy6FW2qJgVxW7fsO3G0eJYAMiGBPFx8ugYu+RyItA==" />    <auto-check src="/signup_check/username" csrf="MUwD6cPHQOB2nbanYN0IDIQJQxDXSWYHIGwFpUF3OjrLzhO4Y/XMZeAG5GcGzQr5YTXO5mgtJlbTzytdltBERA==">
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-signup-form" autocomplete="off" action="/join?return_to=%2FOctoLinker%2Ftestrepo%2Fissues%2Fnew" accept-charset="UTF-8" method="post"><input type="hidden" data-csrf="true" name="authenticity_token" value="rwnIfnh79/3TrOaU9+GeTu8Ar5D/QCwjnpmsPoZvN/PLCFKn62PfAd3LmXjFUhvYVvGMEO/c0cPnUO5fBmSzlg==" />    <auto-check src="/signup_check/username">
       <dl class="form-group"><dt class="input-label"><label name="user[login]" autocapitalize="off" autofocus="autofocus" for="user_login_issues">Pick a username</label></dt><dd><input name="user[login]" autocapitalize="off" autofocus="autofocus" class="form-control" type="text" id="user_login_issues" /></dd></dl>
+      <input type="hidden" data-csrf="true" value="ZRVYF99dLkQ7lHNCtMw/F3nZhGHD8YCPHDM+L3eN3RW4lG3KgKO0vbV+tTDhFSCBb5R1PEhCl5N8leVbbYj21g==" />
     </auto-check>
 
-    <auto-check src="/signup_check/email" csrf="EHsVotDnm7WV+i7vbqqzNHV9M7CitiVF/YaKU1AqWWLttmQgw34/6lNLbncYoyfxf+4LUbejA8TCIAeK3QiwBQ==">
+    <auto-check src="/signup_check/email">
       <dl class="form-group"><dt class="input-label"><label name="user[email]" autocapitalize="off" for="user_email_issues">Email Address</label></dt><dd><input name="user[email]" autocapitalize="off" class="form-control" type="text" id="user_email_issues" /></dd></dl>
+      <input type="hidden" data-csrf="true" value="Zg7VZkfmpFrYdtqSWbp1fACuQjw3h9XqmLg+O1WvEICIhkp2e/Wb0Y9ohpx0O4QMqe63fjedYQ7+TZCNhR3JIQ==" />
     </auto-check>
 
-    <dl class="form-group"><dt class="input-label"><label name="user[password]" for="user_password_issues">Password</label></dt><dd><input name="user[password]" class="form-control" type="password" id="user_password_issues" /></dd></dl>
+    <auto-check src="/users/password"><dl class="form-group"><dt class="input-label"><label name="user[password]" for="user_password_issues">Password</label></dt><dd><input name="user[password]" class="form-control" type="password" id="user_password_issues" /></dd></dl><input type="hidden" data-csrf="true" value="qRfqw8dtVwtnKDayL3oNpLQ+4adaxI/+NUdo6LqIXLYZHyE8GK9ELepIdxtXimDYZ7ktyK62PTkEk11LohvjcQ==" /></auto-check>
 
     <input type="hidden" name="source" class="js-signup-source" value="modal-issues">
-    <input type="text" name="required_field_b480" id="required_field_b480" hidden="hidden" class="form-control" />
-<input type="hidden" name="timestamp" value="1571003841077" class="form-control" />
-<input type="hidden" name="timestamp_secret" value="d1dc3bdbd03e8f373319158f9066e1647a1de9c613513aaed12900c4d032610f" class="form-control" />
+    <input class="form-control" type="text" name="required_field_2ba8" hidden="hidden" />
+<input class="form-control" type="hidden" name="timestamp" value="1600729032864" />
+<input class="form-control" type="hidden" name="timestamp_secret" value="d39c4d9fe3d29351c5b6ad032e020e0ef298964c0ad6bd8a6ab9c2a7a822701d" />
 
 
     <button class="btn btn-primary mt-2 btn-block" type="submit" data-ga-click="(Logged out) New issue modal, clicked Sign up, text:sign-up">Sign up for GitHub</button>
 </form>
-  <p class="mt-4 text-gray text-center">By clicking &ldquo;Sign up for GitHub&rdquo;, you agree to our <a href="https://help.github.com/terms" target="_blank">terms of service</a> and
-  <a href="https://help.github.com/privacy" target="_blank">privacy statement</a>. We’ll occasionally send you account related emails.</p>
+  <p class="mt-4 text-gray text-center">By clicking &ldquo;Sign up for GitHub&rdquo;, you agree to our <a href="https://docs.github.com/terms" target="_blank">terms of service</a> and
+  <a href="https://docs.github.com/privacy" target="_blank">privacy statement</a>. We’ll occasionally send you account related emails.</p>
+
   <p class="mt-4 text-gray text-center">
     Already on GitHub?
-    <a data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;new issue modal&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;2B74:1E6FB:3F6137C:5FEA689:5DA39DC0&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;referrer&quot;:null,&quot;user_id&quot;:null}}" data-hydro-click-hmac="2c6bc732930f9c1e91e33ee8a09c138b7f01f9afda7736ae2c9a42be9501e943" data-ga-click="(Logged out) New issue modal, clicked Sign in, text:sign-in" href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fissues%2Fnew">Sign in</a>
+    <a data-ga-click="(Logged out) New issue modal, clicked Sign in, text:sign-in" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;new issue modal&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="aefc03842c975d08ce95814e10bee9ecdd292ee589aad15b6142c14ca75a758c" href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fissues%2Fnew">Sign in</a>
     to your account
   </p>
 </div>
@@ -621,69 +730,62 @@
 </div>
   </details-dialog>
 </details>
+        <div class="flex-auto text-right d-block d-md-none">
+          <a href="#issue-comment-box" class="py-1">Jump to bottom</a>
+        </div>
       </div>
 
-    <h1 class="gh-header-title">
+    <h1 class="gh-header-title mb-2 lh-condensed f1 mr-0 flex-auto break-word">
       <span class="js-issue-title">
         Issue with some code blocks
       </span>
-      <span class="gh-header-number">#2</span>
+      <span class="f1-light text-gray-light">#2</span>
     </h1>
-    
+    </div>
   </div>
 
-  <div class="TableObject gh-header-meta">
-    <div class="TableObject-item">
-        <span class="State State--green  " title="Status: Open">
-  
-  <svg height="16" class="octicon octicon-issue-opened" viewBox="0 0 14 16" version="1.1" width="14" aria-hidden="true"><path fill-rule="evenodd" d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"/></svg> Open
-
+  <div class="d-flex flex-items-center mt-0 gh-header-meta">
+    <div class="flex-shrink-0 flex-self-start flex-md-self-center">
+        <span title="Status: Open" class="State State--green ">
+  <svg height="16" class="octicon octicon-issue-opened" viewBox="0 0 16 16" version="1.1" width="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm9 3a1 1 0 11-2 0 1 1 0 012 0zm-.25-6.25a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z"></path></svg> Open
 </span>
-
     </div>
-    <div class="TableObject-item TableObject-item--primary">
-        <a class="author text-bold link-gray" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>  opened this issue
+    <div class="flex-auto min-width-0">
+        <a class="author text-bold link-gray" data-hovercard-type="user" data-hovercard-url="/users/stefanbuck/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>  opened this issue
 <relative-time datetime="2016-10-25T22:05:33Z" class="no-wrap">Oct 25, 2016</relative-time>
 &middot; 0 comments
 
-  <span class="js-enable-hovercard" data-issue-and-pr-hovercards-enabled>
-    
-  </span>
-  <div class="position-relative">
-  </div>
+<span data-issue-and-pr-hovercards-enabled>
+  
+</span>
 
     </div>
   </div>
 
 
-    <div class="js-sticky js-sticky-offset-scroll top-0 gh-header-sticky" aria-hidden="true">
+    <div class="js-sticky js-sticky-offset-scroll top-0 gh-header-sticky">
       <div class="sticky-content">
         <div class="d-flex flex-items-center flex-justify-between mt-2">
           <div class="d-flex flex-row flex-items-center min-width-0">
             <div class="mr-2 flex-shrink-0">
-                <span class="State State--green  " title="Status: Open">
-  
-  <svg height="16" class="octicon octicon-issue-opened" viewBox="0 0 14 16" version="1.1" width="14" aria-hidden="true"><path fill-rule="evenodd" d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"/></svg> Open
-
+                <span title="Status: Open" class="State State--green ">
+  <svg height="16" class="octicon octicon-issue-opened" viewBox="0 0 16 16" version="1.1" width="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm9 3a1 1 0 11-2 0 1 1 0 012 0zm-.25-6.25a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z"></path></svg> Open
 </span>
-
             </div>
             <div class="min-width-0">
-              <h1 class="text-bold f5 overflow-hidden width-fit no-wrap">
+              <h1 class="d-flex text-bold f5">
   <a class="js-issue-title css-truncate css-truncate-target link-gray-dark width-fit" href="#">Issue with some code blocks</a>
-  <span class="gh-header-number text-gray-light pr-1">#2</span>
+  <span class="gh-header-number text-gray-light pl-1">#2</span>
 </h1>
 
               <div class="meta text-gray-light css-truncate css-truncate-target d-block width-fit">
-                  <a class="author text-bold link-gray" data-hovercard-z-index-override="111" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>  opened this issue
+                  <a class="author text-bold link-gray" data-hovercard-z-index-override="111" data-hovercard-type="user" data-hovercard-url="/users/stefanbuck/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>  opened this issue
 <relative-time datetime="2016-10-25T22:05:33Z" class="no-wrap">Oct 25, 2016</relative-time>
 &middot; 0 comments
 
-  <span class="js-enable-hovercard" data-issue-and-pr-hovercards-enabled>
-    
-  </span>
-  <div class="position-relative">
-  </div>
+<span data-issue-and-pr-hovercards-enabled>
+  
+</span>
 
               </div>
             </div>
@@ -691,44 +793,50 @@
         </div>
       </div>
     </div>
-    <div class="gh-header-shadow box-shadow"></div>
+    <div class="gh-header-shadow box-shadow js-notification-shelf-offset-top"></div>
 </div>
+
+
+      
 
 
     <h2 class="sr-only">Comments</h2>
-    <div id="discussion_bucket" class="d-flex ">
-      <div class="col-9">
-        <div class="js-quote-selection-container"
-          data-quote-markdown=".js-comment-body"
-          data-issue-and-pr-hovercards-enabled
-          data-team-hovercards-enabled>
+    <div id="discussion_bucket">
+      <div class="gutter-condensed gutter-lg flex-column flex-md-row d-flex">
 
-          <div class="js-discussion js-socket-channel ml-6 pl-3" data-channel="marked-as-read:issue:185246647">
-
+  <div class="flex-shrink-0 col-12 col-md-9 mb-4 mb-md-0">
+              <div class="js-quote-selection-container"
+            data-quote-markdown=".js-comment-body"
             
-<div class="TimelineItem pt-0 js-comment-container js-socket-channel"
+            data-issue-and-pr-hovercards-enabled
+            data-team-hovercards-enabled>
+
+            <div
+              class="js-discussion  ml-0 pl-0 ml-md-6 pl-md-3"
+            >
+                
+<div class="TimelineItem pt-0 js-comment-container js-socket-channel js-updatable-content "
   data-gid="MDU6SXNzdWUxODUyNDY2NDc="
   data-url="/_render_node/MDU6SXNzdWUxODUyNDY2NDc=/issues/body"
-  data-channel="issue:185246647">
+  data-channel="eyJjIjoiaXNzdWU6MTg1MjQ2NjQ3IiwidCI6MTYwMDcyOTAzMn0=--d0d6c5127fae96067b86363e7e9feeba2cdc1cbb3cc32629be2c42656231a487">
 
   
-<div class="avatar-parent-child TimelineItem-avatar ">
-    <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar rounded-1" height="40" width="40" alt="@stefanbuck" src="https://avatars0.githubusercontent.com/u/1393946?s=88&amp;v=4" /></a>
+<div class="avatar-parent-child TimelineItem-avatar d-none d-md-block">
+  <a class="d-inline-block" data-hovercard-type="user" data-hovercard-url="/users/stefanbuck/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar rounded-1 avatar-user" height="40" width="40" alt="@stefanbuck" src="https://avatars1.githubusercontent.com/u/1393946?s=88&amp;u=da89191fbb7db63a2d113c097c04bb7d4658e0d9&amp;v=4" /></a>
 
 </div>
 
+  <div class="timeline-comment-group js-minimizable-comment-group js-targetable-element TimelineItem-body my-0 " id="issue-185246647">
+    <div class="ml-n3 timeline-comment unminimized-comment comment previewable-edit js-task-list-container js-comment timeline-comment--caret "
+        data-body-version="2bec5726d544261f4a4fb08ef5a6899f"
+        data-unfurl-hide-url="/content_reference_attachments/hide">
+      <input type="hidden" data-csrf="true" class="js-data-unfurl-hide-url-csrf" value="Ui4bhxZl8LLGW1rml+BOa8QTmY70YBRN2H7pat4rrPAAEUNlWI7aWYlKIwVCX8hoTXQqd8koS4agaOLAMfoQMA==" />
 
-  
-<div class="timeline-comment-group js-minimizable-comment-group js-targetable-comment TimelineItem-body my-0 " id="issue-185246647">
-  <div class="ml-n3 timeline-comment unminimized-comment comment previewable-edit js-task-list-container js-comment timeline-comment--caret "
-       data-body-version="f078b096f9c9663dd472866d23385fbb"
-       data-unfurl-hide-url="/content_reference_attachments/hide"
-       data-unfurl-authenticity-token="NOao19QItIYqgKTaoo+FtCXEvbbtngWojdHFbdKiXCF6rZuNRPdGo6dJ4oqJJL3vZdayE3SWeevx8f9vUbX3TQ==">
+      
+<div class="timeline-comment-header clearfix d-block d-sm-flex">
+  <div class="timeline-comment-actions flex-shrink-0">
+    
 
-    
-<div class="timeline-comment-header clearfix">
-  <div class="timeline-comment-actions js-timeline-comment-actions" >
-    
 
 
 
@@ -748,7 +856,7 @@
 
 <details class="details-overlay details-reset position-relative d-inline-block ">
   <summary class="btn-link timeline-comment-action link-gray">
-    <svg aria-label="Show options" class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" role="img"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/></svg>
+    <svg aria-label="Show options" class="octicon octicon-kebab-horizontal" viewBox="0 0 16 16" version="1.1" width="16" height="16" role="img"><path d="M8 9a1.5 1.5 0 100-3 1.5 1.5 0 000 3zM1.5 9a1.5 1.5 0 100-3 1.5 1.5 0 000 3zm13 0a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path></svg>
   </summary>
   <details-menu class="dropdown-menu dropdown-menu-sw show-more-popover text-gray-dark anim-scale-in" style="width:185px">
         <clipboard-copy
@@ -774,6 +882,12 @@
   </div>
 
 
+  <div class="d-none d-sm-flex">
+
+      
+
+
+
     
     <span class="timeline-comment-label text-bold tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is a member of the OctoLinker organization.">
       Member
@@ -782,18 +896,21 @@
 
   
 
+  </div>
 
   <h3 class="timeline-comment-header-text f5 text-normal">
 
 
+        <a class="d-inline-block d-md-none" data-hovercard-type="user" data-hovercard-url="/users/stefanbuck/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck"><img class="avatar rounded-1 avatar-user" height="20" width="20" alt="@stefanbuck" src="https://avatars2.githubusercontent.com/u/1393946?s=60&amp;u=da89191fbb7db63a2d113c097c04bb7d4658e0d9&amp;v=4" /></a>
 
-    <strong class="css-truncate expandable">
+    <strong class="css-truncate">
       
 
-  <a class="author link-gray-dark css-truncate-target" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
+  <a class="author link-gray-dark css-truncate-target width-fit" show_full_name="false" data-hovercard-type="user" data-hovercard-url="/users/stefanbuck/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">stefanbuck</a>
   
 
     </strong>
+
 
     commented
 
@@ -805,17 +922,21 @@
         
   <span class="d-inline-block text-gray-light">&#8226;</span>
 
-  <details class="details-overlay details-reset d-inline-block dropdown">
+  <details class="details-overlay details-reset d-inline-block dropdown hx_dropdown-fullscreen">
     <summary class="btn-link no-underline text-gray js-notice">
       <div class="position-relative">
         <span>
             edited
         </span>
-        <svg height="11" class="octicon octicon-triangle-down v-align-middle" viewBox="0 0 12 16" version="1.1" width="8" aria-hidden="true"><path fill-rule="evenodd" d="M0 5l6 6 6-6H0z"/></svg>
+        <svg class="octicon octicon-triangle-down v-align-middle" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"></path></svg>
       </div>
     </summary>
-    <details-menu class="anim-scale-in dropdown-menu dropdown-menu-se py-0" style="width:352px" src="/_render_node/MDU6SXNzdWUxODUyNDY2NDc=/comments/comment_edit_history_log" preload>
-      <include-fragment class="octocat-spinner my-3" aria-label="Loading"></include-fragment>
+    <details-menu
+      class="dropdown-menu dropdown-menu-s width-auto py-0 js-comment-edit-history-menu"
+      style="max-width: 352px; z-index: 99;"
+      src="/_render_node/MDU6SXNzdWUxODUyNDY2NDc=/comments/comment_edit_history_log"
+      preload>
+      <include-fragment class="octocat-spinner my-3" style="min-width: 100px;" aria-label="Loading"></include-fragment>
     </details-menu>
   </details>
 
@@ -824,26 +945,26 @@
 </div>
 
 
-    <div class="edit-comment-hide js-edit-comment-hide" >
+      <div class="edit-comment-hide">
 
-      
+        
 <task-lists disabled sortable>
-<table class="d-block">
+<table class="d-block" data-paste-markdown-skip>
   <tbody class="d-block">
     <tr class="d-block">
       <td class="d-block comment-body markdown-body  js-comment-body">
           <p>python</p>
-<div class="highlight highlight-source-python"><pre><span class="pl-k">import</span> os</pre></div>
+<div class="highlight highlight-source-python"><pre><span class="pl-k">import</span> <span class="pl-s1">os</span></pre></div>
 <p>rust</p>
 <div class="highlight highlight-source-rust"><pre><span class="pl-k">extern</span> <span class="pl-k">crate</span> failure_derive;</pre></div>
 <p>ts</p>
-<div class="highlight highlight-source-ts"><pre><span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">'</span>fs<span class="pl-pds">'</span></span>)</pre></div>
+<div class="highlight highlight-source-ts"><pre><span class="pl-en">require</span><span class="pl-kos">(</span><span class="pl-s">'fs'</span><span class="pl-kos">)</span></pre></div>
 <p>js</p>
-<div class="highlight highlight-source-js"><pre><span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">'</span>fs<span class="pl-pds">'</span></span>)</pre></div>
+<div class="highlight highlight-source-js"><pre><span class="pl-en">require</span><span class="pl-kos">(</span><span class="pl-s">'fs'</span><span class="pl-kos">)</span></pre></div>
 <p>javascript</p>
-<div class="highlight highlight-source-js"><pre><span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">'</span>fs<span class="pl-pds">'</span></span>)</pre></div>
+<div class="highlight highlight-source-js"><pre><span class="pl-en">require</span><span class="pl-kos">(</span><span class="pl-s">'fs'</span><span class="pl-kos">)</span></pre></div>
 <p>uby</p>
-<div class="highlight highlight-source-ruby"><pre><span class="pl-k">require</span>(<span class="pl-s"><span class="pl-pds">'</span>log<span class="pl-pds">'</span></span>)</pre></div>
+<div class="highlight highlight-source-ruby"><pre><span class="pl-en">require</span><span class="pl-kos">(</span><span class="pl-s">'log'</span><span class="pl-kos">)</span></pre></div>
 <p>coffee</p>
 <div class="highlight highlight-source-coffee"><pre><span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">'</span>fs<span class="pl-pds">'</span></span>)</pre></div>
 <p>package.json</p>
@@ -864,12 +985,13 @@
 <div class="highlight highlight-source-viml"><pre>Bundle <span class="pl-s"><span class="pl-pds">"</span>YankRing.vim<span class="pl-pds">"</span></span>
 Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/vim-quickrun.git<span class="pl-pds">"</span></span>
 Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/vim-poslist.git<span class="pl-pds">"</span></span></pre></div>
-<div class="highlight highlight-source-go"><pre><span class="pl-k">import</span> <span class="pl-s"><span class="pl-pds">"</span>os<span class="pl-pds">"</span></span></pre></div>
-<div class="highlight highlight-source-css"><pre><span class="pl-k">@import</span> <span class="pl-s"><span class="pl-pds">"</span>os<span class="pl-pds">"</span></span></pre></div>
+<div class="highlight highlight-source-go"><pre><span class="pl-k">import</span> <span class="pl-s">"os"</span></pre></div>
+<div class="highlight highlight-source-css"><pre><span class="pl-k">@import</span> <span class="pl-s">"os"</span></pre></div>
 <div class="highlight highlight-source-css-less"><pre><span class="pl-k">@import</span> <span class="pl-s"><span class="pl-pds">"</span>os<span class="pl-pds">"</span></span></pre></div>
 <div class="highlight highlight-source-sass"><pre><span class="pl-k">@import</span><span class="pl-v"> </span><span class="pl-s"><span class="pl-pds">"</span>os<span class="pl-pds">"</span></span></pre></div>
-<div class="highlight highlight-text-html-basic"><pre>&lt;<span class="pl-ent">link</span> <span class="pl-e">rel</span>=<span class="pl-s"><span class="pl-pds">"</span>import<span class="pl-pds">"</span></span> <span class="pl-e">href</span>=<span class="pl-s"><span class="pl-pds">"</span>foo.html<span class="pl-pds">"</span></span>&gt;</pre></div>
+<div class="highlight highlight-text-html-basic"><pre><span class="pl-kos">&lt;</span><span class="pl-ent">link</span> <span class="pl-c1">rel</span>="<span class="pl-s">import</span>" <span class="pl-c1">href</span>="<span class="pl-s">foo.html</span>"<span class="pl-kos">&gt;</span></pre></div>
 <div class="highlight highlight-source-java"><pre><span class="pl-k">import</span> <span class="pl-smi">java.util.Date</span>;</pre></div>
+<div class="highlight highlight-text-html-php"><pre><span class="pl-k">use</span> <span class="pl-v">ArrayAccess</span>;</pre></div>
       </td>
     </tr>
   </tbody>
@@ -877,23 +999,25 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
 </task-lists>
 
 
-        
+          
+<div class="comment-reactions flex-items-center border-top  js-reactions-container">
 
-<div class="comment-reactions  js-reactions-container "
 
-    >
 </div>
+
+      </div>
 
     </div>
-
-  </div>
 </div>
 
 </div>
 
+              
 
-            
+                  
+<div class="js-issue-timeline-container">
 
+  
   <div id="js-timeline-progressive-loader" data-timeline-item-src="OctoLinker/testrepo/timeline?id=MDU6SXNzdWUxODUyNDY2NDc%3D&amp;variables%5Bfirst%5D=60" ></div>
 
 
@@ -902,48 +1026,50 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
 
 
 
-<!-- Rendered timeline since 2019-05-04 16:10:11 -->
-<div class="js-timeline-marker js-socket-channel js-updatable-content"
-      id="partial-timeline"
-      data-channel="issue:185246647"
-      data-url="/_render_node/MDU6SXNzdWUxODUyNDY2NDc=/issues/unread_timeline?variables%5BhasFocusedReviewComment%5D=false&amp;variables%5BhasFocusedReviewThread%5D=false&amp;variables%5BsyntaxHighlightingEnabled%5D=true&amp;variables%5BtimelinePageSize%5D=30&amp;variables%5BtimelineSince%5D=2019-05-04T23%3A10%3A11Z"
-      data-last-modified="Sat, 04 May 2019 23:10:11 GMT"
-      data-gid="MDU6SXNzdWUxODUyNDY2NDc=">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="d-none js-timeline-marker-form" action="/_graphql/MarkNotificationSubjectAsRead" accept-charset="UTF-8" data-remote="true" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="ZiXffrMLcvunHvXqQH6UQugyU1qjInS2osPefrSXuOgP7eBgYS5abpLz0aDWXQwMHIoB6KX1Q1e6t0Kpk4Q5Jw==" />
-    <input type="hidden" name="variables[subjectId]" value="MDU6SXNzdWUxODUyNDY2NDc=">
-</form></div>
+  <!-- Rendered timeline since 2020-09-21 15:56:38 -->
+  <div class="js-timeline-marker js-socket-channel js-updatable-content"
+        id="partial-timeline"
+        data-channel="eyJjIjoiaXNzdWU6MTg1MjQ2NjQ3IiwidCI6MTYwMDcyOTAzMn0=--d0d6c5127fae96067b86363e7e9feeba2cdc1cbb3cc32629be2c42656231a487"
+        data-url="/_render_node/MDU6SXNzdWUxODUyNDY2NDc=/issues/unread_timeline?variables%5BhasFocusedReviewComment%5D=false&amp;variables%5BhasFocusedReviewThread%5D=false&amp;variables%5BsyntaxHighlightingEnabled%5D=true&amp;variables%5BtimelinePageSize%5D=30&amp;variables%5BtimelineSince%5D=2020-09-21T22%3A56%3A38Z"
+        data-last-modified="Mon, 21 Sep 2020 22:56:38 GMT"
+        data-gid="MDU6SXNzdWUxODUyNDY2NDc=">
+    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="d-none js-timeline-marker-form" action="/_graphql/MarkNotificationSubjectAsRead" accept-charset="UTF-8" data-remote="true" method="post"><input type="hidden" data-csrf="true" name="authenticity_token" value="BIIdRl7+GTqiGBrI27Jhxa25CPKG3SOGN4PjXjy1Wwu2jw7yREfjhBM1hZsGPM5UAV53l+VtZ7o2t53lvIjtAw==" />
+      <input type="hidden" name="variables[subjectId]" value="MDU6SXNzdWUxODUyNDY2NDc=">
+</form>  </div>
 
-
-          </div>
-
-
-          <span id="issue-comment-box"></span>
-          <div class="discussion-timeline-actions">
-                  
-<div class="flash flash-warn mt-3">
-    <a rel="nofollow" class="btn btn-primary" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;signed out comment&quot;,&quot;repository_id&quot;:45358638,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;2B74:1E6FB:3F6137C:5FEA689:5DA39DC0&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;referrer&quot;:null,&quot;user_id&quot;:null}}" data-hydro-click-hmac="5e6f3cf9fd7019baa7b5b7ac5d5fb4e3e17130ecaf5138002918bd5b39047058" href="/join?source=comment-repo">Sign up for free</a>
-    <strong>to join this conversation on GitHub</strong>.
-    Already have an account?
-    <a rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;signed out comment&quot;,&quot;repository_id&quot;:45358638,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;client_id&quot;:null,&quot;originating_request_id&quot;:&quot;2B74:1E6FB:3F6137C:5FEA689:5DA39DC0&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;referrer&quot;:null,&quot;user_id&quot;:null}}" data-hydro-click-hmac="14e168635574e63936f1f36f6a4f501e1157bb3de9c81112ec1aeda4cc56c976" href="/login?return_to=https%3A%2F%2Fgithub.com%2FOctoLinker%2Ftestrepo%2Fissues%2F2">Sign in to comment</a>
 </div>
 
 
-          </div>
-        </div>
-      </div>
+            </div>
 
-      <div class="col-3 pl-4">
-        
+
+            <span id="issue-comment-box"></span>
+            <div class="discussion-timeline-actions">
+                      
+<div class="flash flash-warn mt-3">
+    <a rel="nofollow" class="btn btn-primary" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;signed out comment&quot;,&quot;repository_id&quot;:45358638,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="00131873df27036dce1353e608758b28c22c4a89f7a563b6423583446e11d20d" href="/join?source=comment-repo">Sign up for free</a>
+    <strong>to join this conversation on GitHub</strong>.
+    Already have an account?
+    <a rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;signed out comment&quot;,&quot;repository_id&quot;:45358638,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/OctoLinker/testrepo/issues/2&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="74a7854d92481b12310d5144d3030cfb67b1298714a784a7cd41bc5c35c896dc" href="/login?return_to=https%3A%2F%2Fgithub.com%2FOctoLinker%2Ftestrepo%2Fissues%2F2">Sign in to comment</a>
+</div>
+
+
+            </div>
+          </div>
+
+</div>
+    <div class="flex-shrink-0 col-12 col-md-3">
+                  
 <div id="partial-discussion-sidebar"
   class="js-socket-channel js-updatable-content"
-  data-channel="issue:185246647"
+  data-channel="eyJjIjoiaXNzdWU6MTg1MjQ2NjQ3IiwidCI6MTYwMDcyOTAzMn0=--d0d6c5127fae96067b86363e7e9feeba2cdc1cbb3cc32629be2c42656231a487"
   data-gid="MDU6SXNzdWUxODUyNDY2NDc="
   data-url="/OctoLinker/testrepo/issues/2/show_partial?partial=issues%2Fsidebar"
   data-project-hovercards-enabled>
 
 
   <div class="discussion-sidebar-item sidebar-assignee js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" aria-label="Select assignees" action="/OctoLinker/testrepo/issues/2/assignees" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="Dep/gN6LecXDkKOMr0adJM0vmClIENaX2qlODRSS+/MzaJqa1TspekaOGLwfogWqa1wvIl8p2xwh5mqgxj3ILQ==" />
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" aria-label="Select assignees" action="/OctoLinker/testrepo/issues/2/assignees" accept-charset="UTF-8" method="post"><input type="hidden" name="_method" value="put" /><input type="hidden" data-csrf="true" name="authenticity_token" value="QzN6JWsiaUlyzKQ2LW2eu+cvx7p8HckJvdxsQGAQXCNp8WUb2QMeAE+2gq9qsWNCBJx0lObdK9y7Y6aTn9Pucg==" />
     
   <div class="discussion-sidebar-heading text-bold">
     Assignees
@@ -971,7 +1097,7 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
 </div>
 
     <div class="discussion-sidebar-item sidebar-progress-bar js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" aria-label="Select milestones" action="/OctoLinker/testrepo/issues/2/set_milestone?partial=issues%2Fsidebar%2Fshow%2Fmilestone" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="authenticity_token" value="mJYmci9ue0rfQI7aHNvHcDGPJKpVahiHxw/lQvkuie+hYZgj9w4J4cFEFtc8cSjpCSafHG+hzNiELY8NLQe1Qw==" />
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" aria-label="Select milestones" action="/OctoLinker/testrepo/issues/2/set_milestone?partial=issues%2Fsidebar%2Fshow%2Fmilestone" accept-charset="UTF-8" method="post"><input type="hidden" name="_method" value="put" /><input type="hidden" data-csrf="true" name="authenticity_token" value="T/gbz1fcepZXJ5Nfi9myDFz3ilYQEn5NMTmlJxX3Hs/TkxTwHxQdj1e5CaaH5mk26Lru5ZuqDxTW+M8crhRHWA==" />
     
   <div class="discussion-sidebar-heading text-bold">
     Milestone
@@ -981,6 +1107,23 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
 
 </form></div>
 
+    
+<div class="discussion-sidebar-item js-discussion-sidebar-item" data-issue-and-pr-hovercards-enabled >
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-issue-sidebar-form" aria-label="Link issues" action="/OctoLinker/testrepo/issues/closing_references?source_id=185246647&amp;source_type=ISSUE" accept-charset="UTF-8" method="post"><input type="hidden" name="_method" value="put" /><input type="hidden" data-csrf="true" name="authenticity_token" value="/fKPv5yCaEKbde2gnoS/s/4OmRrVnzXADOvFPzrf77Ewv2rRXh61zxljQhs3TqzUMo1q/vuQzPO+jXiwP/9jww==" />
+    
+  <div class="discussion-sidebar-heading text-bold">
+    Linked pull requests
+  </div>
+
+
+      
+<p>Successfully merging a pull request may close this issue.</p>
+
+  None yet
+
+</form>
+</div>
+
   
   <div id="partial-users-participants" class="discussion-sidebar-item">
   <div class="participation">
@@ -989,14 +1132,15 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
       1 participant
     </div>
     <div class="participation-avatars d-flex flex-wrap">
-        <a class="participant-avatar" data-hovercard-type="user" data-hovercard-url="/hovercards?user_id=1393946" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">
-          <img class="avatar" src="https://avatars3.githubusercontent.com/u/1393946?s=52&amp;v=4" width="26" height="26" alt="@stefanbuck" /> 
+        <a class="participant-avatar" data-hovercard-type="user" data-hovercard-url="/users/stefanbuck/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/stefanbuck">
+          <img class="avatar avatar-user" src="https://avatars3.githubusercontent.com/u/1393946?s=52&amp;v=4" width="26" height="26" alt="@stefanbuck" /> 
 </a>    </div>
   </div>
 </div>
 
 
   
+  
 
 
 
@@ -1004,9 +1148,8 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
 
 </div>
 
-      </div>
 
-    </div>
+</div></div>    </div>
   </div>
 
   </div>
@@ -1017,35 +1160,33 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
 
     </main>
   </div>
-  
 
   </div>
 
         
-<div class="footer container-lg width-full px-3" role="contentinfo">
-  <div class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light ">
-    <ul class="list-style-none d-flex flex-wrap ">
-      <li class="mr-3">&copy; 2019 <span title="0.55417s from unicorn-cc56c77f8-sgsv8">GitHub</span>, Inc.</li>
-        <li class="mr-3"><a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms">Terms</a></li>
-        <li class="mr-3"><a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy">Privacy</a></li>
-        <li class="mr-3"><a data-ga-click="Footer, go to security, text:security" href="https://github.com/security">Security</a></li>
-        <li class="mr-3"><a href="https://githubstatus.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
-        <li><a data-ga-click="Footer, go to help, text:help" href="https://help.github.com">Help</a></li>
-    </ul>
+<div class="footer container-xl width-full p-responsive" role="contentinfo">
+    <div class="position-relative d-flex flex-row-reverse flex-lg-row flex-wrap flex-lg-nowrap flex-justify-center flex-lg-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light ">
+      <ul class="list-style-none d-flex flex-wrap col-12 col-lg-5 flex-justify-center flex-lg-justify-between mb-2 mb-lg-0">
+        <li class="mr-3 mr-lg-0">&copy; 2020 GitHub, Inc.</li>
+          <li class="mr-3 mr-lg-0"><a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms">Terms</a></li>
+          <li class="mr-3 mr-lg-0"><a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy">Privacy</a></li>
+          <li class="mr-3 mr-lg-0"><a data-ga-click="Footer, go to security, text:security" href="https://github.com/security">Security</a></li>
+          <li class="mr-3 mr-lg-0"><a href="https://githubstatus.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
+          <li><a data-ga-click="Footer, go to help, text:help" href="https://docs.github.com">Help</a></li>
+      </ul>
 
-    <a aria-label="Homepage" title="GitHub" class="footer-octicon d-none d-lg-block mx-lg-4" href="https://github.com">
-      <svg height="24" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+      <a aria-label="Homepage" title="GitHub" class="footer-octicon d-none d-lg-block mx-lg-4" href="https://github.com">
+        <svg height="24" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
 </a>
-   <ul class="list-style-none d-flex flex-wrap ">
-        <li class="mr-3"><a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact">Contact GitHub</a></li>
-        <li class="mr-3"><a href="https://github.com/pricing" data-ga-click="Footer, go to Pricing, text:Pricing">Pricing</a></li>
-      <li class="mr-3"><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
-      <li class="mr-3"><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
-        <li class="mr-3"><a href="https://github.blog" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
-        <li><a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a></li>
-
-    </ul>
-  </div>
+      <ul class="list-style-none d-flex flex-wrap col-12 col-lg-5 flex-justify-center flex-lg-justify-between mb-2 mb-lg-0">
+          <li class="mr-3 mr-lg-0"><a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact">Contact GitHub</a></li>
+          <li class="mr-3 mr-lg-0"><a href="https://github.com/pricing" data-ga-click="Footer, go to Pricing, text:Pricing">Pricing</a></li>
+        <li class="mr-3 mr-lg-0"><a href="https://docs.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
+        <li class="mr-3 mr-lg-0"><a href="https://services.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
+          <li class="mr-3 mr-lg-0"><a href="https://github.blog" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
+          <li><a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a></li>
+      </ul>
+    </div>
   <div class="d-flex flex-justify-center pb-6">
     <span class="f6 text-gray-light"></span>
   </div>
@@ -1054,24 +1195,36 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
 
 
   <div id="ajax-error-message" class="ajax-error-message flash flash-error">
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>
+    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.22 1.754a.25.25 0 00-.44 0L1.698 13.132a.25.25 0 00.22.368h12.164a.25.25 0 00.22-.368L8.22 1.754zm-1.763-.707c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0114.082 15H1.918a1.75 1.75 0 01-1.543-2.575L6.457 1.047zM9 11a1 1 0 11-2 0 1 1 0 012 0zm-.25-5.25a.75.75 0 00-1.5 0v2.5a.75.75 0 001.5 0v-2.5z"></path></svg>
     <button type="button" class="flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
-      <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+      <svg class="octicon octicon-x" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path></svg>
     </button>
     You can’t perform that action at this time.
   </div>
 
 
-    <script crossorigin="anonymous" integrity="sha512-zbZNE9wKXLggY8jyfyICW/LCoZ+bh9mrIQCFe/LVifTR9TUcPPFZ6juoIjzX9UKso37P36MuMZDn3wF2FXOk/w==" type="application/javascript" src="https://github.githubassets.com/assets/compat-bootstrap-1c3aa8d0.js"></script>
-    <script crossorigin="anonymous" integrity="sha512-SAo7MLr+UElCOXkQaY3PhufmhCqrii4AH9Gmf7X+QzfQn6hVOL7cyqwly7Aw8mj8bwxPML8IDCLtkcpj6a6qHg==" type="application/javascript" src="https://github.githubassets.com/assets/frameworks-8a8b92df.js"></script>
+    <script crossorigin="anonymous" async="async" integrity="sha512-bn/3rKJzBl2H64K38R8KaVcT26vKK7BJQC59lwYc+9fjlHzmy0fwh+hzBtsgTdhIi13dxjzNKWhdSN8WTM9qUw==" type="application/javascript" id="js-conditional-compat" data-src="https://github.githubassets.com/assets/compat-bootstrap-6e7ff7ac.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-CxjaMepCmi+z0LTeztU2S8qGD25LyHD6j9t0RSPevy63trFWJVwUM6ipAVLgtpMBBgZ53wq8JPkSeQ6ruaZL2w==" type="application/javascript" src="https://github.githubassets.com/assets/environment-bootstrap-0b18da31.js"></script>
+    <script crossorigin="anonymous" async="async" integrity="sha512-uQnzvTsPtyUfA0k3VCLKlUs6/9mo4UFwcKJoBnxvk3uIHvl0dOShfB1KUq7OY/s1JuUiESbDVyBOAMS4kJrMQw==" type="application/javascript" src="https://github.githubassets.com/assets/vendor-b909f3bd.js"></script>
+    <script crossorigin="anonymous" async="async" integrity="sha512-+nAvJ9DxyGwE/dpMTKk5rl4PPVvtKGXSnrlEPaaHjvLhu33a/cCxpCUZYYq/VfYqdnw+j0Trq3pHnmN5ZaSSCw==" type="application/javascript" src="https://github.githubassets.com/assets/frameworks-fa702f27.js"></script>
     
-    <script crossorigin="anonymous" async="async" integrity="sha512-RMuXQehVxMNBXH39WmpJMQY3WdufxMeZL+gi4uBfcPjFllu0VP1XEeS33sXYJKjimmxJL4t6tBoQsgFScVH4sg==" type="application/javascript" src="https://github.githubassets.com/assets/github-bootstrap-0f92b560.js"></script>
+    <script crossorigin="anonymous" async="async" integrity="sha512-DJwiNJKA15gwM0EVizGKwg2SDSpiNhXFCf4W+jCx0yb6QRgkUg0sj3QmwXZClXTGvavFOanElqD48EnGlV6fNQ==" type="application/javascript" src="https://github.githubassets.com/assets/behaviors-bootstrap-0c9c2234.js"></script>
     
+      <script crossorigin="anonymous" async="async" integrity="sha512-WmLHdpvEzC/gyDbs4RKm2+pVCCIDmiJ4vPW5zdX6lQN1CxH/gYnRSi0gyMHMJv5Xv7zUbD6vOgwlAO6yNI87Vg==" type="application/javascript" data-module-id="./contributions-spider-graph.js" data-src="https://github.githubassets.com/assets/contributions-spider-graph-5a62c776.js"></script>
+      <script crossorigin="anonymous" async="async" integrity="sha512-2tVomjR7M73FMhb8dUvdjjzAErhNyLB9tL++hwpJeElQv494sCpS8OnWZL981ktAg30aqIypXD6TJjdvxcPEWQ==" type="application/javascript" data-module-id="./drag-drop.js" data-src="https://github.githubassets.com/assets/drag-drop-dad5689a.js"></script>
+      <script crossorigin="anonymous" async="async" integrity="sha512-twqtmVRViG8NAUXQj7wa88sBe1+eUuJPMdJNNq1/jqKN5Hsjls1T2I32zQqrnhWjxq4LPjwG667QSeboBxXmtA==" type="application/javascript" data-module-id="./jump-to.js" data-src="https://github.githubassets.com/assets/jump-to-b70aad99.js"></script>
+      <script crossorigin="anonymous" async="async" integrity="sha512-O5MUDplY2zVCSB3Jq0MiMf/lhuo8NBywywSaMZnViWL4ynNrhfhtn1LtGMfqYvyPP3BlHsq3Qli2a1ei19IqsQ==" type="application/javascript" data-module-id="./manage-membership.js" data-src="https://github.githubassets.com/assets/manage-membership-bootstrap-3b93140e.js"></script>
+      <script crossorigin="anonymous" async="async" integrity="sha512-fc2sD+f9kolLYQWmhbjtebxjRxzdt4M+3E78XsdN60ioi/KL0trpAbRG0MdJkCQL0HtcVagxfWG4zA7lgup7IQ==" type="application/javascript" data-module-id="./profile-pins-element.js" data-src="https://github.githubassets.com/assets/profile-pins-element-7dcdac0f.js"></script>
+      <script crossorigin="anonymous" async="async" integrity="sha512-JXSmOrOQXof4xz7y+engxtqrugUopipC5LwEmsfxit4PlVe48UECBUCLuujjIADm1kjb2f/9/azX+qNspSy90w==" type="application/javascript" data-module-id="./randomColor.js" data-src="https://github.githubassets.com/assets/randomColor-2574a63a.js"></script>
+      <script crossorigin="anonymous" async="async" integrity="sha512-FOUgzyCYz3T1et4Stcl3MeKUX3mZkQcsMsTQDgBj6/CtW3HrwyGMaCeXGyhSjTGibphNptgZKgDNkvL+O+2uYw==" type="application/javascript" data-module-id="./sortable-behavior.js" data-src="https://github.githubassets.com/assets/sortable-behavior-14e520cf.js"></script>
+      <script crossorigin="anonymous" async="async" integrity="sha512-Sqqua2FOZToK8Mzg1e4jBubR6ZCFO0gL2JHjgpqafLawUXr69ffELu+IhApoX5uhWlxXxJ0ooE89ANBMtWiUNA==" type="application/javascript" data-module-id="./tweetsodium.js" data-src="https://github.githubassets.com/assets/tweetsodium-4aaaae6b.js"></script>
+      <script crossorigin="anonymous" async="async" integrity="sha512-PCRbqld90pgNROmOGIM1253h+3jU1dORyKR4bCSpyuAliZzKQaEv5t2R3IU+71iZzLGwGVYQVXBE2wdxxJwPDQ==" type="application/javascript" data-module-id="./user-status-submit.js" data-src="https://github.githubassets.com/assets/user-status-submit-3c245baa.js"></script>
     
-    
+    <script crossorigin="anonymous" async="async" integrity="sha512-2CJJx8GnN6pnegknbkH2Cw6dXGKL/Otra1+ayYGp/bHhjYodQm11HGuPMKFQLJ8ZKqkcyg19D4EKRhPrRQHM+A==" type="application/javascript" src="https://github.githubassets.com/assets/issues-bootstrap-d82249c7.js"></script>
+<script crossorigin="anonymous" async="async" integrity="sha512-lFdPR0EKlm3sH19P8Jl5O+i08SkXsrHVBlp7WcGA1eMty+keXfeeQq9MS22M+8E9Mo+LOyjkY8wbkpe9FaoTTQ==" type="application/javascript" src="https://github.githubassets.com/assets/github-bootstrap-94574f47.js"></script>
   <div class="js-stale-session-flash flash flash-warn flash-banner" hidden
     >
-    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>
+    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.22 1.754a.25.25 0 00-.44 0L1.698 13.132a.25.25 0 00.22.368h12.164a.25.25 0 00.22-.368L8.22 1.754zm-1.763-.707c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0114.082 15H1.918a1.75 1.75 0 01-1.543-2.575L6.457 1.047zM9 11a1 1 0 11-2 0 1 1 0 012 0zm-.25-5.25a.75.75 0 00-1.5 0v2.5a.75.75 0 001.5 0v-2.5z"></path></svg>
     <span class="js-stale-session-flash-signed-in" hidden>You signed in with another tab or window. <a href="">Reload</a> to refresh your session.</span>
     <span class="js-stale-session-flash-signed-out" hidden>You signed out in another tab or window. <a href="">Reload</a> to refresh your session.</span>
   </div>
@@ -1080,7 +1233,7 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
     <summary role="button" aria-label="Close dialog"></summary>
     <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast hx_rsm-dialog hx_rsm-modal">
       <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
-        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+        <svg class="octicon octicon-x" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"></path></svg>
       </button>
       <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
     </details-dialog>
@@ -1092,7 +1245,6 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
   </div>
 </div>
 
-  <div aria-live="polite" class="js-global-screen-reader-notice sr-only"></div>
 
   </body>
 </html>

--- a/packages/core/load-plugins.js
+++ b/packages/core/load-plugins.js
@@ -26,3 +26,4 @@ export { default as TypeScript } from '@octolinker/plugin-typescript';
 export { default as Vim } from '@octolinker/plugin-vim';
 export { default as GitHubActions } from '@octolinker/plugin-github-actions';
 export { default as GitHubCodeowners } from '@octolinker/plugin-github-codeowners';
+export { default as PHP } from '@octolinker/plugin-php';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,7 @@
     "@octolinker/plugin-less": "1.0.0",
     "@octolinker/plugin-nodejs-relative-path": "1.0.0",
     "@octolinker/plugin-npm-manifest": "1.0.0",
+    "@octolinker/plugin-php": "1.0.0",
     "@octolinker/plugin-python": "1.0.0",
     "@octolinker/plugin-requirements-txt": "1.0.0",
     "@octolinker/plugin-ruby": "1.0.0",

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -114,6 +114,14 @@ export const PHP = regex`
   ${diffSigns}
   use
   \s
+  (?!function\s)
+  (?<$1>[^;\s]+)
+`;
+
+export const PHP_FUNC = regex`
+  ${diffSigns}
+  use
+  \sfunction\s
   (?<$1>[^;\s]+)
 `;
 

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -110,6 +110,13 @@ export const RUST_CRATE = regex`
   (?<$1>[^:;\s]+)
 `;
 
+export const PHP = regex`
+  ${diffSigns}
+  use
+  \s
+  (?<$1>[^;\s]+)
+`;
+
 export const PYTHON_IMPORT = regex`
   ${diffSigns}
   (import|from)

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -519,7 +519,18 @@ const fixtures = {
         ['Illuminate\\Contracts\\Container\\BindingResolutionException'],
       ],
     ],
-    invalid: [''],
+    invalid: ['use function is_array'],
+  },
+  PHP_FUNC: {
+    valid: [
+      ['use function is_array', ['is_array']],
+      ['use function preg_last_error', ['preg_last_error']],
+    ],
+    invalid: [
+      'use Closure',
+      'use Illuminate\\Contracts\\Container\\BindingResolutionException',
+      ['Illuminate\\Contracts\\Container\\BindingResolutionException'],
+    ],
   },
   NET_PROJ_SDK: {
     valid: [['<Project Sdk="foo">', ['foo']]],

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -510,6 +510,17 @@ const fixtures = {
     ],
     invalid: [],
   },
+  PHP: {
+    valid: [
+      ['use Closure', ['Closure']],
+      ['use ArrayAccess', ['ArrayAccess']],
+      [
+        'use Illuminate\\Contracts\\Container\\BindingResolutionException',
+        ['Illuminate\\Contracts\\Container\\BindingResolutionException'],
+      ],
+    ],
+    invalid: [''],
+  },
   NET_PROJ_SDK: {
     valid: [['<Project Sdk="foo">', ['foo']]],
     invalid: [

--- a/packages/plugin-php/__tests__/index.js
+++ b/packages/plugin-php/__tests__/index.js
@@ -1,0 +1,12 @@
+import php from '../index';
+
+describe('rust-crate', () => {
+  const path = '/blob/path/dummy';
+
+  it('resolves php using the live-resolver', () => {
+    expect(php.resolve(path, ['ArrayAccess'])).toEqual({
+      registry: 'ping',
+      target: 'https://www.php.net/manual/en/class.arrayaccess.php',
+    });
+  });
+});

--- a/packages/plugin-php/__tests__/index.js
+++ b/packages/plugin-php/__tests__/index.js
@@ -1,12 +1,28 @@
+import { PHP_FUNC } from '@octolinker/helper-grammar-regex-collection';
 import php from '../index';
 
 describe('rust-crate', () => {
   const path = '/blob/path/dummy';
 
-  it('resolves php using the live-resolver', () => {
-    expect(php.resolve(path, ['ArrayAccess'])).toEqual({
+  it('resolves classes', () => {
+    expect(php.resolve(path, ['FooBar'])).toEqual({
       registry: 'ping',
-      target: 'https://www.php.net/manual/en/class.arrayaccess.php',
+      target: 'https://www.php.net/manual/en/class.foobar.php',
     });
+  });
+
+  it('resolves functions', () => {
+    expect(php.resolve(path, ['Foo_Bar'], {}, PHP_FUNC)).toEqual({
+      registry: 'ping',
+      target: 'https://www.php.net/manual/en/function.foo-bar.php',
+    });
+  });
+
+  it('does not try to resolve packages', () => {
+    expect(
+      php.resolve(path, [
+        'Illuminate\\Contracts\\Container\\BindingResolutionException',
+      ]),
+    ).toEqual(undefined);
   });
 });

--- a/packages/plugin-php/__tests__/index.js
+++ b/packages/plugin-php/__tests__/index.js
@@ -1,7 +1,7 @@
 import { PHP_FUNC } from '@octolinker/helper-grammar-regex-collection';
 import php from '../index';
 
-describe('rust-crate', () => {
+describe('php', () => {
   const path = '/blob/path/dummy';
 
   it('resolves classes', () => {

--- a/packages/plugin-php/index.js
+++ b/packages/plugin-php/index.js
@@ -1,0 +1,26 @@
+import { PHP } from '@octolinker/helper-grammar-regex-collection';
+import liveResolverQuery from '@octolinker/resolver-live-query';
+
+export default {
+  name: 'PHP',
+
+  resolve(path, [target]) {
+    if (target.includes('\\')) {
+      return;
+    }
+
+    const docsUrl = `https://www.php.net/manual/en/class.${target.toLowerCase()}.php`;
+    return liveResolverQuery({ type: 'ping', target: docsUrl });
+  },
+
+  getPattern() {
+    return {
+      pathRegexes: [/\.php$/],
+      githubClasses: ['type-php', 'highlight-text-html-php'],
+    };
+  },
+
+  getLinkRegexes() {
+    return PHP;
+  },
+};

--- a/packages/plugin-php/index.js
+++ b/packages/plugin-php/index.js
@@ -1,16 +1,27 @@
-import { PHP } from '@octolinker/helper-grammar-regex-collection';
+import { PHP, PHP_FUNC } from '@octolinker/helper-grammar-regex-collection';
 import liveResolverQuery from '@octolinker/resolver-live-query';
 
 export default {
   name: 'PHP',
 
-  resolve(path, [target]) {
+  resolve(path, [target], meta, regExp) {
     if (target.includes('\\')) {
       return;
     }
 
-    const docsUrl = `https://www.php.net/manual/en/class.${target.toLowerCase()}.php`;
-    return liveResolverQuery({ type: 'ping', target: docsUrl });
+    if (regExp === PHP_FUNC) {
+      return liveResolverQuery({
+        type: 'ping',
+        target: `https://www.php.net/manual/en/function.${target
+          .toLowerCase()
+          .replace(/_/g, '-')}.php`,
+      });
+    }
+
+    return liveResolverQuery({
+      type: 'ping',
+      target: `https://www.php.net/manual/en/class.${target.toLowerCase()}.php`,
+    });
   },
 
   getPattern() {
@@ -21,6 +32,6 @@ export default {
   },
 
   getLinkRegexes() {
-    return PHP;
+    return [PHP, PHP_FUNC];
   },
 };

--- a/packages/plugin-php/package.json
+++ b/packages/plugin-php/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@octolinker/plugin-php",
+  "version": "1.0.0",
+  "description": "",
+  "repository": "https://github.com/octolinker/octolinker/tree/master/packages/plugin-php",
+  "license": "MIT",
+  "main": "./index.js",
+  "dependencies": {
+    "@octolinker/resolver-live-query": "1.0.0",
+    "@octolinker/helper-grammar-regex-collection": "1.0.0"
+  }
+}


### PR DESCRIPTION
[![](https://github.com/OctoLinker/OctoLinker/workflows/Node%20CI/badge.svg?branch=phpdocs)](https://github.com/OctoLinker/OctoLinker/pull/1033/checks) [![Pull Request Badge](https://badgen.net/badge/Generated%20by/Pull%20Request%20Badge/purple)](https://pullrequestbadge.com/?rel=badge)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please provide at least one example link
- [ ] Make sure all of the significant new logic is covered by tests


Support for PHP is limited in OctoLinker, and besides making dependencies clickable in a `composer.json` we don't do any other linking. However, providing better PHP support is on my list for quite some time now. This PR links PHP core classes to the related php.net manual page


```php
<?php

use Closure; // => https://www.php.net/manual/en/class.closure.php
use Exception; // => https://www.php.net/manual/en/class.exception.php
use ArrayAccess; // => https://www.php.net/manual/en/class.arrayaccess.php
use function is_array; // => https://www.php.net/manual/en/function.is-array.php
use function preg_last_error; // => https://www.php.net/manual/en/function.preg-last-error.php

?>
```


Demo:

https://github.com/laravel/framework/blob/8.x/src/Illuminate/Container/Container.php