### PR TITLE
Fix return value of PHP plugin

### DIFF
--- a/packages/plugin-php/__tests__/index.js
+++ b/packages/plugin-php/__tests__/index.js
@@ -23,6 +23,6 @@ describe('php', () => {
       php.resolve(path, [
         'Illuminate\\Contracts\\Container\\BindingResolutionException',
       ]),
-    ).toEqual(undefined);
+    ).toEqual([]);
   });
 });

--- a/packages/plugin-php/index.js
+++ b/packages/plugin-php/index.js
@@ -6,7 +6,7 @@ export default {
 
   resolve(path, [target], meta, regExp) {
     if (target.includes('\\')) {
-      return;
+      return [];
     }
 
     if (regExp === PHP_FUNC) {


### PR DESCRIPTION
The return value from a resolve needs to be an array as discussed here https://github.com/OctoLinker/OctoLinker/pull/1035#discussion_r500038960. This might be worth a patch release 