### PR TITLE
Exclude urls from css imports

### DIFF
--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -140,7 +140,12 @@ export const CSS_IMPORT = regex`
   @import
   \s
   ((url|URL)\()?
-  ${captureQuotedWord}
+  ['"]                # beginning quote
+  (?<$1>
+    (?!https?:\/\/)   # exclude urls
+    [^'")]+           # capture the word inside the quotes
+  )
+  ['"]                # end quote
 `;
 
 export const LESS_IMPORT = regex`

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -313,7 +313,12 @@ const fixtures = {
       ['@import url("foo")', ['foo']],
       ['@import url("foo") bar', ['foo']],
     ],
-    invalid: ['@import foo', '@import url(foo)'],
+    invalid: [
+      '@import foo',
+      '@import url(foo)',
+      '@import url("http://octolinker.now.sh/")',
+      '@import url("https://octolinker.now.sh/")',
+    ],
   },
   LESS_IMPORT: {
     valid: [


### PR DESCRIPTION
[![](https://github.com/OctoLinker/OctoLinker/workflows/Node%20CI/badge.svg?branch=css-url-imports)](https://github.com/OctoLinker/OctoLinker/pull/1036/checks) [![Pull Request Badge](https://badgen.net/badge/Generated%20by/Pull%20Request%20Badge/purple)](https://pullrequestbadge.com/?rel=badge)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please provide at least one example link
- [x] Make sure all of the significant new logic is covered by tests

This is another thing I found while working on #905. I was trying to exclude things like `url("https://...")` so we didn't do needless lookups and it turns out the same thing happens with css imports. I'm sure this exists for LESS and SASS as well but didn't dig into those yet.

I'm wondering if there's a better way to handle this. Any ideas?

You can see an example of this here:
- https://github.com/meninaveneno/ROCK-STORY/blob/f0c8d332517c70161420da49feeaf7c786d7fb40/ROCKing.css