### PR TITLE
Add support for action workflow templates

### DIFF
--- a/packages/plugin-github-actions/__tests__/index.js
+++ b/packages/plugin-github-actions/__tests__/index.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import GiHubActions from '../index';
+import GiHubActions, { isWorkflowFile } from '../index';
 
 describe('GiHubActions', () => {
   const target = 'foo/bar';
@@ -16,5 +16,27 @@ describe('GiHubActions', () => {
       GiHubActions.resolve('/octo/cat/.github/dog.yml', [target]),
       '',
     );
+  });
+});
+
+describe('isWorkflowFile', () => {
+  it('matches on .github/workflows folder', () => {
+    expect(
+      isWorkflowFile('/OctoLinker/.github/blob/main/.github/workflows/ci.yml'),
+    ).toBe(true);
+  });
+
+  it('matches on workflows-templates folder in .github repo', () => {
+    expect(
+      isWorkflowFile('/OctoLinker/.github/blob/main/workflow-templates/ci.yml'),
+    ).toBe(true);
+  });
+
+  it("doesn't match on workflows-templates folder in non .github repo", () => {
+    expect(
+      isWorkflowFile(
+        '/OctoLinker/OctoLinker/blob/main/workflow-templates/ci.yml',
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/plugin-github-actions/index.js
+++ b/packages/plugin-github-actions/index.js
@@ -4,11 +4,24 @@ import { dockerHubUrl } from '@octolinker/plugin-docker';
 
 const DOCKER_SOURCE = 'docker://';
 
+export function isWorkflowFile(path) {
+  if (path.includes('.github/workflows')) {
+    return true;
+  }
+
+  const [, , repo, , , folder] = path.split('/');
+  if (repo === '.github' && folder === 'workflow-templates') {
+    return true;
+  }
+
+  return false;
+}
+
 export default {
   name: 'GitHubActions',
 
   resolve(path, [target]) {
-    if (!path.includes('.github/workflows')) {
+    if (!isWorkflowFile(path)) {
       return '';
     }
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please provide at least one example link
- [x] Make sure all of the significant new logic is covered by tests

[Workflow templates](https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization) need to exist in a repo named `.github` and a folder named `workflow-templates`. If there's a better way to check for this I can change it, but this seemed like the easiest way. Since this is based on the repo & folder name I couldn't put an e2e test for it, but the unit tests should be sufficient I think.

Example files:
- https://github.com/xt0rted/.github/blob/dfc99168e4dd2f9f827eab0a9e58ce7ed3a1f0f2/workflow-templates/dependabot-auto-merge.yml#L11
- https://github.com/primer/.github/tree/main/workflow-templates

