### PR TITLE
Wrap element based on the matching group offset

### DIFF
--- a/packages/helper-insert-link/__tests__/__snapshots__/index.js.snap
+++ b/packages/helper-insert-link/__tests__/__snapshots__/index.js.snap
@@ -27,6 +27,44 @@ Array [
 ]
 `;
 
+exports[`insert-link when findAndReplaceDOMText does not find any element wraps a nested element 1`] = `
+<div>
+  foo 
+  <a
+    class="octolinker-link"
+    data-pjax="true"
+  >
+    b
+    <span>
+      ar
+      
+    </span>
+  </a>
+</div>
+`;
+
+exports[`insert-link when findAndReplaceDOMText does not find any element wraps the matching group element 1`] = `
+<div>
+  
+  b
+  <span>
+    ar
+    
+  </span>
+   
+  <a
+    class="octolinker-link"
+    data-pjax="true"
+  >
+    b
+    <span>
+      ar
+      
+    </span>
+  </a>
+</div>
+`;
+
 exports[`insert-link wraps a nested element 1`] = `
 <div>
   foo 

--- a/packages/helper-insert-link/__tests__/index.js
+++ b/packages/helper-insert-link/__tests__/index.js
@@ -118,4 +118,20 @@ describe('insert-link', () => {
       expect(helper(input).matches[0].urls).toEqual(['bar']);
     });
   });
+
+  describe('when findAndReplaceDOMText does not find any element', () => {
+    it('wraps a nested element', () => {
+      const regex = /foo (bar)/g;
+      const input = 'foo b<span>ar</span>';
+
+      expect(helper(input, regex).el).toMatchSnapshot();
+    });
+
+    it('wraps the matching group element', () => {
+      const regex = /bar (bar)/g;
+      const input = 'b<span>ar</span> b<span>ar</span>';
+
+      expect(helper(input, regex).el).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/helper-insert-link/index.js
+++ b/packages/helper-insert-link/index.js
@@ -46,8 +46,13 @@ function injectUrl(node, value, startOffset, endOffset) {
   if (!el && node.textContent.includes(textMatch)) {
     el = createLinkElement();
 
+    let currentOffset = 0;
     [...node.childNodes].forEach((child) => {
-      if (textMatch.includes(child.textContent)) {
+      if (
+        currentOffset >= startOffset &&
+        currentOffset <= endOffset &&
+        textMatch.includes(child.textContent)
+      ) {
         if (!el.childElementCount) {
           node.appendChild(el);
         }
@@ -55,6 +60,8 @@ function injectUrl(node, value, startOffset, endOffset) {
       } else {
         node.appendChild(child);
       }
+
+      currentOffset += child.textContent.length;
     });
   }
 


### PR DESCRIPTION
As described in #1165 and #1166, the printed source code gets rewritten in certain circumstances. This happens if a matching keyword appears on both side of the import statement. By taking the matching group index into account the correct element is wrapped with a octolinker link.



