### PR TITLE
Update resolve url

### DIFF
--- a/e2e/fixtures/go/foo.go
+++ b/e2e/fixtures/go/foo.go
@@ -1,12 +1,12 @@
 package master
 
-// @OctoLinkerResolve(https://golang.org/pkg/context)
+// @OctoLinkerResolve(https://pkg.go.dev/context)
 import "context"
 
-// @OctoLinkerResolve(https://golang.org/pkg/math/big)
+// @OctoLinkerResolve(https://pkg.go.dev/math/big)
 import "math/big"
 
-// @OctoLinkerResolve(https://golang.org/pkg/k8s.io/apimachinery/pkg/api/errors)
+// @OctoLinkerResolve(https://pkg.go.dev/k8s.io/apimachinery/pkg/api/errors)
 import "k8s.io/apimachinery/pkg/api/errors"
 
 // @OctoLinkerResolve(https://github.com/kubernetes/api/tree/master/core/v1)

--- a/e2e/fixtures/go/foo.go
+++ b/e2e/fixtures/go/foo.go
@@ -9,7 +9,7 @@ import "math/big"
 // @OctoLinkerResolve(https://golang.org/pkg/k8s.io/apimachinery/pkg/api/errors)
 import "k8s.io/apimachinery/pkg/api/errors"
 
-// @OctoLinkerResolve(https://golang.org/pkg/k8s.io/api/core/v1)
+// @OctoLinkerResolve(https://github.com/kubernetes/api/tree/master/core/v1)
 import corev1 "k8s.io/api/core/v1"
 
 // @OctoLinkerResolve(https://github.com/ethereum/go-ethereum/tree/master/common)

--- a/packages/helper-grammar-regex-collection/go.js
+++ b/packages/helper-grammar-regex-collection/go.js
@@ -11,6 +11,7 @@ const ALLOWED_DOMAINS = [
   'gopkg.in',
   'golang.org',
   'k8s.io',
+  'pkg.go.dev',
 ];
 
 // For go.mod file

--- a/packages/plugin-go/__tests__/index.js
+++ b/packages/plugin-go/__tests__/index.js
@@ -15,7 +15,7 @@ describe('go-universal', () => {
   it('resolves package', () => {
     expect(goUniversal.resolve(path, ['foo'])).toEqual([
       'https://foo',
-      'https://golang.org/pkg/foo',
+      'https://pkg.go.dev/foo',
       liveResolverQuery({ type: 'go', target: 'foo' }),
     ]);
   });

--- a/packages/plugin-go/index.js
+++ b/packages/plugin-go/index.js
@@ -50,7 +50,7 @@ export default {
 
     return [
       `https://${target}`,
-      `https://golang.org/pkg/${target}`,
+      `https://pkg.go.dev/${target}`,
       liveResolverQuery({ type: 'go', target }),
     ];
   },


### PR DESCRIPTION
The change in url caused the e2e tests to start to fail.

The other urls are technically wrong because `https://golang.org/pkg/context` redirects to `https://pkg.go.dev/context` but updating them causes the tests to fail. This is probably because of https://github.com/OctoLinker/OctoLinker/blob/4a54d31577f21659e33d0fa1cdfff00dc9d02ad3/packages/plugin-go/index.js#L53

### Checklist:

- [ ] If this PR is a new feature, please provide at least one example link
- [ ] Make sure all of the significant new logic is covered by tests
