### PR TITLE
Disable sourcemaps to get webpack-extension-reloader working

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = (env, argv) => ({
     background: './packages/core/background/index',
     options: './packages/helper-settings/page',
   },
-  devtool: argv.mode === 'development' ? 'source-map' : false,
+  devtool: false,
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: '[name].js',


### PR DESCRIPTION
After completing  the webpack 5 migration, I've noticed that [webpack-extension-reloader](https://github.com/rubenspgcavalcante/webpack-extension-reloader) is not working anymore. The auto reloading is super important when working on OctoLinker (at least for me). The plugin itself hasn't been update for a year and is therefore not 100% compatible with webpack 5 anymore. Disabling the sourcemap creation is fixing the problem. 


```
(node:4628) [DEP_WEBPACK_COMPILATION_AFTER_OPTIMIZE_CHUNK_ASSETS] DeprecationWarning: afterOptimizeChunkAssets is deprecated (use Compilation.hooks.processAssets instead and use one of Compilation.PROCESS_ASSETS_STAGE_* as stage option)
(node:4628) [DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET] DeprecationWarning: Compilation.chunks was changed from Array to Set (using Array method 'reduce' is deprecated)
(node:4628) UnhandledPromiseRejectionWarning: TypeError: item.node is not a function
    at /Users/stefan/code/octolinker/node_modules/webpack-sources/lib/ConcatSource.js:59:50
    at Array.map (<anonymous>)
    at ConcatSource.node (/Users/stefan/code/octolinker/node_modules/webpack-sources/lib/ConcatSource.js:58:63)
    at ConcatSource.proto.sourceAndMap (/Users/stefan/code/octolinker/node_modules/webpack-sources/lib/SourceAndMapMixin.js:29:18)
    at getTaskForFile (/Users/stefan/code/octolinker/node_modules/webpack/lib/SourceMapDevToolPlugin.js:78:30)
    at /Users/stefan/code/octolinker/node_modules/webpack/lib/SourceMapDevToolPlugin.js:269:22
    at /Users/stefan/code/octolinker/node_modules/webpack/lib/Cache.js:91:34
    at Array.<anonymous> (/Users/stefan/code/octolinker/node_modules/webpack/lib/cache/MemoryCachePlugin.js:45:13)
    at /Users/stefan/code/octolinker/node_modules/webpack/lib/Cache.js:91:19
    at Hook.eval [as callAsync] (eval at create (/Users/stefan/code/octolinker/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:17:1)
(node:4628) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:4628) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```