### PR TITLE
Add explicit commit message prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,13 @@ updates:
     interval: weekly
     time: "12:00"
   open-pull-requests-limit: 10
+  commit-message:
+    prefix: ""
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: weekly
     time: "12:00"
   open-pull-requests-limit: 10
+  commit-message:
+    prefix: ""


### PR DESCRIPTION
I talked to support about the commit message prefixes that started being used here (happened in one of my repos too) and they said the way to prevent it to by setting the `commit-message` property in the dependabot config.

### Checklist:

- [ ] If this PR is a new feature, please provide at least one example link
- [ ] Make sure all of the significant new logic is covered by tests
