### PR TITLE
Drop unnecessary details from manifest.json

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -32,9 +32,7 @@
       ],
       "js": [
         "app.js"
-      ],
-      "run_at": "document_idle",
-      "all_frames": false
+      ]
     }
   ],
   "permissions": [


### PR DESCRIPTION
They are the defaults already https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts
