### PR TITLE
Creating annotations for failed e2e tests

### DIFF
--- a/e2e/automated.test.js
+++ b/e2e/automated.test.js
@@ -16,6 +16,11 @@ async function executeTest(url, targetUrl, selector) {
   await page.waitForSelector(`${selector}[href$="${targetUrl}"]`);
 }
 
+function createAnnotation({ file, lineNumber, ex }) {
+  // eslint-disable-next-line no-console
+  console.log(`::error file=${file},line=${lineNumber}::${ex.message}`);
+}
+
 describe('End to End tests', () => {
   beforeAll(async () => {
     if (!process.env.E2E_USER_NAME || !process.env.E2E_USER_PASSWORD) {
@@ -48,25 +53,35 @@ describe('End to End tests', () => {
   });
 
   describe('single blob', () => {
-    fixtures.forEach(({ url, content, lineNumber, targetUrl }) => {
+    fixtures.forEach(({ url, file, content, lineNumber, targetUrl }) => {
       if (targetUrl === false) {
         it(`does not resolve ${content}`, async () => {
-          await executeTest(
-            url,
-            targetUrl,
-            `#LC${lineNumber} .octolinker-link`,
-          );
+          try {
+            await executeTest(
+              url,
+              targetUrl,
+              `#LC${lineNumber} .octolinker-link`,
+            );
+          } catch (ex) {
+            createAnnotation({ file, lineNumber, ex });
+            throw ex;
+          }
         });
         return;
       }
 
       it(`resolves ${content} to ${targetUrl}`, async () => {
         if (lineNumber) {
-          await executeTest(
-            url,
-            targetUrl,
-            `#LC${lineNumber} .octolinker-link`,
-          );
+          try {
+            await executeTest(
+              url,
+              targetUrl,
+              `#LC${lineNumber} .octolinker-link`,
+            );
+          } catch (ex) {
+            createAnnotation({ file, lineNumber, ex });
+            throw ex;
+          }
         } else {
           await executeTest(
             url,

--- a/e2e/generate-fixtures-json.js
+++ b/e2e/generate-fixtures-json.js
@@ -80,6 +80,7 @@ function findTests(contents) {
 
         memo.push({
           url: `${fixturesRoot}${filePath}`,
+          file: `e2e${filePath}`,
           content: lines[index + 1].trim(),
           targetUrl,
           lineNumber,


### PR DESCRIPTION
[![](https://github.com/OctoLinker/OctoLinker/workflows/Node%20CI/badge.svg?branch=test-annotations)](https://github.com/OctoLinker/OctoLinker/pull/1063/checks) [![Pull Request Badge](https://badgen.net/badge/Generated%20by/Pull%20Request%20Badge/purple)](https://pullrequestbadge.com/?rel=badge)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please provide at least one example link
- [ ] Make sure all of the significant new logic is covered by tests

I split this out of #1035 since it's not related to that piece of work.

I'm wondering if we should take a dependency on [actions/core](https://github.com/actions/toolkit/tree/main/packages/core) so we can use their [`issueCommand`](https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts) function which handles building & escaping everything.