### PR TITLE
Add workflow to auto merge dependabot prs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,14 @@
+name: auto-merge
+
+on:
+  pull_request_target:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: major
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@xt0rted as discussed a few weeks ago, we should auto merge dependabot PRs. We don't have a auto release schedule. Also the test coverage with unit, integration and end 2 end tests should prevent us from any surprises. 