### PR TITLE
Prevent GitHub's code navigation styling on our links

### DIFF
--- a/packages/helper-insert-link/__tests__/__snapshots__/index.js.snap
+++ b/packages/helper-insert-link/__tests__/__snapshots__/index.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`insert-link does not remove closing parentheses from commented out require() calls 1`] = `
-<div>
+<div
+  clickadded="false"
+>
   // var faker = require(
   <a
     class="octolinker-link"
@@ -69,7 +71,9 @@ exports[`insert-link wraps a nested element 1`] = `
 <div>
   foo 
   <div>
-    <span>
+    <span
+      clickadded="false"
+    >
       <i>
         
         "
@@ -90,7 +94,9 @@ exports[`insert-link wraps a nested element 1`] = `
 `;
 
 exports[`insert-link wraps a single string 1`] = `
-<div>
+<div
+  clickadded="false"
+>
   foo 
   <a
     class="octolinker-link"
@@ -105,7 +111,9 @@ exports[`insert-link wraps a single string 1`] = `
 exports[`insert-link wraps a single word 1`] = `
 <div>
   foo 
-  <span>
+  <span
+    clickadded="false"
+  >
     <a
       class="octolinker-link"
       data-pjax="true"
@@ -119,7 +127,9 @@ exports[`insert-link wraps a single word 1`] = `
 exports[`insert-link wraps double quotes 1`] = `
 <div>
   foo 
-  <span>
+  <span
+    clickadded="false"
+  >
     <a
       class="octolinker-link"
       data-pjax="true"
@@ -133,7 +143,9 @@ exports[`insert-link wraps double quotes 1`] = `
 exports[`insert-link wraps mixed quotes 1`] = `
 <div>
   foo 
-  <span>
+  <span
+    clickadded="false"
+  >
     <a
       class="octolinker-link"
       data-pjax="true"
@@ -145,7 +157,9 @@ exports[`insert-link wraps mixed quotes 1`] = `
 `;
 
 exports[`insert-link wraps multiple strings 1`] = `
-<div>
+<div
+  clickadded="false"
+>
   foo 
   <a
     class="octolinker-link"
@@ -160,7 +174,9 @@ exports[`insert-link wraps multiple strings 1`] = `
 exports[`insert-link wraps single quotes 1`] = `
 <div>
   foo 
-  <span>
+  <span
+    clickadded="false"
+  >
     <a
       class="octolinker-link"
       data-pjax="true"
@@ -174,7 +190,9 @@ exports[`insert-link wraps single quotes 1`] = `
 exports[`insert-link wraps the element once 1`] = `
 <div>
   foo 
-  <span>
+  <span
+    clickadded="false"
+  >
     <i>
       
       "
@@ -196,7 +214,9 @@ exports[`insert-link wraps the element once 1`] = `
 exports[`insert-link wraps the elements based on their char position which is specified in the keywords map 1`] = `
 <div>
   foo 
-  <span>
+  <span
+    clickadded="false"
+  >
     <i>
       
       "

--- a/packages/helper-insert-link/index.js
+++ b/packages/helper-insert-link/index.js
@@ -38,6 +38,9 @@ function injectUrl(node, value, startOffset, endOffset) {
         return el;
       },
     });
+
+    // Prevent's GitHub's code navigation styling from being applied to our links
+    el.parentElement.setAttribute('clickadded', 'false');
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);


### PR DESCRIPTION
This resolves the issue mentioned in https://github.com/OctoLinker/OctoLinker/issues/1695#issuecomment-1312817951 which should be backwards compatible with the old site. I'm not sure if there's a better way to do this, but based on what their code's doing this attribute is what stops the `pl-token` class from being added which is where the hover style comes from. They set it to `true` so I figured `false` made more sense in this context.

### Checklist:

- [ ] If this PR is a new feature, please provide at least one example link
- [ ] Make sure all of the significant new logic is covered by tests
