### PR TITLE
Ensure release note is updated

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ The outline above is an extremely simplified version. In real life you have to d
 
 - Please check to make sure that there aren't existing pull requests attempting to address the issue mentioned. We also recommend checking for issues related to the issue on the tracker, as a team member may be working on the issue in a branch or fork.
 - Non-trivial changes should be discussed in an issue first
-- Develop in a topic branch, not master
+- Develop in a topic branch, not main
 - Lint the code by `yarn lint`
 - Add relevant tests to cover the change
 - Make sure test-suite passes: `yarn test`
@@ -46,14 +46,11 @@ The outline above is an extremely simplified version. In real life you have to d
 
 ## Release Checklist
 
-- Update the version number in [packages/core/package.json](https://github.com/OctoLinker/OctoLinker/blob/master/packages/core/package.json) and [assets/manifest.json](https://github.com/OctoLinker/OctoLinker/blob/master/assets/manifest.json). Use `minor` or `major` instead of `patch` if needed (see [semver.org](http://semver.org/) for details).
+- Run `npm version <patch|minor|major>` to update the version number in [packages/core/package.json](https://github.com/OctoLinker/OctoLinker/blob/main/packages/core/package.json) and [assets/manifest.json](https://github.com/OctoLinker/OctoLinker/blob/main/assets/manifest.json). Use `minor` or `major` instead of `patch` if needed (see [semver.org](http://semver.org/) for details).
   Consider that non-`patch` releases will cause users to receive update notifications, so lean towards a `patch` release for platform-specific stuff.
-  See [lib/notification.js](https://github.com/OctoLinker/OctoLinker/blob/030859292f7ea4e8a3852a876707c22a6fe74d9a/lib/notification.js#L4).
 - Open a [pull request](https://github.com/OctoLinker/OctoLinker/pulls) with the new version.
 - Once the pull request is merged in, tag the resulting commit as `vX.Y.Z` (where `X`, `Y`, `Z` are the major, minor, and patch versions).
-- Push the tag to GitHub. This will trigger Travis CI to create a new [GitHub Release](https://github.com/OctoLinker/OctoLinker/releases) and submit the new Chrome extension to the Chrome Web Store. See [.travis.yml](https://github.com/OctoLinker/OctoLinker/blob/master/.travis.yml) for details.
-- Submit `firefox-octolinker-X.Y.Z.zip` from the [GitHub Release](https://github.com/OctoLinker/OctoLinker/releases) to [addons.mozilla.org](https://addons.mozilla.org/en-US/developers/addon/octolinker/versions#version-upload). Be sure to include the `Source code (zip)` file from the release as well.
+- Push the tag to GitHub. This will trigger a GitHub Action to create a new [GitHub Release](https://github.com/OctoLinker/OctoLinker/releases). This is uploading a new extension version to the Chrome Web Store and Mozilla Add-On Store. See [release.yml](https://github.com/OctoLinker/OctoLinker/blob/main/.github/workflows/release.yml) workflow for details.
+- Submit 
 - Submit `opera-octolinker-X.Y.Z.zip` from the [GitHub Release](https://github.com/OctoLinker/OctoLinker/releases) to [addons.opera.com](https://addons.opera.com/developer/package/226344/?tab=versions). Afterwards, go to the [Conversation tab](https://addons.opera.com/developer/package/226344/?tab=conversation), add a link to the `Source code (zip)` file and copy/paste the build instructions from previous releases.
 - Update release notes at https://github.com/OctoLinker/OctoLinker/releases/tag/vX.Y.Z. You can find a list of changes since the previous release at https://github.com/OctoLinker/OctoLinker/compare/vA.B.C...vX.Y.Z, where `A.B.C` is the previous version number.
-  Consider that non-`patch` releases will cause users to receive update notifications showing the first line of the release notes.
-  See [lib/notification.js](https://github.com/OctoLinker/OctoLinker/blob/030859292f7ea4e8a3852a876707c22a6fe74d9a/lib/notification.js#L4).

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest",
     "e2e": "node ./e2e/generate-fixtures-json.js && jest --config=e2e/jest-e2e.config.js",
     "test:watch": "jest --watch",
-    "version": "dot-json assets/manifest.json version $npm_package_version && dot-json packages/core/package.json version $npm_package_version && git add assets/manifest.json packages/core/package.json",
+    "version": "./scripts/version.sh",
     "release:cws": "cd dist && webstore upload --auto-publish",
     "release:amo": "cd dist && web-ext-submit",
     "release": "yarn release:cws && yarn release:amo",

--- a/packages/core/notification.js
+++ b/packages/core/notification.js
@@ -2,9 +2,7 @@ import * as storage from '@octolinker/helper-settings';
 import { showNotification } from '@octolinker/user-interface';
 
 let notificationEl;
-const releaseDescription =
-  'More GitHub Actions support and better OctoLinker notifications';
-const { version } = require('./package.json');
+const { version, releaseDescription } = require('./package.json');
 
 const displayVersion = version.replace('v', '');
 const majorMinor = version.split('.').slice(0, -1).join('.');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/octolinker/octolinker/tree/master/packages/core",
   "license": "MIT",
   "main": "./index.js",
+  "releaseDescription": "More GitHub Actions support and better OctoLinker notifications",
   "dependencies": {
     "@octolinker/blob-reader": "1.0.0",
     "@octolinker/helper-github-api": "1.0.0",

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This script will test if you have given a leap year or not.
+
+echo "Please summarize this release in one sentence"
+
+read note
+
+dot-json assets/manifest.json version $npm_package_version
+dot-json packages/core/package.json version $npm_package_version
+dot-json packages/core/package.json releaseDescription $note
+git add assets/manifest.json packages/core/package.json

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# This script will test if you have given a leap year or not.
 
 echo "Please summarize this release in one sentence"
 


### PR DESCRIPTION
[![](https://github.com/OctoLinker/OctoLinker/workflows/Node%20CI/badge.svg?branch=release-note)](https://github.com/OctoLinker/OctoLinker/pull/1050/checks) [![Pull Request Badge](https://badgen.net/badge/Generated%20by/Pull%20Request%20Badge/purple)](https://pullrequestbadge.com/?rel=badge)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This change ensures that a release description is added before performing a release using `npm version <patch|minor|major>`