### PR TITLE
Force .sh files to have LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto
 *.js text eol=lf
+*.sh text eol=lf
 packages/blob-reader/fixtures/* linguist-documentation


### PR DESCRIPTION
<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please provide at least one example link
- [ ] Make sure all of the significant new logic is covered by tests

I'm on Windows and any time I run one of the scripts in WSL it fails or runs incorrectly due to the line endings being CRLF instead of LF.