### PR TITLE
Support built-in packages with `node:` prefix

### DIFF
--- a/e2e/fixtures/javascript/index.js
+++ b/e2e/fixtures/javascript/index.js
@@ -1,6 +1,9 @@
 // @OctoLinkerResolve(https://nodejs.org/api/fs.html)
 require('fs');
 
+// @OctoLinkerResolve(https://nodejs.org/api/fs.html)
+require('node:fs');
+
 // @OctoLinkerResolve(https://github.com/lodash/lodash)
 require("lodash");
 
@@ -10,11 +13,19 @@ require('react');
 // @OctoLinkerResolve(https://nodejs.org/api/http.html)
 const http = require('http');
 
+// @OctoLinkerResolve(https://nodejs.org/api/http.html)
+const http2 = require('node:http');
+
 // @OctoLinkerResolve(https://nodejs.org/api/cluster.html)
 const { cluster } = require('cluster');
 
+const { cluster: cluster2 } = require('node:cluster');
+
 // @OctoLinkerResolve(https://nodejs.org/api/path.html)
 import path from "path";
+
+// @OctoLinkerResolve(https://nodejs.org/api/fs.html)
+import fs from "node:fs";
 
 // @OctoLinkerResolve(https://nodejs.org/api/url.html)
 import url from 'url';
@@ -25,9 +36,17 @@ import * as fs from "https://deno.land/x/std/fs/mod.ts";
 // @OctoLinkerResolve(https://nodejs.org/api/os.html)
 import { os } from 'os';
 
-import { 
-  foo 
+// @OctoLinkerResolve(https://nodejs.org/api/os.html)
+import { os as os2 } from 'node:os';
+
+import {
+  foo
 } from 'dns';
+// @OctoLinkerResolveAbove(https://nodejs.org/api/dns.html)
+
+import {
+  foo2
+} from 'node:dns';
 // @OctoLinkerResolveAbove(https://nodejs.org/api/dns.html)
 
 // @OctoLinkerResolve(https://nodejs.org/api/net.html)

--- a/packages/plugin-javascript/__tests__/index.js
+++ b/packages/plugin-javascript/__tests__/index.js
@@ -25,6 +25,13 @@ describe('javascript-universal', () => {
     });
   });
 
+  it("resolves 'node:module' to 'https://nodejs.org/api/module.html'", () => {
+    expect(plugin.resolve(path, ['node:module'])).toEqual({
+      target: 'https://nodejs.org/api/modules.html',
+      type: 'trusted-url',
+    });
+  });
+
   it("resolves 'https://example.org/foo.ts' to 'https://example.org/foo.ts'", () => {
     expect(plugin.resolve(path, ['https://example.org/foo.ts'])).toEqual({
       target: 'https://example.org/foo.ts',

--- a/packages/plugin-javascript/index.js
+++ b/packages/plugin-javascript/index.js
@@ -74,6 +74,10 @@ export default {
   name: 'JavaScript',
 
   resolve(path, [target]) {
+    if (target.startsWith('node:')) {
+      target = target.substring(5);
+    }
+
     if (isURLImport(target)) {
       return resolverTrustedUrl({ target });
     }


### PR DESCRIPTION
<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please provide at least one example link
- [x] Make sure all of the significant new logic is covered by tests

Looks to be supported in:
- `v16.0.0`, `v14.18.0` (ESM import and CommonJS require())
- `v14.13.1`, `v12.20.0` (only ESM import)
- In TypeScript with the latest versions of `@types/node`

Fixes #1466
