### PR TITLE
Adjust toast position for Octotree

### DIFF
--- a/packages/user-interface/style.css
+++ b/packages/user-interface/style.css
@@ -2,6 +2,10 @@
   pointer-events: none;
 }
 
+.octotree-show .octolinker-toast  {
+  left: var(--octotree-sidebar-width) !important
+}
+
 .octolinker-toast .octo-toast-image  {
   width: 58px;
   height: 40px;


### PR DESCRIPTION
As outlined in https://github.com/ovity/octotree/issues/997, Octotree is hiding the toast notification that we introduced recently. Usually I would like to avoid such tweaks, but since Octotree is a widely used extension it's worth a fix in my opinion. 

## Before
<img width="536" alt="Screenshot 2020-11-11 at 22 06 31" src="https://user-images.githubusercontent.com/1393946/98864607-73087700-246a-11eb-8165-2832583a6f0e.png">


## After
<img width="777" alt="Screenshot 2020-11-11 at 22 06 08" src="https://user-images.githubusercontent.com/1393946/98864618-77cd2b00-246a-11eb-8c97-2cd5484f0c32.png">