### PR TITLE
Set FORCE_COLOR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+env:
+  FORCE_COLOR: 2
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,6 +20,8 @@ jobs:
       with:
         node-version: 16
         cache: 'yarn'
+      env:
+        FORCE_COLOR: 0
     - run: yarn install
     - run: ./packages/blob-reader/scripts/update-fixtures.sh
     - run: yarn test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 on:
   release:
    types: [published]
+env:
+  FORCE_COLOR: 2
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please provide at least one example link
- [ ] Make sure all of the significant new logic is covered by tests

This change forces color output in the build log for things like jest's test results making it easier to find failing tests. There's a [known issue](https://github.com/actions/setup-node/issues/317) with `actions/setup-node` where when this is set the cache feature fails, so it has to be disabled for that step.