### PR TITLE
Adjust toast position for Octotree

### DIFF
--- a/packages/user-interface/style.css
+++ b/packages/user-interface/style.css
@@ -1,3 +1,6 @@
+.octolinker-toast {
+  z-index: 1000000002 !important;
+}
 .octolinker-toast svg {
   pointer-events: none;
 }

--- a/packages/user-interface/style.css
+++ b/packages/user-interface/style.css
@@ -2,10 +2,6 @@
   pointer-events: none;
 }
 
-.octotree-show .octolinker-toast  {
-  left: var(--octotree-sidebar-width) !important
-}
-
 .octolinker-toast .octo-toast-image  {
   width: 58px;
   height: 40px;


### PR DESCRIPTION
As suggested in https://github.com/OctoLinker/OctoLinker/pull/1120#discussion_r522915677 this PR is using `z-index` to ensure the OctoLinker toast message stays on top

## After
<img width="518" alt="Screenshot 2020-11-15 at 22 25 42" src="https://user-images.githubusercontent.com/1393946/99197275-d0b20180-2791-11eb-82b2-a58c499093bd.png">

## Before
<img width="502" alt="Screenshot 2020-11-15 at 22 25 20" src="https://user-images.githubusercontent.com/1393946/99197277-d27bc500-2791-11eb-9738-eb2ea1baa5dc.png"> 
