### PR TITLE
Show usage statistics on setttings page

### DIFF
--- a/packages/core/stats.js
+++ b/packages/core/stats.js
@@ -5,10 +5,7 @@ const CLASS_NAME = 'octolinker-link';
 let tid = null;
 
 function updateCounter() {
-  const stats = storage.get('stats') || {
-    since: Date.now(),
-    counter: 0,
-  };
+  const stats = storage.get('stats');
 
   storage.set('stats', {
     ...stats,

--- a/packages/helper-settings/SettingsForm.js
+++ b/packages/helper-settings/SettingsForm.js
@@ -4,7 +4,7 @@ import { h, Component } from 'preact';
 import linkState from 'linkstate';
 
 import './style.css';
-import { Input, Checkbox } from './components';
+import { Input, Checkbox, Stats } from './components';
 import * as storage from './index';
 
 const githubTokenDescription = () => (
@@ -84,110 +84,113 @@ export default class Form extends Component {
   }
 
   render(props, state) {
-    const { errorMessage, tokenLoaded } = this.state;
-
+    const { errorMessage, tokenLoaded, stats } = this.state;
     return (
-      <form
-        onChange={this.onBlur.bind(this)}
-        onSubmit={(event) => event.preventDefault()}
-      >
-        <div className="flash-success">
-          {tokenLoaded && '✔ Token successfully added!'}
-        </div>
-        <Input
-          type="password"
-          name="githubToken"
-          className="js-token"
-          label="Access token"
-          description={githubTokenDescription()}
-          value={state.githubToken}
-          error={errorMessage}
-          onInput={(event) => {
-            linkState(this, 'githubToken')(event);
-            setTimeout(this.validateToken.bind(this), 100);
-          }}
-        />
-        <p>
-          For public repositories,{' '}
-          <a
-            href="https://github.com/settings/tokens/new?scopes=public_repo&description=OctoLinker"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            create a token
-          </a>{' '}
-          with the{' '}
-          <code>
-            <strong>public_repo</strong>
-          </code>{' '}
-          permission. If you want OctoLinker for private repositories,
-          you&apos;ll need to{' '}
-          <a
-            href="https://github.com/settings/tokens/new?scopes=repo&description=OctoLinker"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            create a token
-          </a>{' '}
-          with the{' '}
-          <code>
-            <strong>repo</strong>
-          </code>{' '}
-          permissions. Then copy and paste it into the input field above.
-        </p>
-        <p>
-          <details>
-            <summary>Why is a GitHub token needed?</summary>
-            <p>
-              OctoLinker uses the{' '}
-              <a
-                href="https://developer.github.com/v3/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                GitHub API
-              </a>{' '}
-              to retrieve repository metadata. By default, it makes
-              unauthenticated requests to the GitHub API. However, there are two
-              situations when requests must be authenticated:
-            </p>
-            <p>
-              <ul>
-                <li>You access a private repository</li>
-                <li>
-                  You exceed{' '}
-                  <a
-                    href="https://developer.github.com/v3/#rate-limiting"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    the rate limit for unauthenticated requests
-                  </a>
-                </li>
-              </ul>
-            </p>
-            <p>
-              When that happens, OctoLinker needs an GitHub access token in
-              order to continue to work.
-            </p>
-          </details>
-        </p>
+      <div>
+        <form
+          onChange={this.onBlur.bind(this)}
+          onSubmit={(event) => event.preventDefault()}
+        >
+          <div className="flash-success">
+            {tokenLoaded && '✔ Token successfully added!'}
+          </div>
+          <Input
+            type="password"
+            name="githubToken"
+            className="js-token"
+            label="Access token"
+            description={githubTokenDescription()}
+            value={state.githubToken}
+            error={errorMessage}
+            onInput={(event) => {
+              linkState(this, 'githubToken')(event);
+              setTimeout(this.validateToken.bind(this), 100);
+            }}
+          />
+          <p>
+            For public repositories,{' '}
+            <a
+              href="https://github.com/settings/tokens/new?scopes=public_repo&description=OctoLinker"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              create a token
+            </a>{' '}
+            with the{' '}
+            <code>
+              <strong>public_repo</strong>
+            </code>{' '}
+            permission. If you want OctoLinker for private repositories,
+            you&apos;ll need to{' '}
+            <a
+              href="https://github.com/settings/tokens/new?scopes=repo&description=OctoLinker"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              create a token
+            </a>{' '}
+            with the{' '}
+            <code>
+              <strong>repo</strong>
+            </code>{' '}
+            permissions. Then copy and paste it into the input field above.
+          </p>
+          <p>
+            <details>
+              <summary>Why is a GitHub token needed?</summary>
+              <p>
+                OctoLinker uses the{' '}
+                <a
+                  href="https://developer.github.com/v3/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  GitHub API
+                </a>{' '}
+                to retrieve repository metadata. By default, it makes
+                unauthenticated requests to the GitHub API. However, there are
+                two situations when requests must be authenticated:
+              </p>
+              <p>
+                <ul>
+                  <li>You access a private repository</li>
+                  <li>
+                    You exceed{' '}
+                    <a
+                      href="https://developer.github.com/v3/#rate-limiting"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      the rate limit for unauthenticated requests
+                    </a>
+                  </li>
+                </ul>
+              </p>
+              <p>
+                When that happens, OctoLinker needs an GitHub access token in
+                order to continue to work.
+              </p>
+            </details>
+          </p>
+          <hr />
+          <Checkbox
+            name="enablePrivateRepositories"
+            label="Private repositories"
+            description="Enable support for private repositories (requires a GitHub token)"
+            checked={state.enablePrivateRepositories}
+            onClick={linkState(this, 'enablePrivateRepositories')}
+          />
+          <Checkbox
+            name="showUpdateNotification"
+            label="Update notification"
+            description="Show a notification if a new version is available."
+            checked={state.showUpdateNotification}
+            onClick={linkState(this, 'showUpdateNotification')}
+          />
+        </form>
         <hr />
-        <Checkbox
-          name="enablePrivateRepositories"
-          label="Private repositories"
-          description="Enable support for private repositories (requires a GitHub token)"
-          checked={state.enablePrivateRepositories}
-          onClick={linkState(this, 'enablePrivateRepositories')}
-        />
-        <Checkbox
-          name="showUpdateNotification"
-          label="Update notification"
-          description="Show a notification if a new version is available."
-          checked={state.showUpdateNotification}
-          onClick={linkState(this, 'showUpdateNotification')}
-        />
-      </form>
+        <Stats counter={stats.counter} />
+      </div>
     );
   }
 }

--- a/packages/helper-settings/components/index.js
+++ b/packages/helper-settings/components/index.js
@@ -2,3 +2,4 @@ import 'webext-base-css';
 
 export { default as Input } from './input';
 export { default as Checkbox } from './checkbox';
+export { default as Stats } from './stats';

--- a/packages/helper-settings/components/stats.js
+++ b/packages/helper-settings/components/stats.js
@@ -1,0 +1,8 @@
+import { h } from 'preact';
+
+export default ({ counter }) => (
+  <div>
+    <h2>Statistics</h2>
+    Links followed: <strong>{counter}</strong>
+  </div>
+);

--- a/packages/helper-settings/components/stats.js
+++ b/packages/helper-settings/components/stats.js
@@ -4,5 +4,9 @@ export default ({ counter }) => (
   <div>
     <h2>Statistics</h2>
     Links followed: <strong>{counter}</strong>
+    <span className="note pt-4">
+      Your statistics are stored in your browser, we do not store them anywhere
+      else.
+    </span>
   </div>
 );

--- a/packages/helper-settings/index.js
+++ b/packages/helper-settings/index.js
@@ -5,6 +5,10 @@ const store = {};
 const defaults = {
   enablePrivateRepositories: true,
   showUpdateNotification: true,
+  stats: {
+    since: Date.now(),
+    counter: 0,
+  },
 };
 
 export const get = (key) => {

--- a/packages/helper-settings/style.css
+++ b/packages/helper-settings/style.css
@@ -19,6 +19,10 @@ code {
   opacity: 0.6;
 }
 
+.pt-4 {
+  padding-top: 1rem;
+}
+
 input[type='checkbox'] {
   margin-inline-end: 0.6em;
   margin-top: 0.2em;


### PR DESCRIPTION
Since https://github.com/OctoLinker/OctoLinker/pull/917 we track the usage of OctoLinker by increasing a counter whenever a user follows a link. The data are stored in the users browser using the Storage API. This PR makes this statiscs accesibale by adding a new section to the settings page.

Reviewer note: [ignore whitespace in diff using this link](https://github.com/OctoLinker/OctoLinker/pull/1129/files?w=1)

<img src="https://user-images.githubusercontent.com/1393946/101414423-57b44e80-38e6-11eb-9f45-b11aee182523.png" width="400" />


