### PR TITLE
Set an explicit commit message prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,13 @@ updates:
     interval: weekly
     time: "12:00"
   open-pull-requests-limit: 10
+  commit-message:
+    prefix: ""
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: weekly
     time: "12:00"
   open-pull-requests-limit: 10
+  commit-message:
+    prefix: ""


### PR DESCRIPTION
According to support this should stop the commit message prefixes we recently started getting applied to dependabot PRs.

### Checklist:

- [ ] If this PR is a new feature, please provide at least one example link
- [ ] Make sure all of the significant new logic is covered by tests
