### PR TITLE
Update fixtures url to meet new url structure

### DIFF
--- a/e2e/diff-fixtures.json
+++ b/e2e/diff-fixtures.json
@@ -1,26 +1,26 @@
 [
   {
-    "url": "https://github.com/OctoLinker/OctoLinker/commit/b97dfbfdbf3dee5f4836426e6dac6d6f473461db?diff=split#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R24",
+    "url": "https://github.com/OctoLinker/OctoLinker/commit/b97dfbfdbf3dee5f4836426e6dac6d6f473461db?diff=split#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R24",
     "targetUrl": "https://github.com/eslint/eslint"
   },
   {
-    "url": "https://github.com/OctoLinker/OctoLinker/commit/b97dfbfdbf3dee5f4836426e6dac6d6f473461db?diff=split#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L23",
+    "url": "https://github.com/OctoLinker/OctoLinker/commit/b97dfbfdbf3dee5f4836426e6dac6d6f473461db?diff=split#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L23",
     "targetUrl": "https://github.com/eslint/eslint"
   },
   {
-    "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L42",
+    "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L42",
     "targetUrl": "https://github.com/eslint/eslint"
   },
   {
-    "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R42",
+    "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R42",
     "targetUrl": "https://github.com/eslint/eslint"
   },
   {
-    "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-11e9f7f953edc64ba14b0cc350ae7b9dL2",
+    "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fL2",
     "targetUrl": "https://github.com/webpack-contrib/copy-webpack-plugin"
   },
   {
-    "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-11e9f7f953edc64ba14b0cc350ae7b9dR2",
+    "url": "https://github.com/OctoLinker/OctoLinker/pull/451/files#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fR2",
     "targetUrl": "https://github.com/webpack-contrib/copy-webpack-plugin"
   }
 ]


### PR DESCRIPTION
Following up on https://github.com/OctoLinker/OctoLinker/pull/1079#issuecomment-708201350 it seems like GitHub made some tweaks to the hash when linking to a specific line in a diff view. 