### PR TITLE
Bind window object to requestIdleCallback assignment

### DIFF
--- a/packages/core/app.js
+++ b/packages/core/app.js
@@ -50,7 +50,7 @@ async function run(rootElement) {
     });
 
   // Prefetch live resolver results in background
-  (window.requestIdleCallback || setTimeout)(() => {
+  (window.requestIdleCallback || setTimeout).bind(window)(() => {
     loader(matches);
   });
 }


### PR DESCRIPTION
### Checklist:

- [x] If this PR is a new feature, please provide at least one example link
- [x] Make sure all of the significant new logic is covered by tests

The issue reported in https://github.com/OctoLinker/OctoLinker/issues/942#issuecomment-976689694 is a result of how Firefox is treating the `window.requestIdleCallback` assignment. In Chrome this works fine, but in Firefox any call to it results in the error:

>TypeError: 'requestIdleCallback' called on an object that does not implement interface Window.

I had the same results in v94 and v96.

Another option is to remove the conditional check and [shim the function](https://developers.google.com/web/updates/2015/08/using-requestidlecallback#checking_for_requestidlecallback) at the top of the file with:

```js
window.requestIdleCallback =
  window.requestIdleCallback ||
  function (cb) {
    const start = Date.now();
    return setTimeout(() => {
      cb({
        didTimeout: false,
        timeRemaining: () => Math.max(0, 50 - (Date.now() - start)),
      });
    }, 1);
  };
```

Could you test these in Safari? I don't have my MacBook setup right now so I can't confirm if it still work with that.