### PR TITLE
Add laravel support

### DIFF
--- a/e2e/__snapshots__/automated.test.js.snap
+++ b/e2e/__snapshots__/automated.test.js.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`End to End tests diff view links commentbox 1`] = `27`;
+exports[`End to End tests diff view links commentbox 1`] = `28`;
 
 exports[`End to End tests diff view resolves https://github.com/OctoLinker/OctoLinker/commit/b97dfbfdbf3dee5f4836426e6dac6d6f473461db?diff=split#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L23 to https://github.com/eslint/eslint 1`] = `27`;
 
 exports[`End to End tests diff view resolves https://github.com/OctoLinker/OctoLinker/commit/b97dfbfdbf3dee5f4836426e6dac6d6f473461db?diff=split#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R24 to https://github.com/eslint/eslint 1`] = `27`;
 
-exports[`End to End tests diff view resolves https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fL2 to https://github.com/webpack-contrib/copy-webpack-plugin 1`] = `27`;
+exports[`End to End tests diff view resolves https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fL2 to https://github.com/webpack-contrib/copy-webpack-plugin 1`] = `28`;
 
-exports[`End to End tests diff view resolves https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fR2 to https://github.com/webpack-contrib/copy-webpack-plugin 1`] = `27`;
+exports[`End to End tests diff view resolves https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fR2 to https://github.com/webpack-contrib/copy-webpack-plugin 1`] = `28`;
 
-exports[`End to End tests diff view resolves https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L42 to https://github.com/eslint/eslint 1`] = `27`;
+exports[`End to End tests diff view resolves https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L42 to https://github.com/eslint/eslint 1`] = `28`;
 
-exports[`End to End tests diff view resolves https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R42 to https://github.com/eslint/eslint 1`] = `27`;
+exports[`End to End tests diff view resolves https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R42 to https://github.com/eslint/eslint 1`] = `28`;
 
 exports[`End to End tests single blob resolves  to https://nodejs.org/api/dns.html 1`] = `11`;
 
@@ -266,12 +266,16 @@ exports[`End to End tests single blob resolves requireNamespace("rlang") to http
 
 exports[`End to End tests single blob resolves requireNamespace("rlang", quietly = TRUE) to https://github.com/r-lib/rlang 1`] = `7`;
 
-exports[`End to End tests single blob resolves use ArrayAccess; to https://www.php.net/manual/en/class.arrayaccess.php 1`] = `5`;
+exports[`End to End tests single blob resolves use ArrayAccess; to https://www.php.net/manual/en/class.arrayaccess.php 1`] = `7`;
 
-exports[`End to End tests single blob resolves use Closure; to https://www.php.net/manual/en/class.closure.php 1`] = `5`;
+exports[`End to End tests single blob resolves use Closure; to https://www.php.net/manual/en/class.closure.php 1`] = `7`;
 
-exports[`End to End tests single blob resolves use Exception; to https://www.php.net/manual/en/class.exception.php 1`] = `5`;
+exports[`End to End tests single blob resolves use Exception; to https://www.php.net/manual/en/class.exception.php 1`] = `7`;
 
-exports[`End to End tests single blob resolves use function is_array; to https://www.php.net/manual/en/function.is-array.php 1`] = `5`;
+exports[`End to End tests single blob resolves use Illuminate\\Contracts\\Container\\BindingResolutionException; to https://laravel.com/api/8.x/Illuminate/Contracts/Container/BindingResolutionException.html 1`] = `7`;
 
-exports[`End to End tests single blob resolves use function preg_last_error; to https://www.php.net/manual/en/function.preg-last-error.php 1`] = `5`;
+exports[`End to End tests single blob resolves use Illuminate\\Contracts\\Container\\Container as ContainerContract; to https://laravel.com/api/8.x/Illuminate/Contracts/Container/Container.html 1`] = `7`;
+
+exports[`End to End tests single blob resolves use function is_array; to https://www.php.net/manual/en/function.is-array.php 1`] = `7`;
+
+exports[`End to End tests single blob resolves use function preg_last_error; to https://www.php.net/manual/en/function.preg-last-error.php 1`] = `7`;

--- a/e2e/fixtures/php/foo.php
+++ b/e2e/fixtures/php/foo.php
@@ -15,10 +15,10 @@ use function is_array;
 // @OctoLinkerResolve(https://www.php.net/manual/en/function.preg-last-error.php)
 use function preg_last_error;
 
-// @OctoLinkerDoesNotResolve
+// @OctoLinkerResolve(https://laravel.com/api/8.x/Illuminate/Contracts/Container/BindingResolutionException.html)
 use Illuminate\Contracts\Container\BindingResolutionException;
 
-// @OctoLinkerDoesNotResolve
+// @OctoLinkerResolve(https://laravel.com/api/8.x/Illuminate/Contracts/Container/Container.html)
 use Illuminate\Contracts\Container\Container as ContainerContract;
 
 ?>

--- a/packages/helper-insert-link/index.js
+++ b/packages/helper-insert-link/index.js
@@ -17,14 +17,14 @@ function createLinkElement() {
 
 function injectUrl(node, value, startOffset, endOffset) {
   let el;
-  try {
-    // Take quote marks into account to narrow down match
-    // in case value is given on the left and right hand side
-    if (startOffset > 0) {
-      startOffset -= 1;
-    }
-    const textMatch = node.textContent.slice(startOffset, endOffset + 1).trim(); // we don't want to include whitespace in the link
+  // Take quote marks into account to narrow down match
+  // in case value is given on the left and right hand side
+  if (startOffset > 0) {
+    startOffset -= 1;
+  }
+  const textMatch = node.textContent.slice(startOffset, endOffset + 1).trim(); // we don't want to include whitespace in the link
 
+  try {
     findAndReplaceDOMText(node, {
       find: textMatch,
       replace: (portion) => {
@@ -41,6 +41,21 @@ function injectUrl(node, value, startOffset, endOffset) {
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);
+  }
+
+  if (!el && node.textContent.includes(textMatch)) {
+    el = createLinkElement();
+
+    [...node.childNodes].forEach((child) => {
+      if (textMatch.includes(child.textContent)) {
+        if (!el.childElementCount) {
+          node.appendChild(el);
+        }
+        el.appendChild(child);
+      } else {
+        node.appendChild(child);
+      }
+    });
   }
 
   return el;

--- a/packages/helper-settings/SettingsForm.js
+++ b/packages/helper-settings/SettingsForm.js
@@ -187,6 +187,17 @@ export default class Form extends Component {
             checked={state.showUpdateNotification}
             onClick={linkState(this, 'showUpdateNotification')}
           />
+          <hr />
+          <h2>Feature preview</h2>
+          <div>
+            <Checkbox
+              name="enableBetterPHP"
+              label="Better PHP support"
+              description="Enable support for Symfony, Laravel, Doctrine, Cake and PHPUnit."
+              checked={state.enableBetterPHP}
+              onClick={linkState(this, 'enableBetterPHP')}
+            />
+          </div>
         </form>
         <hr />
         <Stats counter={stats.counter} />

--- a/packages/helper-settings/index.js
+++ b/packages/helper-settings/index.js
@@ -9,6 +9,7 @@ const defaults = {
     since: Date.now(),
     counter: 0,
   },
+  flagPHP: false,
 };
 
 export const get = (key) => {

--- a/packages/helper-settings/index.js
+++ b/packages/helper-settings/index.js
@@ -9,12 +9,33 @@ const defaults = {
     since: Date.now(),
     counter: 0,
   },
-  flagPHP: false,
+  enableBetterPHP: false,
 };
+
+function isTestEnv() {
+  if (process.env.NODE_ENV === 'test') {
+    return true;
+  }
+
+  if (
+    typeof window !== 'undefined' &&
+    /OctoLinker\/OctoLinker\/blob\/.+\/e2e\/fixtures/.test(
+      window.location.pathname,
+    )
+  ) {
+    return true;
+  }
+
+  return false;
+}
 
 export const get = (key) => {
   if (process.env.OCTOLINKER_LIVE_DEMO) {
     return;
+  }
+
+  if (isTestEnv() && key === 'enableBetterPHP') {
+    return true;
   }
 
   return store[key];

--- a/packages/plugin-php/__tests__/index.js
+++ b/packages/plugin-php/__tests__/index.js
@@ -18,11 +18,35 @@ describe('php', () => {
     });
   });
 
-  it('does not try to resolve packages', () => {
+  it('resolves laravel', () => {
     expect(
       php.resolve(path, [
         'Illuminate\\Contracts\\Container\\BindingResolutionException',
       ]),
-    ).toEqual([]);
+    ).toEqual({
+      type: 'trusted-url',
+      target:
+        'https://laravel.com/api/8.x/Illuminate/Contracts/Container/BindingResolutionException.html',
+    });
+  });
+
+  it('resolves Doctrine', () => {
+    expect(php.resolve(path, ['Doctrine\\foo\\bar\\baz'])).toEqual({
+      type: 'trusted-url',
+      target:
+        'https://github.com/doctrine/foo/blob/HEAD/lib/Doctrine/foo/bar/baz.php',
+    });
+  });
+
+  it('resolves PHPUnit', () => {
+    expect(php.resolve(path, ['PHPUnit\\foo\\bar\\baz'])).toEqual({
+      type: 'trusted-url',
+      target:
+        'https://github.com/sebastianbergmann/phpunit/blob/master/src/foo/bar/baz.php',
+    });
+  });
+
+  it('does not try to resolve packages', () => {
+    expect(php.resolve(path, ['Foo\\Bar\\Baz'])).toEqual([]);
   });
 });

--- a/packages/plugin-php/index.js
+++ b/packages/plugin-php/index.js
@@ -9,7 +9,7 @@ export default {
 
   resolve(path, [target], meta, regExp) {
     const enableBetterPHP = storage.get('enableBetterPHP');
-    if (enableBetterPHP || process.env.NODE_ENV === 'test') {
+    if (enableBetterPHP) {
       const linkMapping = mappingList.find(({ importPath }) =>
         target.startsWith(`${importPath}\\`),
       );

--- a/packages/plugin-php/index.js
+++ b/packages/plugin-php/index.js
@@ -1,10 +1,49 @@
 import { PHP, PHP_FUNC } from '@octolinker/helper-grammar-regex-collection';
 import liveResolverQuery from '@octolinker/resolver-live-query';
+import resolverTrustedUrl from '@octolinker/resolver-trusted-url';
+import * as storage from '@octolinker/helper-settings';
+import mappingList from './mapping';
 
 export default {
   name: 'PHP',
 
   resolve(path, [target], meta, regExp) {
+    const enableBetterPHP = storage.get('enableBetterPHP');
+    if (enableBetterPHP || process.env.NODE_ENV === 'test') {
+      const linkMapping = mappingList.find(({ importPath }) =>
+        target.startsWith(`${importPath}\\`),
+      );
+
+      if (linkMapping) {
+        const { url, delimiter, hook } = linkMapping;
+        const targetPath = target.replace(/\\/g, delimiter);
+
+        return resolverTrustedUrl({
+          target: url.replace('%s', targetPath),
+        });
+      }
+
+      if (target.startsWith('Doctrine\\')) {
+        const targetPath = target.replace(/\\/g, '/');
+        const [, repo] = targetPath.split('/');
+
+        return resolverTrustedUrl({
+          target: `https://github.com/doctrine/${repo}/blob/HEAD/lib/${targetPath}.php`,
+        });
+      }
+
+      if (target.startsWith('PHPUnit\\')) {
+        const targetPath = target.replace(/\\/g, '/');
+        const [, ...filePath] = targetPath.split('/');
+
+        return resolverTrustedUrl({
+          target: `https://github.com/sebastianbergmann/phpunit/blob/master/src/${filePath.join(
+            '/',
+          )}.php`,
+        });
+      }
+    }
+
     if (target.includes('\\')) {
       return [];
     }

--- a/packages/plugin-php/mapping.js
+++ b/packages/plugin-php/mapping.js
@@ -1,0 +1,23 @@
+export default [
+  {
+    // Turn Illuminate\View\View;
+    // into a link pointing to https://laravel.com/api/8.x/Illuminate/View/View.html
+    importPath: 'Illuminate',
+    url: 'https://laravel.com/api/8.x/%s.html',
+    delimiter: '/',
+  },
+  {
+    // Turn Symfony\Component\Form\Event\SubmitEvent;
+    // into a link pointing to https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Form/Event/SubmitEvent.php
+    importPath: 'Symfony',
+    url: 'https://github.com/symfony/symfony/blob/5.x/src/%s.php',
+    delimiter: '/',
+  },
+  {
+    // Turns Cake\Core\Configure;
+    // into a link pointing to https://api.cakephp.org/4.1/class-Cake.Core.Configure.html
+    importPath: 'Cake',
+    url: 'https://api.cakephp.org/4.1/class-%s.html',
+    delimiter: '.',
+  },
+];

--- a/packages/plugin-php/package.json
+++ b/packages/plugin-php/package.json
@@ -6,7 +6,9 @@
   "license": "MIT",
   "main": "./index.js",
   "dependencies": {
+    "@octolinker/helper-settings": "1.0.0",
     "@octolinker/resolver-live-query": "1.0.0",
+    "@octolinker/resolver-trusted-url": "1.0.0",
     "@octolinker/helper-grammar-regex-collection": "1.0.0"
   }
 }


### PR DESCRIPTION
Add feature preview to support to link `use` statements from the following projects:

- Symfony
- Laravel
- Doctrine
- CakePHP
- PHPUnit

To enable the feature, go to the extension settings page and enable the `Better PHP support` checkbox