### PR TITLE
Link github actions to their pinned version

### DIFF
--- a/e2e/fixtures/.github/workflows/ci.yml
+++ b/e2e/fixtures/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     - uses: 'actions/checkout@v2.4.0'
     # @OctoLinkerResolve(https://github.com/actions/checkout/tree/v2.4.0)
     - uses: "actions/checkout@v2.4.0"
+    # @OctoLinkerResolve(https://github.com/actions/checkout/tree/ec3a7ce113134d7a93b817d10a8272cb61118579)
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
     # @OctoLinkerResolve(https://github.com/actions/setup-node)
     - uses: actions/setup-node
     # @OctoLinkerResolve(https://github.com/actions/upload-artifact/tree/master)

--- a/e2e/fixtures/.github/workflows/ci.yml
+++ b/e2e/fixtures/.github/workflows/ci.yml
@@ -5,13 +5,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    # @OctoLinkerResolve(https://github.com/actions/checkout)
+    # @OctoLinkerResolve(https://github.com/actions/checkout/tree/v1)
     - uses: actions/checkout@v1
+    # @OctoLinkerResolve(https://github.com/actions/checkout/tree/v2)
+    - uses: 'actions/checkout@v2'
+    # @OctoLinkerResolve(https://github.com/actions/checkout/tree/v2)
+    - uses: "actions/checkout@v2"
     # @OctoLinkerResolve(https://github.com/actions/setup-node)
     - uses: actions/setup-node
-    # @OctoLinkerResolve(https://github.com/actions/upload-artifact)
+    # @OctoLinkerResolve(https://github.com/actions/upload-artifact/tree/master)
     - uses: actions/upload-artifact@master
-    # @OctoLinkerResolve(https://github.com/github/codeql-action/tree/main/init)
+    # @OctoLinkerResolve(https://github.com/github/codeql-action/tree/v1/init)
     - uses: github/codeql-action/init@v1
     # @OctoLinkerResolve(https://hub.docker.com/_/alpine)
     - uses: docker://alpine:3.8

--- a/e2e/fixtures/.github/workflows/ci.yml
+++ b/e2e/fixtures/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ jobs:
     steps:
     # @OctoLinkerResolve(https://github.com/actions/checkout/tree/v1)
     - uses: actions/checkout@v1
-    # @OctoLinkerResolve(https://github.com/actions/checkout/tree/v2)
-    - uses: 'actions/checkout@v2'
-    # @OctoLinkerResolve(https://github.com/actions/checkout/tree/v2)
-    - uses: "actions/checkout@v2"
+    # @OctoLinkerResolve(https://github.com/actions/checkout/tree/v2.4.0)
+    - uses: 'actions/checkout@v2.4.0'
+    # @OctoLinkerResolve(https://github.com/actions/checkout/tree/v2.4.0)
+    - uses: "actions/checkout@v2.4.0"
     # @OctoLinkerResolve(https://github.com/actions/setup-node)
     - uses: actions/setup-node
     # @OctoLinkerResolve(https://github.com/actions/upload-artifact/tree/master)

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -212,7 +212,14 @@ export const NET_PACKAGE = regex`
 `;
 
 export const GITHUB_ACTIONS = regex`
-  uses:\s(?<$1>[^@\s]+)
+  uses:\s*
+  ['"]?               # begin optional quote
+  (?<$1>[^@'"\s]+)    # repo with optional file path
+  (
+    @
+    (?<$2>[^'"\s]+)   # hash/tag
+  )?                  # the version is optional
+  ['"]?               # end optional quote
 `;
 
 export const JAVA_IMPORT = regex`

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -528,8 +528,12 @@ const fixtures = {
   GITHUB_ACTIONS: {
     valid: [
       ['uses: foo/bar', ['foo/bar']],
-      ['uses: foo/bar@v1', ['foo/bar']],
-      ['uses: foo/bar@master', ['foo/bar']],
+      ['uses: foo/bar@v1', ['foo/bar', 'v1']],
+      ['uses: foo/bar@master', ['foo/bar', 'master']],
+      ['uses: "foo/bar"', ['foo/bar']],
+      ['uses: "foo/bar@v1"', ['foo/bar', 'v1']],
+      ["uses: 'foo/bar'", ['foo/bar']],
+      ["uses: 'foo/bar@v1'", ['foo/bar', 'v1']],
     ],
     invalid: [],
   },

--- a/packages/plugin-github-actions/__tests__/index.js
+++ b/packages/plugin-github-actions/__tests__/index.js
@@ -11,6 +11,16 @@ describe('GiHubActions', () => {
     );
   });
 
+  it('resolves link with version when file is within .github/workflows', () => {
+    assert.deepEqual(
+      GiHubActions.resolve('/octo/cat/.github/workflows/dog.yml@v1', [
+        target,
+        'v1',
+      ]),
+      '{BASE_URL}/foo/bar/tree/v1',
+    );
+  });
+
   it('does not resolves link when file is not within .github/workflows', () => {
     assert.deepEqual(
       GiHubActions.resolve('/octo/cat/.github/dog.yml', [target]),
@@ -38,5 +48,13 @@ describe('isWorkflowFile', () => {
         '/OctoLinker/OctoLinker/blob/main/workflow-templates/ci.yml',
       ),
     ).toBe(false);
+  });
+
+  it('matches with pinned version in url', () => {
+    expect(
+      isWorkflowFile(
+        '/OctoLinker/.github/blob/main/.github/workflows/ci.yml@v3',
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/plugin-github-actions/index.js
+++ b/packages/plugin-github-actions/index.js
@@ -20,7 +20,7 @@ export function isWorkflowFile(path) {
 export default {
   name: 'GitHubActions',
 
-  resolve(path, [target]) {
+  resolve(path, [target, version]) {
     if (!isWorkflowFile(path)) {
       return '';
     }
@@ -40,10 +40,18 @@ export default {
     const [org, repo, ...folder] = target.split('/');
 
     if (folder.length) {
+      if (version) {
+        return `{BASE_URL}/${join(org, repo, 'tree', version, ...folder)}`;
+      }
+
       return [
         `{BASE_URL}/${join(org, repo, 'tree', 'main', ...folder)}`,
         `{BASE_URL}/${join(org, repo, 'tree', 'master', ...folder)}`,
       ];
+    }
+
+    if (version) {
+      return `{BASE_URL}/${target}/tree/${version}`;
     }
 
     return `{BASE_URL}/${target}`;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [x] If this PR is a new feature, please provide at least one example link
- [x] Make sure all of the significant new logic is covered by tests

This adjusts GitHub Actions links so if they include a tag/sha we link directly to that instead of the default branch. I figured since most actions are pinned to a version it'd make more sense to link to that instead of the default branch. I'm not sure if we want to do this or not, I'm fine with it either way.