### PR TITLE
Add support for any docker registry

### DIFF
--- a/e2e/fixtures/docker/Dockerfile
+++ b/e2e/fixtures/docker/Dockerfile
@@ -1,5 +1,11 @@
 // @OctoLinkerResolve(https://hub.docker.com/_/php)
 FROM php:php:5.6-apache
 
+// @OctoLinkerResolve(https://hub.docker.com/r/datadog/agent)
+FROM datadog/agent:7-rc
+
+// @OctoLinkerResolve(https://ghcr.io/flexget/flexget)
+FROM ghcr.io/flexget/flexget:3.2.12
+
 // @OctoLinkerResolve(<root>/docker/docker-entrypoint.sh)
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/packages/plugin-docker/__tests__/index.js
+++ b/packages/plugin-docker/__tests__/index.js
@@ -1,47 +1,47 @@
+import { DOCKER_ENTRYPOINT } from '@octolinker/helper-grammar-regex-collection';
 import dockerImage from '../index';
 
 describe('docker-image', () => {
   const path = '/blob/path/dummy';
 
   it('resolves foo to https://hub.docker.com/_/foo', () => {
-    expect(dockerImage.resolve(path, ['foo'])).toEqual([
-      '{BASE_URL}/blob/path/foo',
-      'https://hub.docker.com/_/foo',
-    ]);
+    expect(dockerImage.resolve(path, ['foo'])).toEqual({
+      target: 'https://hub.docker.com/_/foo',
+      type: 'trusted-url',
+    });
   });
 
   it('resolves foo:1.2.3 to https://hub.docker.com/_/foo', () => {
-    expect(dockerImage.resolve(path, ['foo:1.2.3'])).toEqual([
-      '{BASE_URL}/blob/path/foo:1.2.3',
-      'https://hub.docker.com/_/foo',
-    ]);
+    expect(dockerImage.resolve(path, ['foo:1.2.3'])).toEqual({
+      target: 'https://hub.docker.com/_/foo',
+      type: 'trusted-url',
+    });
   });
 
   it('resolves foo:1.2.3-alpha to https://hub.docker.com/_/foo', () => {
-    expect(dockerImage.resolve(path, ['foo:1.2.3-alpha'])).toEqual([
-      '{BASE_URL}/blob/path/foo:1.2.3-alpha',
-      'https://hub.docker.com/_/foo',
-    ]);
+    expect(dockerImage.resolve(path, ['foo:1.2.3-alpha'])).toEqual({
+      target: 'https://hub.docker.com/_/foo',
+      type: 'trusted-url',
+    });
   });
 
   it('resolves foo/bar to https://hub.docker.com/r/foo/bar', () => {
-    expect(dockerImage.resolve(path, ['foo/bar'])).toEqual([
-      '{BASE_URL}/blob/path/foo/bar',
-      'https://hub.docker.com/r/foo/bar',
-    ]);
+    expect(dockerImage.resolve(path, ['foo/bar'])).toEqual({
+      target: 'https://hub.docker.com/r/foo/bar',
+      type: 'trusted-url',
+    });
   });
 
   it('resolves foo/bar:1.2.3 to https://hub.docker.com/r/foo/bar', () => {
-    expect(dockerImage.resolve(path, ['foo/bar:1.2.3'])).toEqual([
-      '{BASE_URL}/blob/path/foo/bar:1.2.3',
-      'https://hub.docker.com/r/foo/bar',
-    ]);
+    expect(dockerImage.resolve(path, ['foo/bar:1.2.3'])).toEqual({
+      target: 'https://hub.docker.com/r/foo/bar',
+      type: 'trusted-url',
+    });
   });
 
   it('resolves foobar.sh to "{BASE_URL}/blob/path/foobar.sh" ', () => {
-    expect(dockerImage.resolve(path, ['foobar.sh'])).toEqual([
-      '{BASE_URL}/blob/path/foobar.sh',
-      'https://hub.docker.com/_/foobar.sh',
-    ]);
+    expect(
+      dockerImage.resolve(path, ['foobar.sh'], {}, DOCKER_ENTRYPOINT),
+    ).toEqual('{BASE_URL}/blob/path/foobar.sh');
   });
 });

--- a/packages/plugin-docker/index.js
+++ b/packages/plugin-docker/index.js
@@ -3,23 +3,43 @@ import {
   DOCKER_ENTRYPOINT,
 } from '@octolinker/helper-grammar-regex-collection';
 import relativeFile from '@octolinker/resolver-relative-file';
+import resolverTrustedUrl from '@octolinker/resolver-trusted-url';
 
-export function dockerHubUrl(target) {
+function isURL(str) {
+  // RegExp origin https://stackoverflow.com/a/3809435/2121324
+  const expression =
+    /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/gi;
+  const urlRegex = new RegExp(expression);
+
+  return urlRegex.test(str);
+}
+
+export function dockerUrl(target) {
   let isOfficial = true;
   const imageName = target.split(':')[0];
+
+  if (isURL(`https://${imageName}`)) {
+    return resolverTrustedUrl({ target: `https://${imageName}` });
+  }
 
   if (target.includes('/')) {
     isOfficial = false;
   }
 
-  return `https://hub.docker.com/${isOfficial ? '_' : 'r'}/${imageName}`;
+  return resolverTrustedUrl({
+    target: `https://hub.docker.com/${isOfficial ? '_' : 'r'}/${imageName}`,
+  });
 }
 
 export default {
   name: 'Docker',
 
-  resolve(path, [target]) {
-    return [relativeFile({ path, target }), dockerHubUrl(target)];
+  resolve(path, [target], meta, regex) {
+    if (regex === DOCKER_ENTRYPOINT) {
+      return relativeFile({ path, target });
+    }
+
+    return dockerUrl(target);
   },
 
   getPattern() {

--- a/packages/plugin-github-actions/index.js
+++ b/packages/plugin-github-actions/index.js
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { GITHUB_ACTIONS } from '@octolinker/helper-grammar-regex-collection';
-import { dockerHubUrl } from '@octolinker/plugin-docker';
+import { dockerUrl } from '@octolinker/plugin-docker';
 
 const DOCKER_SOURCE = 'docker://';
 
@@ -15,7 +15,7 @@ export default {
     if (target.startsWith(DOCKER_SOURCE)) {
       const image = target.substring(DOCKER_SOURCE.length);
 
-      return dockerHubUrl(image);
+      return dockerUrl(image);
     }
 
     if (target.startsWith('.')) {


### PR DESCRIPTION
Fixes #1455 

This change enables any docker registry, whereas before OctoLinker assumed all images hosted on docker hub.  