### PR TITLE
Solidity: improve path matching

### DIFF
--- a/e2e/fixtures/solidity/foo.sol
+++ b/e2e/fixtures/solidity/foo.sol
@@ -3,3 +3,6 @@ pragma solidity >=0.8.0 <0.9.0;
 
 /* @OctoLinkerResolve(<root>/solidity/import.sol) */
 import "./import.sol";
+
+/* @OctoLinkerResolve(<root>/solidity/import.sol) */
+import {YourContract} from "./import.sol";

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -320,9 +320,3 @@ export const R_NAMESPACE = regex`
 (?<$1>[\w\.]+) # package name
 :{2,3} # namespace operator
 `;
-
-export const SOLIDITY_IMPORT = regex`
-  import
-  \s
-  ${captureQuotedWord}
-`;

--- a/packages/plugin-solidity/index.js
+++ b/packages/plugin-solidity/index.js
@@ -1,4 +1,4 @@
-import { SOLIDITY_IMPORT } from '@octolinker/helper-grammar-regex-collection';
+import { IMPORT } from '@octolinker/helper-grammar-regex-collection';
 import relativeFile from '@octolinker/resolver-relative-file';
 import liveResolverQuery from '@octolinker/resolver-live-query';
 
@@ -33,6 +33,6 @@ export default {
   },
 
   getLinkRegexes() {
-    return SOLIDITY_IMPORT;
+    return IMPORT;
   },
 };


### PR DESCRIPTION
This PR improve the matching of Solidity files by using the JS regex.
Now matching also:
```solidity
import {YourContract} from "./import.sol";
```