### PR TITLE
Support action workflow run view

### DIFF
--- a/packages/blob-reader/helper.js
+++ b/packages/blob-reader/helper.js
@@ -86,6 +86,13 @@ function getPath(el) {
     ret = $('.js-permalink-shortcut')?.getAttribute('href');
   }
 
+  // When current page is an actions run workflow file
+  if (!ret) {
+    ret = $(
+      '.actions-fullwidth-module .text-small .Link--secondary',
+    )?.getAttribute('href');
+  }
+
   // When current page is a gist, get path from blob name
   if (isGist()) {
     ret = $('.gist-blob-name', el.parentElement)?.textContent.trim();

--- a/packages/plugin-github-actions/index.js
+++ b/packages/plugin-github-actions/index.js
@@ -59,7 +59,7 @@ export default {
 
   getPattern() {
     return {
-      pathRegexes: [/\.ya?ml$/],
+      pathRegexes: [/\.ya?ml$/, /\/actions\/runs\/\d*\/workflow$/],
       githubClasses: [],
     };
   },


### PR DESCRIPTION
Add support for linking action workflows in the [new actions UI](https://github.blog/2022-10-20-improving-navigation-for-github-actions/). This is more of a proof of concept, but figured I'd PR it for feedback. Unfortunately there's no other classes or attributes I can see that would let us get this link like we do on the source pages.

Example: https://github.com/OctoLinker/OctoLinker/actions/runs/3457001003/workflow

### Checklist:

- [ ] If this PR is a new feature, please provide at least one example link
- [ ] Make sure all of the significant new logic is covered by tests
