### PR TITLE
Fix Safari CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,6 @@ jobs:
     - uses: actions/download-artifact@v2 # npm install+build seems slow and problematic on macOS
       with:
         path: dist
+        name: artifact 
     - uses: maxim-lobanov/setup-xcode@v1
     - run: yarn safari-pack


### PR DESCRIPTION
Follows: https://github.com/OctoLinker/OctoLinker/pull/1167#issuecomment-757384115

From the log:
```
Artifact artifact was downloaded to /Users/runner/work/OctoLinker/OctoLinker/dist/artifact
9
```
